### PR TITLE
Orolia RW disciplining parameters

### DIFF
--- a/Time-Card/DRV/ptp_ocp.c
+++ b/Time-Card/DRV/ptp_ocp.c
@@ -67,6 +67,8 @@ struct disciplining_parameters {
 	/** Equilibrium Coarse value for factory_settings */
 	int32_t coarse_equilibrium_factory;
 	int32_t coarse_equilibrium;
+	/** Date at which calibration has been made */
+	time_t calibration_date;
 	/** Factory Settings that can be used with any mRO50 */
 	/** Number of control nodes in ctrl_load_nodes_factory */
 	uint8_t ctrl_nodes_length_factory;
@@ -74,7 +76,6 @@ struct disciplining_parameters {
 	uint8_t ctrl_nodes_length;
 	/** Indicate wether calibration parameters are valid */
 	bool calibration_valid;
-	int8_t pad_0[4];
 };
 
 #define ART_CALIBRATION_READ_PARAMETERS _IOR('M', 8, struct disciplining_parameters *)

--- a/Time-Card/DRV/ptp_ocp.c
+++ b/Time-Card/DRV/ptp_ocp.c
@@ -1475,10 +1475,16 @@ ptp_ocp_read_eeprom(struct ptp_ocp *bp)
 {
 	struct i2c_adapter *adap;
 	struct device *dev;
+	struct pci_dev *pdev =  bp->pdev;
 	int err;
+	int id;
+	int serial_addr;
+	int serial_reg;
 
 	if (!bp->i2c_ctrl)
 		return;
+
+	id = pci_dev_id(pdev) << 1;
 
 	dev = device_find_child(&bp->i2c_ctrl->dev, NULL, ptp_ocp_firstchild);
 	if (!dev) {
@@ -1503,7 +1509,14 @@ ptp_ocp_read_eeprom(struct ptp_ocp *bp)
 	if (err)
 		goto read_fail;
 
-	err = ptp_ocp_read_i2c(adap, 0x58, 0x9A,
+	if (pdev->vendor == PCI_VENDOR_ID_OROLIA && pdev->device == PCI_DEVICE_ID_OROLIA_ARTCARD) {
+		serial_addr = 0x50;
+		serial_reg = 0x66;
+	} else {
+		serial_addr = 0x58;
+		serial_reg = 0x9A;
+	}
+	err = ptp_ocp_read_i2c(adap, serial_addr, serial_reg,
 			       sizeof(bp->serial), bp->serial);
 	if (err)
 		goto read_fail;


### PR DESCRIPTION
- Add condition to read Orolia's ART card serial at the right place
-  Implement disciplining parameters R/W in EEPROM:
  - IOCTL for mRO misc devices can be used to R/W disciplining parameters from/to at24 EEPROM.
  - R/W operations are done through the I2C interface of the EEPROM (Write operation implemented from at24 regmap device write behaviour)
