### PR TITLE
Add support for Debian systems for the Time Card.

### DIFF
--- a/Time-Card/DRV/remake
+++ b/Time-Card/DRV/remake
@@ -10,7 +10,7 @@ if [ "$*" == "install" ]; then
 fi
 
 case "$DIST" in
-    ubuntu)
+    debian*|ubuntu)
         KDIR=/usr/src/linux-headers-${KVER}
         ;;
     centos*)


### PR DESCRIPTION
Related: https://github.com/opencomputeproject/Time-Appliance-Project/issues/23

This patch doesn't make it possible to compile the driver on stock Debian kernels (current kernel version is 5.10 in Bullseye), but it does make it so the build script will not error out on non-Ubuntu systems running Debian or other Debian derivatives (like Raspberry Pi OS).