### PR TITLE
tft: Show header info of input file

### DIFF
--- a/Software/tft/header/config.go
+++ b/Software/tft/header/config.go
@@ -28,15 +28,15 @@ func CheckConfig(c *Config) error {
 		return errors.New("No output file provided")
 	}
 
-	if c.VendorId <= 0 || c.VendorId > 65535 {
+	if c.Apply && (c.VendorId <= 0 || c.VendorId > 65535) {
 		return errors.New("Empty or incorrect PCI Vendor ID specified")
 	}
 
-	if c.DeviceId <= 0 || c.DeviceId > 65535 {
+	if c.Apply && (c.DeviceId <= 0 || c.DeviceId > 65535) {
 		return errors.New("Empty or incorrect PCI Device ID specified")
 	}
 
-	if c.HardwareRevision < 0 || c.HardwareRevision > 65535 {
+	if c.Apply && (c.HardwareRevision < 0 || c.HardwareRevision > 65535) {
 		return errors.New("Incorrect PCI Device Revision ID specified")
 	}
 

--- a/Software/tft/main.go
+++ b/Software/tft/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"flag"
+	"fmt"
 
 	h "github.com/opencomputeproject/Time-Appliance-Project/Software/tft/header"
 	log "github.com/sirupsen/logrus"
@@ -27,6 +28,19 @@ func main() {
 	}
 	defer h.CloseFiles(c)
 
+	oldHdr, err := h.ReadHeader(c)
+	if err == nil {
+		fmt.Println("Input file has header:")
+		fmt.Printf("PCI Vendor ID: 0x%04x\n", oldHdr.VendorId)
+		fmt.Printf("PCI Device ID: 0x%04x\n", oldHdr.DeviceId)
+		fmt.Printf("PCI HW Revision ID: 0x%04x\n", oldHdr.HardwareRevision)
+		fmt.Printf("Image CRC16: 0x%04x\n", oldHdr.CRC)
+		fmt.Printf("Image size: %d\n", oldHdr.ImageSize)
+		if c.Apply {
+			fmt.Println("Image header will be overwritten with new values")
+		}
+	}
+
 	hdr, err := h.PrepareHeader(c)
 	if err != nil {
 		log.Fatal(err)
@@ -41,6 +55,7 @@ func main() {
 		log.Fatal(err)
 	}
 
+	// we have to rewrite header as CRC is calculated
 	if err := h.WriteHeader(c, hdr); err != nil {
 		log.Fatal(err)
 	}


### PR DESCRIPTION
Previously there was no check for existing header in the file and it was
easy to create multiple headers and corrupt firmware binary. This patch
adds check for header and rewrites existing one. It also shows previous
values and now tft could be used to read header info.

Signed-off-by: Vadim Fedorenko <vadfed@fb.com>