### PR TITLE
DRV: build on modern kernels (verified 7.0), PTM bring-up notes, spi-xilinx flash fix rebase

### DIFF
--- a/DRV/0002-spi-xilinx-Inhibit-transmitter-modern-kernels.patch
+++ b/DRV/0002-spi-xilinx-Inhibit-transmitter-modern-kernels.patch
@@ -1,0 +1,103 @@
+From: Jonathan Lemon <jonathan.lemon@gmail.com>
+Subject: [PATCH] spi: xilinx: Inhibit transmitter while filling TX FIFO (kernels >= 6.x rebase)
+
+This is the same fix as 0001-spi-xilinx-Inhibit-transmitter-while-
+filling-TX-FIFO.patch, rebased onto the current spi-xilinx driver
+(verified against v7.0). The original hunks no longer apply because
+the driver was converted to the spi_controller API.
+
+Without this fix, flashing the Time Card over devlink fails: erase
+cycles complete but page-program writes time out ("Connection timed
+out" from flashcp/mtd), because the transmitter clocks out the first
+address bytes repeatedly while the TX FIFO is still being filled,
+locking up the flash chip. With the fix, erase/write/verify of the
+full factory image succeeds.
+
+Apply from the kernel source tree root:
+    patch -p1 < 0002-spi-xilinx-Inhibit-transmitter-modern-kernels.patch
+or build the patched file as an out-of-tree module (obj-m := spi-xilinx.o)
+and install it under /lib/modules/$(uname -r)/updates/.
+
+--- a/drivers/spi/spi-xilinx.c	2026-07-11 00:17:40.448808201 -0700
++++ b/drivers/spi/spi-xilinx.c	2026-07-11 00:17:40.450509079 -0700
+@@ -179,7 +179,8 @@
+ 	/* Disable the transmitter, enable Manual Target Select Assertion,
+ 	 * put SPI controller into host mode, and enable it */
+ 	xspi->write_fn(XSPI_CR_MANUAL_SSELECT |	XSPI_CR_MASTER_MODE |
+-		XSPI_CR_ENABLE | XSPI_CR_TXFIFO_RESET |	XSPI_CR_RXFIFO_RESET,
++		XSPI_CR_ENABLE | XSPI_CR_TXFIFO_RESET |	XSPI_CR_RXFIFO_RESET |
++		XSPI_CR_TRANS_INHIBIT,
+ 		regs_base + XSPI_CR_OFFSET);
+ }
+ 
+@@ -235,12 +236,23 @@
+ 	return 0;
+ }
+ 
++static void xilinx_spi_inhibit_master(struct xilinx_spi *xspi, bool inhibit)
++{
++	u16 cr;
++
++	cr = xspi->read_fn(xspi->regs + XSPI_CR_OFFSET);
++	if (inhibit)
++		cr |= XSPI_CR_TRANS_INHIBIT;
++	else
++		cr &= ~XSPI_CR_TRANS_INHIBIT;
++	xspi->write_fn(cr, xspi->regs + XSPI_CR_OFFSET);
++}
++
+ static int xilinx_spi_txrx_bufs(struct spi_device *spi, struct spi_transfer *t)
+ {
+ 	struct xilinx_spi *xspi = spi_controller_get_devdata(spi->controller);
+ 	int remaining_words;	/* the number of words left to transfer */
+ 	bool use_irq = false;
+-	u16 cr = 0;
+ 
+ 	/* We get here with transmitter inhibited */
+ 
+@@ -253,10 +265,6 @@
+ 		u32 isr;
+ 
+ 		use_irq = true;
+-		/* Inhibit irq to avoid spurious irqs on tx_empty*/
+-		cr = xspi->read_fn(xspi->regs + XSPI_CR_OFFSET);
+-		xspi->write_fn(cr | XSPI_CR_TRANS_INHIBIT,
+-			       xspi->regs + XSPI_CR_OFFSET);
+ 		/* ACK old irqs (if any) */
+ 		isr = xspi->read_fn(xspi->regs + XIPIF_V123B_IISR_OFFSET);
+ 		if (isr)
+@@ -282,9 +290,9 @@
+ 		/* Start the transfer by not inhibiting the transmitter any
+ 		 * longer
+ 		 */
++		xilinx_spi_inhibit_master(xspi, false);
+ 
+ 		if (use_irq) {
+-			xspi->write_fn(cr, xspi->regs + XSPI_CR_OFFSET);
+ 			wait_for_completion(&xspi->done);
+ 			/* A transmit has just completed. Process received data
+ 			 * and check for more data to transmit. Always inhibit
+@@ -292,8 +300,7 @@
+ 			 * register/FIFO, or make sure it is stopped if we're
+ 			 * done.
+ 			 */
+-			xspi->write_fn(cr | XSPI_CR_TRANS_INHIBIT,
+-				       xspi->regs + XSPI_CR_OFFSET);
++			xilinx_spi_inhibit_master(xspi, true);
+ 			sr = XSPI_SR_TX_EMPTY_MASK;
+ 		} else
+ 			sr = xspi->read_fn(xspi->regs + XSPI_SR_OFFSET);
+@@ -327,10 +334,10 @@
+ 		remaining_words -= n_words;
+ 	}
+ 
+-	if (use_irq) {
++	if (use_irq)
+ 		xspi->write_fn(0, xspi->regs + XIPIF_V123B_DGIER_OFFSET);
+-		xspi->write_fn(cr, xspi->regs + XSPI_CR_OFFSET);
+-	}
++
++	xilinx_spi_inhibit_master(xspi, true);
+ 
+ 	return t->len;
+ }

