### PR TITLE
Initialize ktime_t type to S64_MAX (not U64_MAX)

### DIFF
--- a/DRV/ptp_ocp.c
+++ b/DRV/ptp_ocp.c
@@ -1903,7 +1903,7 @@ ptp_ocp_watchdog(struct timer_list *t)
 static void
 ptp_ocp_estimate_pci_timing(struct ptp_ocp *bp)
 {
-	ktime_t start, end, delay = U64_MAX;
+	ktime_t start, end, delay = S64_MAX;
 	u32 ctrl;
 	int i;
 


### PR DESCRIPTION
Using the ioctl PTP_SYS_OFFSET_EXTENDED via testptp:
```
#testptp -d /dev/ptp2 -x 1
extended timestamp request returned 1 samples
sample # 0: real time before: 1765392269.485510129
            phc time: 1765392306.482641995
            real time after: 1765392265.190545816       <- This value is incorrect
```
The issue was that the **ts_window_adjust** is a negative value. 
```
#cat /sys/class/timecard/ocp0/ts_window_adjust
-3
```
Due to delay in ptp_ocp_estimate_pci_timing() getting initialized to a U64_MAX should be S64_MAX (as ktime_t is "typedef s64	ktime_t;")
With this change:

```
# cat /sys/class/timecard/ocp0/ts_window_adjust
267
# /root/testptp/testptp -d /dev/ptp2 -x 1
extended timestamp request returned 1 samples
sample # 0: real time before: 1765392342.651265647
            phc time: 1765392379.647310186
            real time after: 1765392342.651268356
```