--- a/DRV/README.md
+++ b/DRV/README.md
@@ -7,6 +7,39 @@ Kernel 5.12+ is recommended
 Make sure vt-d option is enabled in BIOS.   
 Run the remake followed by modprobe ptp_ocp
 
+## Modern kernels (6.x and later)
+
+`ptp_ocp.c` carries version guards so it builds from 5.x up to current
+kernels (verified against 7.0). The guarded APIs are: the PTM
+cross-timestamp interface (`system_counterval_t.use_nsecs` with
+`CSID_X86_ART` replaces `convert_art_ns_to_tsc()` on >= 6.10), timer APIs
+(`timer_delete_sync`, `timer_container_of`), const-ified
+`struct bin_attribute` callbacks and groups, the const
+`device_find_child()` match signature, and the embedded PPS device.
+
+### PTM (Precision Time Measurement)
+
+With the LitePCIe-with-PTM gateware (release `TimeCardPTM_V31` or later)
+the driver enables PCIe PTM at probe and implements `getcrosststamp()`
+through hardware PTM dialogs, so `PTP_SYS_OFFSET_PRECISE` works and
+`phc2sys`/`chrony` pick it up automatically — this removes the PCIe
+read-asymmetry from PHC comparisons. The root port above the card must
+advertise the PTM Root capability. Verify after boot:
+
+```
+lspci -vvv -s <card> | grep -A3 "Precision Time"   # Requester+ ... Enabled+
+dmesg | grep "PTM enabled"
+```
+
+### Flashing note (spi-xilinx)
+
+Updating the gateware via `devlink dev flash` needs the spi-xilinx fix in
+`0002-spi-xilinx-Inhibit-transmitter-modern-kernels.patch` (a rebase of
+the original 0001 patch, which no longer applies to current kernels).
+Without it, erases succeed but page-program writes time out and the flash
+chip locks up mid-update. Build the patched `spi-xilinx.ko` and install it
+under `/lib/modules/$(uname -r)/updates/` before flashing.
+
 ## Outcome
 ```
 $ ls -g /sys/class/timecard/ocp0/

--- a/DRV/ptp_ocp.c
+++ b/DRV/ptp_ocp.c
@@ -26,6 +26,21 @@
 #include <linux/crc16.h>
 #include <linux/timekeeping.h>
 
+#include <linux/version.h>
+
+/* Compatibility for kernel API changes; see DRV/README.md. */
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 2, 0)
+#define timer_delete_sync(t) timer_delete_sync(t)
+#endif
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 16, 0)
+#define timer_container_of(var, timer, field) from_timer(var, timer, field)
+#endif
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 15, 0)
+#define OCP_BIN_ATTR_CONST const
+#else
+#define OCP_BIN_ATTR_CONST
+#endif
+
 /*---------------------------------------------------------------------------*/
 #ifndef MRO50_IOCTL_H
 #define MRO50_IOCTL_H
@@ -1677,7 +1692,15 @@ ptp_ocp_syncdevicetime(ktime_t *device_time,
 	*device_time = t1;
 
 #if IS_ENABLED(CONFIG_X86_TSC) && !defined(CONFIG_UML)
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 10, 0)
+	*system_counterval = (struct system_counterval_t) {
+		.cycles = ptm_master_time,
+		.cs_id = CSID_X86_ART,
+		.use_nsecs = true,
+	};
+#else
 	*system_counterval = convert_art_ns_to_tsc(ptm_master_time);
+#endif
 #else
 	*system_counterval = (struct system_counterval_t) { };
 #endif
@@ -1867,7 +1890,7 @@ ptp_ocp_utc_distribute(struct ptp_ocp *bp, u32 val)
 static void
 ptp_ocp_watchdog(struct timer_list *t)
 {
-	struct ptp_ocp *bp = from_timer(bp, t, watchdog);
+	struct ptp_ocp *bp = timer_container_of(bp, t, watchdog);
 	unsigned long flags;
 	u32 status, utc_offset;
 
@@ -2146,7 +2169,11 @@ fail:
 }
 
 static int
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 14, 0)
+ptp_ocp_firstchild(struct device *dev, const void *data)
+#else
 ptp_ocp_firstchild(struct device *dev, void *data)
+#endif
 {
 	return 1;
 }
@@ -4618,7 +4645,7 @@ out:
 
 static ssize_t
 config_read(struct file *filp, struct kobject *kobj,
-	    struct bin_attribute *bin_attr, char *buf,
+	    OCP_BIN_ATTR_CONST struct bin_attribute *bin_attr, char *buf,
 	    loff_t off, size_t count)
 {
 	struct ptp_ocp *bp = dev_get_drvdata(kobj_to_dev(kobj));
@@ -4640,7 +4667,7 @@ config_read(struct file *filp, struct kobject *kobj,
 
 static ssize_t
 config_write(struct file *filp, struct kobject *kobj,
-	     struct bin_attribute *bin_attr, char *buf,
+	     OCP_BIN_ATTR_CONST struct bin_attribute *bin_attr, char *buf,
 	     loff_t off, size_t count)
 {
 	struct ptp_ocp *bp = dev_get_drvdata(kobj_to_dev(kobj));
@@ -4663,7 +4690,7 @@ static BIN_ATTR_RW(config, OCP_CONFIG_SIZE);
 
 static ssize_t
 disciplining_config_read(struct file *filp, struct kobject *kobj,
-	    struct bin_attribute *bin_attr, char *buf,
+	    OCP_BIN_ATTR_CONST struct bin_attribute *bin_attr, char *buf,
 	    loff_t off, size_t count)
 {
 	struct ptp_ocp *bp = dev_get_drvdata(kobj_to_dev(kobj));
@@ -4698,7 +4725,7 @@ out:
 
 static ssize_t
 disciplining_config_write(struct file *filp, struct kobject *kobj,
-	     struct bin_attribute *bin_attr, char *buf,
+	     OCP_BIN_ATTR_CONST struct bin_attribute *bin_attr, char *buf,
 	     loff_t off, size_t count)
 {
 	struct ptp_ocp *bp = dev_get_drvdata(kobj_to_dev(kobj));
@@ -4726,7 +4753,7 @@ static BIN_ATTR_RW(disciplining_config, OCP_ART_CONFIG_SIZE);
 
 static ssize_t
 temperature_table_read(struct file *filp, struct kobject *kobj,
-	    struct bin_attribute *bin_attr, char *buf,
+	    OCP_BIN_ATTR_CONST struct bin_attribute *bin_attr, char *buf,
 	    loff_t off, size_t count)
 {
 	struct ptp_ocp *bp = dev_get_drvdata(kobj_to_dev(kobj));
@@ -4761,7 +4788,7 @@ out:
 
 static ssize_t
 temperature_table_write(struct file *filp, struct kobject *kobj,
-	     struct bin_attribute *bin_attr, char *buf,
+	     OCP_BIN_ATTR_CONST struct bin_attribute *bin_attr, char *buf,
 	     loff_t off, size_t count)
 {
 	struct ptp_ocp *bp = dev_get_drvdata(kobj_to_dev(kobj));
@@ -4787,7 +4814,7 @@ temperature_table_write(struct file *filp, struct kobject *kobj,
 }
 static BIN_ATTR_RW(temperature_table, OCP_ART_TEMP_TABLE_SIZE);
 
-static struct bin_attribute *bin_timecard_attrs[] = {
+static OCP_BIN_ATTR_CONST struct bin_attribute *OCP_BIN_ATTR_CONST bin_timecard_attrs[] = {
         &bin_attr_config,
         NULL,
 };
@@ -4853,7 +4880,7 @@ static struct attribute *art_timecard_attrs[] = {
 	NULL,
 };
 
-static struct bin_attribute *bin_art_timecard_attrs[] = {
+static OCP_BIN_ATTR_CONST struct bin_attribute *OCP_BIN_ATTR_CONST bin_art_timecard_attrs[] = {
 		&bin_attr_disciplining_config,
 		&bin_attr_temperature_table,
 		NULL,
@@ -5426,7 +5453,11 @@ ptp_ocp_complete(struct ptp_ocp *bp)
 
 	pps = pps_lookup_dev(bp->ptp);
 	if (pps)
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 13, 0)
+		ptp_ocp_symlink(bp, &pps->dev, "pps");
+#else
 		ptp_ocp_symlink(bp, pps->dev, "pps");
+#endif
 
 	if (bp->mro50.name)
 		ptp_ocp_symlink(bp, bp->mro50.this_device, "mro50");
@@ -5580,7 +5611,7 @@ ptp_ocp_detach(struct ptp_ocp *bp)
 	ptp_ocp_debugfs_remove_device(bp);
 	ptp_ocp_detach_sysfs(bp);
 	if (timer_pending(&bp->watchdog))
-		del_timer_sync(&bp->watchdog);
+		timer_delete_sync(&bp->watchdog);
 	if (bp->ts0)
 		ptp_ocp_unregister_ext(bp->ts0);
 	if (bp->ts1)


### PR DESCRIPTION
Makes the driver build and run on current kernels while keeping older ones working (all changes behind LINUX_VERSION_CODE guards):

- **PTM getcrosststamp**: on kernels ≥ 6.10 use the `system_counterval_t` `use_nsecs` interface with `CSID_X86_ART` (`convert_art_ns_to_tsc()` was removed from the kernel)
- `timer_delete_sync` / `timer_container_of` renames
- const-ified `struct bin_attribute` callbacks + attribute groups
- const `device_find_child()` match signature
- embedded `struct device` in `pps_device`

Also adds **0002-spi-xilinx-Inhibit-transmitter-modern-kernels.patch** — the existing 0001 spi-xilinx patch rebased onto the current spi_controller-based driver (the old hunks no longer apply). Without it, `devlink dev flash` erases the SPI flash but every page-program write times out, leaving the card unbootable-in-flash mid-update; with it, the full factory image writes and verifies.

README gains a modern-kernels section, PTM verification steps, and the flashing prerequisite.

Tested end to end on kernel 7.0.0 with the TimeCardPTM_V31 gateware on a 1d9b:0400 card: PTM capability negotiated (Requester+, 8 ns granularity), `PTP_SYS_OFFSET_PRECISE` serving hardware cross-timestamps to phc2sys, and a full gateware flash + power-cycle bring-up through the patched spi-xilinx.