### PR TITLE
Expand Windows Time Card controls and diagnostics

### DIFF
--- a/DRV/Windows/PRODUCTION_SIGNING.md
+++ b/DRV/Windows/PRODUCTION_SIGNING.md
@@ -15,7 +15,7 @@ From PowerShell in this directory:
 This performs a clean unsigned x64 Release build and creates:
 
 - `submission\TimeCard\` - the driver folder to add to an HLK project.
-- `submission\TimeCard-1.9-x64.cab` - a CAB with the required driver,
+- `submission\TimeCard-1.13-x64.cab` - a CAB with the required driver,
   INF, catalog, subsystem icons, and PDB in a non-root `TimeCard` folder.
 
 The CAB is intentionally unsigned unless a registered code-signing
@@ -55,7 +55,7 @@ Use this route for a retail driver and for Windows Update eligibility:
 Microsoft currently limits attestation signing to supported testing
 scenarios; attestation-signed retail drivers are not published to Windows
 Update. When the Partner Center account is eligible for such a scenario,
-upload the certificate-signed `TimeCard-1.9-x64.cab`, leave both test-signing
+upload the certificate-signed `TimeCard-1.13-x64.cab`, leave both test-signing
 options disabled, and download the Microsoft-signed result.
 
 ## Verify the returned package

--- a/DRV/Windows/README.md
+++ b/DRV/Windows/README.md
@@ -15,9 +15,16 @@ Linux `/dev/ptpN`, so applications use the versioned IOCTL ABI through
 - Validated query and routing control for all four SMA connectors, including
   input/output direction, named timing functions, fixed-direction detection,
   and immediate readback.
+- Bounded configuration and readback for four periodic signal generators and
+  four frequency counters, including direct SMA input/output routing.
 - Read-only Xilinx AXI IIC controller access with status, address-only probes,
   7-bit bus discovery, and bounded EEPROM/register reads. The known onboard
   devices are the board EEPROM at `0x50` and MAC EEPROM at `0x58`.
+- Guarded Xilinx SPI and SPI-NOR access for FPGA firmware query, 4 KiB erase,
+  page programming, and bounded read-back. All offsets are relative to the
+  FPGA image region at `0x00400000`; the configuration region is unreachable.
+- Non-destructive UART receive-activity observation for subsystem presence
+  checks without removing bytes from the receiver FIFO.
 - A stable six-byte card serial number read from offset zero of the factory
   24MAC402 identity EEPROM, matching Linux `ptp_ocp`.
 - MSI and MSI-X/LitePCIe BAR layouts matching the Linux `ptp_ocp` driver.
@@ -166,11 +173,46 @@ subaddress. Transfers are limited to 255 bytes. The `serial` command reads the
 same six identity bytes used by the Linux `serialnum` attribute. The ABI
 deliberately provides no I2C data-write or EEPROM-programming operation.
 
+Driver 1.11 fixes the AXI IIC dynamic-receive completion sequence. It waits for
+the optional subaddress message to leave the transmit FIFO, drains data only
+after the receive watermark event, advances that watermark for reads longer
+than one FIFO, and clears the expected final receive NACK with `RX_FULL`. A
+failed transient transaction is reset and retried once within the requested
+bounded timeout. Driver 1.12 also reports controller transport failures as I/O
+device errors instead of the misleading Windows "CRC data error" translation.
+
 The NMEA generator is separate from the UART receiver. Driver 1.9 enables it
 at 9,600 baud on first use when firmware left it disabled, and keeps the UART 3
 receiver divisor synchronized whenever `nmea-set` changes the generator baud.
 Supported rates are 1,200 through 2,000,000 baud using the selector table from
 Linux `ptp_ocp`.
+
+Driver 1.10 / ABI 5 adds dedicated controls for all four periodic signal
+generators and frequency counters. Generator configuration follows the Linux
+`ptp_ocp` register sequence: disable, program a PHC-aligned start, period,
+pulse width and polarity, then assert valid plus enable. Frequency counters
+accept an integration window of 0 (disabled) or 1–255 seconds and report the
+FPGA valid, error, overrun, and 24-bit frequency-result fields.
+
+Driver 1.12 / ABI 6 adds the guarded FPGA flash interface and UART activity
+observation. The SPI controller offsets, Xilinx FIFO sequence, FPGA image
+start, 4 KiB erase geometry, and OCPC image-header format follow Linux
+`ptp_ocp`. Flash programming cannot address bytes below `0x00400000`, cannot
+cross a 256-byte page, and requires write-enable plus ready polling. The
+Control Center performs a complete read-back comparison after programming.
+
+Driver 1.13 / ABI 7 adds schematic-aware controls for U27, the PCA9546A at
+`0x70`, and U6, the IS32FL3207 at `0x6e` on mux channel 1. The four mux bits
+route the MAC clock, sensor, analog/ADC expansion, and DC expansion branches.
+LED IOCTLs are limited to the six RGB indicators (GNSS1, GNSS2, IO1â€“IO4),
+use 8-bit PWM, cap global current at 128, and restore the caller's mux mask
+after every operation. Arbitrary I2C writes and EEPROM programming remain
+unavailable.
+
+The schematic's U26 TMUX1072 is not software-controlled. Its `MACSER` select
+comes only from the physical DIP switch: 0 routes MAC I2C and 1 routes the FPGA
+MAC UART. The Control Center identifies this prerequisite instead of claiming
+that U26 can be changed through the driver.
 
 ## Device Manager
 

--- a/DRV/Windows/TimeCardControlCenter/App.xaml
+++ b/DRV/Windows/TimeCardControlCenter/App.xaml
@@ -1,8 +1,7 @@
 <Application x:Class="TimeCardControlCenter.App"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-             StartupUri="MainWindow.xaml"
-             ShutdownMode="OnMainWindowClose">
+             ShutdownMode="OnExplicitShutdown">
     <Application.Resources>
         <ResourceDictionary>
             <Color x:Key="WindowColor">#07111F</Color>
@@ -221,8 +220,8 @@
                 <Setter Property="Foreground" Value="{StaticResource MutedBrush}" />
                 <Setter Property="FontFamily" Value="Segoe UI Semibold" />
                 <Setter Property="FontSize" Value="14" />
-                <Setter Property="Height" Value="48" />
-                <Setter Property="Margin" Value="12,3" />
+                <Setter Property="Height" Value="44" />
+                <Setter Property="Margin" Value="12,2" />
                 <Setter Property="Cursor" Value="Hand" />
                 <Setter Property="Template">
                     <Setter.Value>
@@ -249,6 +248,34 @@
                                                  StrokeThickness="1.5" />
                                         <Ellipse Margin="8" Fill="{TemplateBinding Foreground}" />
                                     </Grid>
+                                    <Canvas x:Name="UartNavGlyph" Grid.Column="1" Width="20" Height="20"
+                                            Visibility="Collapsed" HorizontalAlignment="Left"
+                                            VerticalAlignment="Center">
+                                        <Path Data="M 1.5,4.5 L 18.5,4.5 L 16.5,15.5 L 3.5,15.5 Z"
+                                              Stroke="{TemplateBinding Foreground}" StrokeThickness="1.5"
+                                              StrokeLineJoin="Round" />
+                                        <Ellipse Canvas.Left="2.5" Canvas.Top="8.75" Width="2.5" Height="2.5"
+                                                 Stroke="{TemplateBinding Foreground}" StrokeThickness="1" />
+                                        <Ellipse Canvas.Left="15" Canvas.Top="8.75" Width="2.5" Height="2.5"
+                                                 Stroke="{TemplateBinding Foreground}" StrokeThickness="1" />
+                                        <Ellipse Canvas.Left="5.5" Canvas.Top="7" Width="1.5" Height="1.5" Fill="{TemplateBinding Foreground}" />
+                                        <Ellipse Canvas.Left="7.5" Canvas.Top="7" Width="1.5" Height="1.5" Fill="{TemplateBinding Foreground}" />
+                                        <Ellipse Canvas.Left="9.5" Canvas.Top="7" Width="1.5" Height="1.5" Fill="{TemplateBinding Foreground}" />
+                                        <Ellipse Canvas.Left="11.5" Canvas.Top="7" Width="1.5" Height="1.5" Fill="{TemplateBinding Foreground}" />
+                                        <Ellipse Canvas.Left="13.5" Canvas.Top="7" Width="1.5" Height="1.5" Fill="{TemplateBinding Foreground}" />
+                                        <Ellipse Canvas.Left="6.5" Canvas.Top="11" Width="1.5" Height="1.5" Fill="{TemplateBinding Foreground}" />
+                                        <Ellipse Canvas.Left="8.5" Canvas.Top="11" Width="1.5" Height="1.5" Fill="{TemplateBinding Foreground}" />
+                                        <Ellipse Canvas.Left="10.5" Canvas.Top="11" Width="1.5" Height="1.5" Fill="{TemplateBinding Foreground}" />
+                                        <Ellipse Canvas.Left="12.5" Canvas.Top="11" Width="1.5" Height="1.5" Fill="{TemplateBinding Foreground}" />
+                                    </Canvas>
+                                    <Grid x:Name="TimingNavGlyph" Grid.Column="1" Width="20" Height="20"
+                                          Visibility="Collapsed" HorizontalAlignment="Left"
+                                          VerticalAlignment="Center">
+                                        <Path Data="M 1,10 L 4,10 L 6,4 L 9,16 L 12,7 L 14,10 L 19,10"
+                                              Stroke="{TemplateBinding Foreground}" StrokeThickness="1.7"
+                                              StrokeStartLineCap="Round" StrokeEndLineCap="Round"
+                                              StrokeLineJoin="Round" />
+                                    </Grid>
                                     <TextBlock Grid.Column="2" Text="{TemplateBinding ToolTip}" VerticalAlignment="Center"
                                                Foreground="{TemplateBinding Foreground}" />
                                 </Grid>
@@ -265,6 +292,14 @@
                                 <Trigger Property="Tag" Value="Sma">
                                     <Setter TargetName="NavGlyph" Property="Visibility" Value="Collapsed" />
                                     <Setter TargetName="SmaNavGlyph" Property="Visibility" Value="Visible" />
+                                </Trigger>
+                                <Trigger Property="Tag" Value="Uart">
+                                    <Setter TargetName="NavGlyph" Property="Visibility" Value="Collapsed" />
+                                    <Setter TargetName="UartNavGlyph" Property="Visibility" Value="Visible" />
+                                </Trigger>
+                                <Trigger Property="Tag" Value="Timing">
+                                    <Setter TargetName="NavGlyph" Property="Visibility" Value="Collapsed" />
+                                    <Setter TargetName="TimingNavGlyph" Property="Visibility" Value="Visible" />
                                 </Trigger>
                             </ControlTemplate.Triggers>
                         </ControlTemplate>

--- a/DRV/Windows/TimeCardControlCenter/App.xaml.cs
+++ b/DRV/Windows/TimeCardControlCenter/App.xaml.cs
@@ -1,8 +1,53 @@
+using System;
+using System.IO;
+using System.Threading.Tasks;
 using System.Windows;
 
 namespace TimeCardControlCenter
 {
     public partial class App : Application
     {
+        protected override async void OnStartup(StartupEventArgs e)
+        {
+            base.OnStartup(e);
+            ShutdownMode = ShutdownMode.OnExplicitShutdown;
+
+            SplashWindow splash = new SplashWindow();
+            splash.Show();
+
+            try
+            {
+                await Task.Delay(650);
+                splash.SetStatus("Preparing hardware services");
+                await Task.Delay(750);
+
+                splash.SetStatus("Loading workspace modules");
+                MainWindow controlCenter = new MainWindow();
+                await Task.Delay(950);
+
+                splash.SetStatus("Control Center ready");
+                await Task.Delay(550);
+
+                MainWindow = controlCenter;
+                ShutdownMode = ShutdownMode.OnMainWindowClose;
+                await splash.CloseAnimatedAsync();
+                controlCenter.Show();
+            }
+            catch (Exception ex)
+            {
+                splash.Close();
+                try
+                {
+                    File.WriteAllText(Path.Combine(Path.GetTempPath(),
+                        "timecard-control-center-startup.log"), ex.ToString());
+                }
+                catch
+                {
+                }
+                MessageBox.Show("Time Card Control Center could not start.\n\n" + ex.Message,
+                    "Startup failed", MessageBoxButton.OK, MessageBoxImage.Error);
+                Shutdown(-1);
+            }
+        }
     }
 }

--- a/DRV/Windows/TimeCardControlCenter/MainWindow.xaml
+++ b/DRV/Windows/TimeCardControlCenter/MainWindow.xaml
@@ -1,13 +1,14 @@
 <Window x:Class="TimeCardControlCenter.MainWindow"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:local="clr-namespace:TimeCardControlCenter"
         xmlns:shell="clr-namespace:System.Windows.Shell;assembly=PresentationFramework"
         Title="OCP Time Card Control Center"
         Width="1440" Height="900" MinWidth="1180" MinHeight="720"
         WindowStartupLocation="CenterScreen" WindowStyle="None"
         Background="#07111F" AllowsTransparency="False"
         Icon="Assets/timecard-app.ico"
-        Loaded="Window_Loaded" Closed="Window_Closed" StateChanged="Window_StateChanged">
+        Loaded="Window_Loaded" Closing="Window_Closing" Closed="Window_Closed" StateChanged="Window_StateChanged">
     <shell:WindowChrome.WindowChrome>
         <shell:WindowChrome CaptionHeight="0" ResizeBorderThickness="7"
                             CornerRadius="16" GlassFrameThickness="0" />
@@ -56,6 +57,11 @@
             <Setter Property="Margin" Value="0,0,14,14" />
             <Setter Property="Padding" Value="18" />
             <Setter Property="MinHeight" Value="154" />
+        </Style>
+        <Style x:Key="MetricCard" TargetType="Border" BasedOn="{StaticResource Panel}">
+            <Setter Property="Margin" Value="0,0,14,0" />
+            <Setter Property="Padding" Value="16" />
+            <Setter Property="MinHeight" Value="82" />
         </Style>
     </Window.Resources>
 
@@ -141,12 +147,113 @@
                         </Grid.RowDefinitions>
                         <StackPanel>
                             <Border Margin="16,0,16,16" Background="#07111F" BorderBrush="{StaticResource BorderBrush}"
-                                    BorderThickness="1" CornerRadius="12" Padding="10,7">
-                                <Image Source="Assets/timecard-logo.png" Height="72" Stretch="Uniform" />
+                                    BorderThickness="1" CornerRadius="12" Padding="10,7" ToolTip="OCP Time Card">
+                                <Grid Height="72" ClipToBounds="True">
+                                    <Ellipse x:Name="LogoDepthShadow" Height="12" Margin="28,53,28,0"
+                                             VerticalAlignment="Top" Opacity="0.20" IsHitTestVisible="False"
+                                             RenderTransformOrigin="0.5,0.5">
+                                        <Ellipse.Fill>
+                                            <RadialGradientBrush>
+                                                <GradientStop Color="#8069C441" Offset="0" />
+                                                <GradientStop Color="#00335B76" Offset="1" />
+                                            </RadialGradientBrush>
+                                        </Ellipse.Fill>
+                                        <Ellipse.RenderTransform>
+                                            <ScaleTransform x:Name="LogoShadowScale" />
+                                        </Ellipse.RenderTransform>
+                                        <Ellipse.Effect><BlurEffect Radius="7" /></Ellipse.Effect>
+                                    </Ellipse>
+                                    <Viewport3D x:Name="AnimatedTimeCardLogo" ClipToBounds="True"
+                                                IsHitTestVisible="False" RenderOptions.EdgeMode="Aliased">
+                                        <Viewport3D.Camera>
+                                            <PerspectiveCamera Position="0,0,1.4" LookDirection="0,0,-1.4"
+                                                               UpDirection="0,1,0" FieldOfView="42" />
+                                        </Viewport3D.Camera>
+                                        <ModelVisual3D>
+                                            <ModelVisual3D.Content>
+                                                <Model3DGroup>
+                                                    <AmbientLight Color="#FFFFFFFF" />
+                                                    <GeometryModel3D>
+                                                        <GeometryModel3D.Geometry>
+                                                            <MeshGeometry3D
+                                        Positions="-0.285,-0.19,0  0.285,-0.19,0  0.285,0.19,0  -0.285,0.19,0"
+                                                                TextureCoordinates="0,1  1,1  1,0  0,0"
+                                                                TriangleIndices="0,1,2 0,2,3"
+                                                                Normals="0,0,1 0,0,1 0,0,1 0,0,1" />
+                                                        </GeometryModel3D.Geometry>
+                                                        <GeometryModel3D.Material>
+                                                            <DiffuseMaterial>
+                                                                <DiffuseMaterial.Brush>
+                                                                    <ImageBrush ImageSource="Assets/timecard-logo.png" Stretch="Fill" />
+                                                                </DiffuseMaterial.Brush>
+                                                            </DiffuseMaterial>
+                                                        </GeometryModel3D.Material>
+                                                        <GeometryModel3D.Transform>
+                                                            <Transform3DGroup>
+                                                                <RotateTransform3D>
+                                                                    <RotateTransform3D.Rotation>
+                                                                        <AxisAngleRotation3D x:Name="LogoPitch" Axis="1,0,0" Angle="-1.2" />
+                                                                    </RotateTransform3D.Rotation>
+                                                                </RotateTransform3D>
+                                                                <RotateTransform3D>
+                                                                    <RotateTransform3D.Rotation>
+                                                                        <AxisAngleRotation3D x:Name="LogoYaw" Axis="0,1,0" Angle="-3.2" />
+                                                                    </RotateTransform3D.Rotation>
+                                                                </RotateTransform3D>
+                                                                <RotateTransform3D>
+                                                                    <RotateTransform3D.Rotation>
+                                                                        <AxisAngleRotation3D x:Name="LogoRoll" Axis="0,0,1" Angle="-0.35" />
+                                                                    </RotateTransform3D.Rotation>
+                                                                </RotateTransform3D>
+                                                                <TranslateTransform3D x:Name="LogoFloat" OffsetY="-0.012" />
+                                                            </Transform3DGroup>
+                                                        </GeometryModel3D.Transform>
+                                                    </GeometryModel3D>
+                                                </Model3DGroup>
+                                            </ModelVisual3D.Content>
+                                        </ModelVisual3D>
+                                    </Viewport3D>
+                                </Grid>
+                                <Border.Triggers>
+                                    <EventTrigger RoutedEvent="FrameworkElement.Loaded">
+                                        <BeginStoryboard>
+                                            <Storyboard>
+                                                <DoubleAnimation Storyboard.TargetName="LogoYaw" Storyboard.TargetProperty="Angle"
+                                                                 From="-3.2" To="3.2" Duration="0:0:5.8"
+                                                                 AutoReverse="True" RepeatBehavior="Forever"
+                                                                 AccelerationRatio="0.35" DecelerationRatio="0.35" />
+                                                <DoubleAnimation Storyboard.TargetName="LogoPitch" Storyboard.TargetProperty="Angle"
+                                                                 From="-1.2" To="1.6" Duration="0:0:4.7"
+                                                                 AutoReverse="True" RepeatBehavior="Forever"
+                                                                 AccelerationRatio="0.3" DecelerationRatio="0.3" />
+                                                <DoubleAnimation Storyboard.TargetName="LogoRoll" Storyboard.TargetProperty="Angle"
+                                                                 From="-0.35" To="0.35" Duration="0:0:7.1"
+                                                                 AutoReverse="True" RepeatBehavior="Forever"
+                                                                 AccelerationRatio="0.4" DecelerationRatio="0.4" />
+                                                <DoubleAnimation Storyboard.TargetName="LogoFloat" Storyboard.TargetProperty="OffsetY"
+                                                                 From="-0.012" To="0.018" Duration="0:0:3.9"
+                                                                 AutoReverse="True" RepeatBehavior="Forever"
+                                                                 AccelerationRatio="0.35" DecelerationRatio="0.35" />
+                                                <DoubleAnimation Storyboard.TargetName="LogoFloat" Storyboard.TargetProperty="OffsetZ"
+                                                                 From="0" To="0.018" Duration="0:0:5.8"
+                                                                 AutoReverse="True" RepeatBehavior="Forever"
+                                                                 AccelerationRatio="0.35" DecelerationRatio="0.35" />
+                                                <DoubleAnimation Storyboard.TargetName="LogoDepthShadow" Storyboard.TargetProperty="Opacity"
+                                                                 From="0.17" To="0.28" Duration="0:0:3.9"
+                                                                 AutoReverse="True" RepeatBehavior="Forever" />
+                                                <DoubleAnimation Storyboard.TargetName="LogoShadowScale" Storyboard.TargetProperty="ScaleX"
+                                                                 From="0.92" To="1.04" Duration="0:0:3.9"
+                                                                 AutoReverse="True" RepeatBehavior="Forever" />
+                                            </Storyboard>
+                                        </BeginStoryboard>
+                                    </EventTrigger>
+                                </Border.Triggers>
                             </Border>
                             <TextBlock Text="WORKSPACES" Style="{StaticResource Label}" Margin="26,0,0,10" />
                         </StackPanel>
-                        <StackPanel Grid.Row="1">
+                        <ScrollViewer Grid.Row="1" VerticalScrollBarVisibility="Auto"
+                                      HorizontalScrollBarVisibility="Disabled">
+                          <StackPanel>
                             <RadioButton x:Name="OverviewNav" GroupName="Navigation" Style="{StaticResource NavRadio}" Tag="Overview"
                                          Content="&#xE80F;" ToolTip="Overview" IsChecked="True"
                                          Checked="Navigate_Checked" />
@@ -160,13 +267,16 @@
                                          Content="&#xE756;" ToolTip="UART Console" Checked="Navigate_Checked" />
                             <RadioButton x:Name="SmaNav" GroupName="Navigation" Style="{StaticResource NavRadio}" Tag="Sma"
                                          Content="&#xE9CA;" ToolTip="SMA Connectors" Checked="Navigate_Checked" />
+                            <RadioButton x:Name="TimingNav" GroupName="Navigation" Style="{StaticResource NavRadio}" Tag="Timing"
+                                         Content="&#xE9D2;" ToolTip="Generators &amp; Freq." Checked="Navigate_Checked" />
                             <RadioButton x:Name="I2cNav" GroupName="Navigation" Style="{StaticResource NavRadio}" Tag="I2c"
                                          Content="&#xE950;" ToolTip="I&#x00B2;C Bus" Checked="Navigate_Checked" />
                             <RadioButton x:Name="SubsystemsNav" GroupName="Navigation" Style="{StaticResource NavRadio}" Tag="Subsystems"
                                          Content="&#xE713;" ToolTip="Subsystems" Checked="Navigate_Checked" />
                             <RadioButton x:Name="DiagnosticsNav" GroupName="Navigation" Style="{StaticResource NavRadio}" Tag="Diagnostics"
                                          Content="&#xE9D9;" ToolTip="Diagnostics" Checked="Navigate_Checked" />
-                        </StackPanel>
+                          </StackPanel>
+                        </ScrollViewer>
                         <Border Grid.Row="2" Margin="14,0" Background="#0E1E2D" BorderBrush="{StaticResource BorderBrush}"
                                 BorderThickness="1" CornerRadius="12" Padding="14">
                             <StackPanel>
@@ -204,7 +314,7 @@
                                                Foreground="{StaticResource MutedBrush}" FontSize="13" />
                                 </StackPanel>
                                 <StackPanel Grid.Column="1" Orientation="Horizontal" VerticalAlignment="Center">
-                                    <Button Content="Sync from Windows" Click="SetClock_Click" Margin="0,0,10,0" />
+                                    <Button Content="Sync from System Clock" Click="SetClock_Click" Margin="0,0,10,0" />
                                     <Button Content="Sync from Time Card" Click="SetSystemFromClock_Click"
                                             Style="{StaticResource SecondaryButton}" Margin="0,0,10,0" />
                                     <Button Content="Refresh now" Click="Refresh_Click" Style="{StaticResource SecondaryButton}" />
@@ -246,7 +356,7 @@
                                 <Grid.ColumnDefinitions><ColumnDefinition Width="1.65*" /><ColumnDefinition Width="1*" /></Grid.ColumnDefinitions>
                                 <Border Grid.Column="0" Style="{StaticResource Panel}" Margin="0,0,18,0">
                                     <Grid>
-                                        <Grid.RowDefinitions><RowDefinition Height="Auto" /><RowDefinition Height="Auto" /><RowDefinition Height="Auto" /></Grid.RowDefinitions>
+                                        <Grid.RowDefinitions><RowDefinition Height="Auto" /><RowDefinition Height="Auto" /><RowDefinition Height="Auto" /><RowDefinition Height="Auto" /></Grid.RowDefinitions>
                                         <Grid>
                                             <TextBlock Text="Precision Hardware Clock" Style="{StaticResource SectionTitle}" />
                                             <Border Style="{StaticResource StatusChip}" HorizontalAlignment="Right">
@@ -259,17 +369,82 @@
                                         <Grid Grid.Row="2" Margin="0,16,0,0">
                                             <Grid.ColumnDefinitions><ColumnDefinition Width="*" /><ColumnDefinition Width="*" /><ColumnDefinition Width="*" /></Grid.ColumnDefinitions>
                                             <StackPanel>
-                                                <TextBlock Text="OFFSET TO WINDOWS" Style="{StaticResource Label}" />
+                                                <TextBlock Text="OFFSET TO SYSTEM CLOCK" Style="{StaticResource Label}" />
                                                 <TextBlock x:Name="OffsetText" Text="—" FontFamily="Segoe UI Semibold" FontSize="17" Margin="0,5,0,0" />
                                             </StackPanel>
                                             <StackPanel Grid.Column="1">
-                                                <TextBlock Text="SAMPLE WINDOW" Style="{StaticResource Label}" />
-                                                <TextBlock x:Name="SamplingWindowText" Text="—" FontFamily="Segoe UI Semibold" FontSize="17" Margin="0,5,0,0" />
-                                            </StackPanel>
-                                            <StackPanel Grid.Column="2">
                                                 <TextBlock Text="SYSTEM UTC" Style="{StaticResource Label}" />
                                                 <TextBlock x:Name="SystemTimeText" Text="—" FontFamily="Segoe UI Semibold" FontSize="14" Margin="0,7,0,0" />
                                             </StackPanel>
+                                            <StackPanel Grid.Column="2">
+                                                <TextBlock Text="SAMPLE WINDOW" Style="{StaticResource Label}" />
+                                                <TextBlock x:Name="SamplingWindowText" Text="—" FontFamily="Segoe UI Semibold" FontSize="17" Margin="0,5,0,0" />
+                                            </StackPanel>
+                                        </Grid>
+                                        <Grid Grid.Row="3" Margin="0,24,0,0">
+                                            <Grid.ColumnDefinitions>
+                                                <ColumnDefinition Width="*" />
+                                                <ColumnDefinition Width="*" />
+                                            </Grid.ColumnDefinitions>
+
+                                            <Border Grid.Column="0" Margin="0,0,7,0" Padding="14,13,14,11"
+                                                    CornerRadius="12" Background="#091522"
+                                                    BorderBrush="{StaticResource BorderBrush}" BorderThickness="1">
+                                                <Grid>
+                                                    <Grid.RowDefinitions>
+                                                        <RowDefinition Height="Auto" />
+                                                        <RowDefinition Height="112" />
+                                                        <RowDefinition Height="Auto" />
+                                                    </Grid.RowDefinitions>
+                                                    <Grid>
+                                                        <TextBlock Text="OFFSET TO SYSTEM CLOCK" Style="{StaticResource Label}" />
+                                                        <TextBlock x:Name="OffsetHistoryValueText" Text="&#x2014;"
+                                                                   HorizontalAlignment="Right" Foreground="{StaticResource CyanBrush}"
+                                                                   FontFamily="Segoe UI Semibold" FontSize="12" />
+                                                    </Grid>
+                                                    <local:RollingTelemetryChart x:Name="OffsetHistoryChart" Grid.Row="1"
+                                                                                 Margin="0,11,0,8" Capacity="60"
+                                                                                 MinimumRange="10"
+                                                                                 LineBrush="{StaticResource CyanBrush}"
+                                                                                 AreaBrush="#204CC9F0"
+                                                                                 ToolTip="Rolling Time Card offset with detail-focused automatic vertical zoom" />
+                                                    <Grid Grid.Row="2">
+                                                        <TextBlock x:Name="OffsetHistoryScaleText" Text="WAITING FOR SAMPLES"
+                                                                   Foreground="{StaticResource MutedBrush}" FontSize="9" />
+                                                        <TextBlock Text="ROLLING &#x00B7; 60 S" HorizontalAlignment="Right"
+                                                                   Foreground="#617A90" FontSize="9" />
+                                                    </Grid>
+                                                </Grid>
+                                            </Border>
+
+                                            <Border Grid.Column="1" Margin="7,0,0,0" Padding="14,13,14,11"
+                                                    CornerRadius="12" Background="#091522"
+                                                    BorderBrush="{StaticResource BorderBrush}" BorderThickness="1">
+                                                <Grid>
+                                                    <Grid.RowDefinitions>
+                                                        <RowDefinition Height="Auto" />
+                                                        <RowDefinition Height="112" />
+                                                        <RowDefinition Height="Auto" />
+                                                    </Grid.RowDefinitions>
+                                                    <Grid>
+                                                        <TextBlock Text="SAMPLE WINDOW" Style="{StaticResource Label}" />
+                                                        <TextBlock x:Name="SamplingHistoryValueText" Text="&#x2014;"
+                                                                   HorizontalAlignment="Right" Foreground="{StaticResource GoldBrush}"
+                                                                   FontFamily="Segoe UI Semibold" FontSize="12" />
+                                                    </Grid>
+                                                    <local:RollingTelemetryChart x:Name="SamplingHistoryChart" Grid.Row="1"
+                                                                                 Margin="0,11,0,8" Capacity="60"
+                                                                                 LineBrush="{StaticResource GoldBrush}"
+                                                                                 AreaBrush="#20DAB539"
+                                                                                 ToolTip="Rolling cross-timestamp sample window" />
+                                                    <Grid Grid.Row="2">
+                                                        <TextBlock x:Name="SamplingHistoryScaleText" Text="WAITING FOR SAMPLES"
+                                                                   Foreground="{StaticResource MutedBrush}" FontSize="9" />
+                                                        <TextBlock Text="ROLLING &#x00B7; 60 S" HorizontalAlignment="Right"
+                                                                   Foreground="#617A90" FontSize="9" />
+                                                    </Grid>
+                                                </Grid>
+                                            </Border>
                                         </Grid>
                                     </Grid>
                                 </Border>
@@ -311,16 +486,16 @@
                     <!-- CLOCK -->
                     <ScrollViewer x:Name="ClockPage" Visibility="Collapsed" VerticalScrollBarVisibility="Auto">
                         <Grid Margin="32,28,32,34">
-                            <Grid.RowDefinitions><RowDefinition Height="Auto" /><RowDefinition Height="Auto" /><RowDefinition Height="Auto" /><RowDefinition Height="Auto" /></Grid.RowDefinitions>
+                            <Grid.RowDefinitions><RowDefinition Height="Auto" /><RowDefinition Height="Auto" /><RowDefinition Height="Auto" /><RowDefinition Height="Auto" /><RowDefinition Height="Auto" /><RowDefinition Height="Auto" /></Grid.RowDefinitions>
                             <Grid>
                                 <Grid.ColumnDefinitions><ColumnDefinition Width="*" /><ColumnDefinition Width="Auto" /></Grid.ColumnDefinitions>
                                 <StackPanel>
                                     <TextBlock Text="PRECISION HARDWARE CLOCK" Style="{StaticResource Eyebrow}" />
                                     <TextBlock Text="Clock control &amp; cross-timestamping" Style="{StaticResource PageTitle}" Margin="0,5,0,4" />
-                                    <TextBlock Text="Compare the card PHC to Windows UTC and perform an explicit one-shot synchronization."
+                                    <TextBlock Text="Compare the card PHC to system UTC and perform an explicit one-shot synchronization."
                                                Foreground="{StaticResource MutedBrush}" />
                                 </StackPanel>
-                                <Button Grid.Column="1" Content="Set PHC from Windows" Click="SetClock_Click" VerticalAlignment="Center" />
+                                <Button Grid.Column="1" Content="Sync from System Clock" Click="SetClock_Click" VerticalAlignment="Center" />
                             </Grid>
                             <Grid Grid.Row="1" Margin="0,26,0,20">
                                 <Grid.ColumnDefinitions><ColumnDefinition Width="1.6*" /><ColumnDefinition Width="1*" /></Grid.ColumnDefinitions>
@@ -340,6 +515,35 @@
                                                 <TextBlock x:Name="ClockOffsetText" Text="—" FontFamily="Segoe UI Semibold" FontSize="20" Margin="0,5,0,0" />
                                             </StackPanel>
                                         </Grid>
+                                        <Border Margin="0,22,0,0" Padding="14,12,14,10"
+                                                CornerRadius="12" Background="#091522"
+                                                BorderBrush="{StaticResource BorderBrush}" BorderThickness="1">
+                                            <Grid>
+                                                <Grid.RowDefinitions>
+                                                    <RowDefinition Height="Auto" />
+                                                    <RowDefinition Height="104" />
+                                                    <RowDefinition Height="Auto" />
+                                                </Grid.RowDefinitions>
+                                                <Grid>
+                                                    <TextBlock Text="MEASURED OFFSET HISTORY" Style="{StaticResource Label}" />
+                                                    <TextBlock x:Name="ClockOffsetHistoryValueText" Text="&#x2014;"
+                                                               HorizontalAlignment="Right" Foreground="{StaticResource CyanBrush}"
+                                                               FontFamily="Segoe UI Semibold" FontSize="12" />
+                                                </Grid>
+                                                <local:RollingTelemetryChart x:Name="ClockOffsetHistoryChart" Grid.Row="1"
+                                                                             Margin="0,10,0,8" Capacity="60"
+                                                                             MinimumRange="10"
+                                                                             LineBrush="{StaticResource CyanBrush}"
+                                                                             AreaBrush="#204CC9F0"
+                                                                             ToolTip="Rolling measured offset with detail-focused automatic vertical zoom" />
+                                                <Grid Grid.Row="2">
+                                                    <TextBlock x:Name="ClockOffsetHistoryScaleText" Text="WAITING FOR SAMPLES"
+                                                               Foreground="{StaticResource MutedBrush}" FontSize="9" />
+                                                    <TextBlock Text="ROLLING &#x00B7; 60 S" HorizontalAlignment="Right"
+                                                               Foreground="#617A90" FontSize="9" />
+                                                </Grid>
+                                            </Grid>
+                                        </Border>
                                     </StackPanel>
                                 </Border>
                                 <Border Grid.Column="1" Style="{StaticResource Panel}">
@@ -351,6 +555,34 @@
                                         <Separator Background="{StaticResource BorderBrush}" Margin="0,20" />
                                         <TextBlock Text="Sampling uncertainty" Style="{StaticResource Label}" />
                                         <TextBlock x:Name="ClockSamplingText" Text="—" FontSize="18" FontFamily="Segoe UI Semibold" Margin="0,6,0,0" />
+                                        <Border Margin="0,18,0,0" Padding="14,12,14,10"
+                                                CornerRadius="12" Background="#091522"
+                                                BorderBrush="{StaticResource BorderBrush}" BorderThickness="1">
+                                            <Grid>
+                                                <Grid.RowDefinitions>
+                                                    <RowDefinition Height="Auto" />
+                                                    <RowDefinition Height="104" />
+                                                    <RowDefinition Height="Auto" />
+                                                </Grid.RowDefinitions>
+                                                <Grid>
+                                                    <TextBlock Text="SAMPLING UNCERTAINTY HISTORY" Style="{StaticResource Label}" />
+                                                    <TextBlock x:Name="ClockSamplingHistoryValueText" Text="&#x2014;"
+                                                               HorizontalAlignment="Right" Foreground="{StaticResource GoldBrush}"
+                                                               FontFamily="Segoe UI Semibold" FontSize="12" />
+                                                </Grid>
+                                                <local:RollingTelemetryChart x:Name="ClockSamplingHistoryChart" Grid.Row="1"
+                                                                             Margin="0,10,0,8" Capacity="60"
+                                                                             LineBrush="{StaticResource GoldBrush}"
+                                                                             AreaBrush="#20DAB539"
+                                                                             ToolTip="Rolling cross-timestamp sampling uncertainty" />
+                                                <Grid Grid.Row="2">
+                                                    <TextBlock x:Name="ClockSamplingHistoryScaleText" Text="WAITING FOR SAMPLES"
+                                                               Foreground="{StaticResource MutedBrush}" FontSize="9" />
+                                                    <TextBlock Text="ROLLING &#x00B7; 60 S" HorizontalAlignment="Right"
+                                                               Foreground="#617A90" FontSize="9" />
+                                                </Grid>
+                                            </Grid>
+                                        </Border>
                                     </StackPanel>
                                 </Border>
                             </Grid>
@@ -408,7 +640,7 @@
                             <Grid.RowDefinitions>
                                 <RowDefinition Height="Auto" /><RowDefinition Height="Auto" /><RowDefinition Height="Auto" />
                                 <RowDefinition Height="Auto" /><RowDefinition Height="Auto" /><RowDefinition Height="Auto" />
-                                <RowDefinition Height="Auto" />
+                                <RowDefinition Height="Auto" /><RowDefinition Height="Auto" />
                             </Grid.RowDefinitions>
                             <StackPanel>
                                 <TextBlock Text="GNSS &amp; TIME-OF-DAY" Style="{StaticResource Eyebrow}" />
@@ -537,7 +769,57 @@
                                 </StackPanel></Border>
                             </UniformGrid>
 
-                            <Grid Grid.Row="5" Margin="0,18,0,0">
+                            <Border Grid.Row="5" Style="{StaticResource Panel}" Margin="0,18,0,0" Padding="18">
+                                <Grid>
+                                    <Grid.RowDefinitions><RowDefinition Height="Auto" /><RowDefinition Height="Auto" /></Grid.RowDefinitions>
+                                    <Grid>
+                                        <Grid.ColumnDefinitions><ColumnDefinition Width="*" /><ColumnDefinition Width="Auto" /></Grid.ColumnDefinitions>
+                                        <StackPanel>
+                                            <TextBlock Text="Satellite sky map" Style="{StaticResource SectionTitle}" />
+                                            <TextBlock Text="North-up polar view from UBX-NAV-SAT: zenith is centered and the horizon is the outer ring. Marker size follows C/N₀."
+                                                       Foreground="{StaticResource MutedBrush}" TextWrapping="Wrap" Margin="0,5,0,0" />
+                                        </StackPanel>
+                                        <TextBlock x:Name="UbloxSkyMapStatusText" Grid.Column="1" Text="AWAITING UBX-NAV-SAT"
+                                                   Foreground="{StaticResource GoldBrush}" FontFamily="Segoe UI Semibold" FontSize="10"
+                                                   VerticalAlignment="Top" Margin="18,3,0,0" />
+                                    </Grid>
+                                    <Grid Grid.Row="1" Margin="0,16,0,0">
+                                        <Grid.ColumnDefinitions><ColumnDefinition Width="1*" /><ColumnDefinition Width="330" /></Grid.ColumnDefinitions>
+                                        <Border Background="#07111F" BorderBrush="{StaticResource BorderBrush}" BorderThickness="1"
+                                                CornerRadius="12" Padding="10" MinHeight="430">
+                                            <Canvas x:Name="UbloxSkyMapCanvas" Height="408" Background="Transparent"
+                                                    SizeChanged="UbloxSkyMap_SizeChanged" />
+                                        </Border>
+                                        <StackPanel Grid.Column="1" Margin="18,0,0,0">
+                                            <TextBlock Text="Signal summary" FontFamily="Segoe UI Semibold" FontSize="14" />
+                                            <TextBlock x:Name="UbloxSkyMapSummaryText" Text="Refresh the receiver to load satellite geometry."
+                                                       Foreground="{StaticResource MutedBrush}" TextWrapping="Wrap" Margin="0,5,0,12" />
+                                            <UniformGrid Columns="2" Margin="0,0,0,8">
+                                                <StackPanel Orientation="Horizontal" Margin="0,4"><Ellipse Width="9" Height="9" Fill="#69C441" Margin="0,0,7,0" /><TextBlock Text="GPS" FontSize="11" /></StackPanel>
+                                                <StackPanel Orientation="Horizontal" Margin="0,4"><Ellipse Width="9" Height="9" Fill="#4CC9F0" Margin="0,0,7,0" /><TextBlock Text="Galileo" FontSize="11" /></StackPanel>
+                                                <StackPanel Orientation="Horizontal" Margin="0,4"><Ellipse Width="9" Height="9" Fill="#DAB539" Margin="0,0,7,0" /><TextBlock Text="BeiDou" FontSize="11" /></StackPanel>
+                                                <StackPanel Orientation="Horizontal" Margin="0,4"><Ellipse Width="9" Height="9" Fill="#FF667A" Margin="0,0,7,0" /><TextBlock Text="GLONASS" FontSize="11" /></StackPanel>
+                                                <StackPanel Orientation="Horizontal" Margin="0,4"><Ellipse Width="9" Height="9" Fill="#50E3C2" Margin="0,0,7,0" /><TextBlock Text="SBAS" FontSize="11" /></StackPanel>
+                                                <StackPanel Orientation="Horizontal" Margin="0,4"><Ellipse Width="9" Height="9" Fill="#CB88FF" Margin="0,0,7,0" /><TextBlock Text="QZSS" FontSize="11" /></StackPanel>
+                                                <StackPanel Orientation="Horizontal" Margin="0,4"><Ellipse Width="9" Height="9" Fill="#FF9E64" Margin="0,0,7,0" /><TextBlock Text="NavIC" FontSize="11" /></StackPanel>
+                                                <TextBlock Text="White ring = used" Foreground="{StaticResource MutedBrush}" FontSize="10" Margin="0,4" />
+                                            </UniformGrid>
+                                            <Grid Margin="0,5,0,6">
+                                                <Grid.ColumnDefinitions><ColumnDefinition Width="54" /><ColumnDefinition Width="90" /><ColumnDefinition Width="58" /><ColumnDefinition Width="*" /></Grid.ColumnDefinitions>
+                                                <TextBlock Text="SV" Style="{StaticResource Label}" />
+                                                <TextBlock Grid.Column="1" Text="EL / AZ" Style="{StaticResource Label}" />
+                                                <TextBlock Grid.Column="2" Text="C/N₀" Style="{StaticResource Label}" />
+                                                <TextBlock Grid.Column="3" Text="SIGNAL" Style="{StaticResource Label}" />
+                                            </Grid>
+                                            <ScrollViewer Height="260" VerticalScrollBarVisibility="Auto" HorizontalScrollBarVisibility="Disabled">
+                                                <StackPanel x:Name="UbloxSatelliteListPanel" />
+                                            </ScrollViewer>
+                                        </StackPanel>
+                                    </Grid>
+                                </Grid>
+                            </Border>
+
+                            <Grid Grid.Row="6" Margin="0,18,0,0">
                                 <Grid.ColumnDefinitions><ColumnDefinition Width="1*" /><ColumnDefinition Width="1*" /></Grid.ColumnDefinitions>
                                 <Border x:Name="UbloxRatePanel" Style="{StaticResource Panel}" Margin="0,0,18,0" IsEnabled="False">
                                     <StackPanel>
@@ -588,7 +870,7 @@
                                 </Border>
                             </Grid>
 
-                            <Grid Grid.Row="6" Margin="0,18,0,0">
+                            <Grid Grid.Row="7" Margin="0,18,0,0">
                                 <Grid.ColumnDefinitions><ColumnDefinition Width="1.2*" /><ColumnDefinition Width="0.8*" /></Grid.ColumnDefinitions>
                                 <Border x:Name="UbloxTimePulsePanel" Style="{StaticResource Panel}" Margin="0,0,18,0" IsEnabled="False">
                                     <StackPanel>
@@ -839,7 +1121,7 @@
                         <StackPanel>
                             <TextBlock Text="HARDWARE UART CONSOLE" Style="{StaticResource Eyebrow}" />
                             <TextBlock Text="Inspect, configure &amp; command serial devices" Style="{StaticResource PageTitle}" Margin="0,5,0,4" />
-                            <TextBlock Text="Lossless text or hexadecimal access to GNSS, secondary GNSS, atomic clock, and NMEA UARTs."
+                            <TextBlock Text="Inspect UART traffic as ASCII, hexadecimal, decimal, or binary data across all four hardware ports."
                                        Foreground="{StaticResource MutedBrush}" />
                         </StackPanel>
                         <Border Grid.Row="1" Style="{StaticResource Panel}" Margin="0,24,0,14" Padding="16">
@@ -863,7 +1145,15 @@
                                 <StackPanel Grid.Column="3" Margin="0,0,12,0"><TextBlock Text="TIMEOUT (MS)" Style="{StaticResource Label}" Margin="0,0,0,5" />
                                     <TextBox x:Name="UartTimeoutTextBox" Text="1000" /></StackPanel>
                                 <StackPanel Grid.Column="4" Margin="0,0,12,0"><TextBlock Text="DISPLAY" Style="{StaticResource Label}" Margin="0,0,0,5" />
-                                    <ComboBox x:Name="UartFormatCombo" SelectedIndex="0"><ComboBoxItem>Auto</ComboBoxItem><ComboBoxItem>Text</ComboBoxItem><ComboBoxItem>Hex</ComboBoxItem></ComboBox></StackPanel>
+                                    <ComboBox x:Name="UartFormatCombo" SelectedIndex="0"
+                                              SelectionChanged="UartFormat_SelectionChanged"
+                                              ToolTip="Choose how each received and transmitted byte is displayed">
+                                        <ComboBoxItem Tag="Auto">Auto</ComboBoxItem>
+                                        <ComboBoxItem Tag="Ascii">ASCII</ComboBoxItem>
+                                        <ComboBoxItem Tag="Hex">Hexadecimal</ComboBoxItem>
+                                        <ComboBoxItem Tag="Decimal">Decimal</ComboBoxItem>
+                                        <ComboBoxItem Tag="Binary">Binary</ComboBoxItem>
+                                    </ComboBox></StackPanel>
                                 <Button Grid.Column="5" Content="Configure 8N1" Click="ConfigureUart_Click" VerticalAlignment="Bottom" />
                             </Grid>
                         </Border>
@@ -939,8 +1229,11 @@
                                     <TextBlock Text="Select connector direction and the FPGA timing signal routed to it."
                                                Foreground="{StaticResource MutedBrush}" />
                                 </StackPanel>
-                                <Button Grid.Column="1" Content="Refresh connector states" Click="RefreshSma_Click"
-                                        Style="{StaticResource SecondaryButton}" VerticalAlignment="Center" />
+                                <StackPanel Grid.Column="1" Orientation="Horizontal" VerticalAlignment="Center">
+                                    <Button Content="Generators &amp; frequency" Click="OpenTiming_Click" Margin="0,0,10,0" />
+                                    <Button Content="Refresh connector states" Click="RefreshSma_Click"
+                                            Style="{StaticResource SecondaryButton}" />
+                                </StackPanel>
                             </Grid>
 
                             <Border Grid.Row="1" Background="#312919" BorderBrush="#6D5622" BorderThickness="1"
@@ -1049,100 +1342,296 @@
                         </Grid>
                     </ScrollViewer>
 
-                    <!-- I2C BUS -->
-                    <ScrollViewer x:Name="I2cPage" Visibility="Collapsed" VerticalScrollBarVisibility="Auto">
+                    <!-- SIGNAL GENERATORS AND FREQUENCY COUNTERS -->
+                    <ScrollViewer x:Name="TimingPage" Visibility="Collapsed" VerticalScrollBarVisibility="Auto">
                         <Grid Margin="32,28,32,34">
-                            <Grid.RowDefinitions>
-                                <RowDefinition Height="Auto" />
-                                <RowDefinition Height="Auto" />
-                                <RowDefinition Height="Auto" />
-                                <RowDefinition Height="Auto" />
-                            </Grid.RowDefinitions>
+                            <Grid.RowDefinitions><RowDefinition Height="Auto" /><RowDefinition Height="Auto" /><RowDefinition Height="Auto" /><RowDefinition Height="Auto" /></Grid.RowDefinitions>
                             <Grid>
                                 <Grid.ColumnDefinitions><ColumnDefinition Width="*" /><ColumnDefinition Width="Auto" /></Grid.ColumnDefinitions>
                                 <StackPanel>
-                                    <TextBlock Text="READ-ONLY I&#x00B2;C WORKBENCH" Style="{StaticResource Eyebrow}" />
-                                    <TextBlock Text="Inspect the Time Card's onboard I&#x00B2;C bus" Style="{StaticResource PageTitle}" Margin="0,5,0,4" />
-                                    <TextBlock Text="Discover devices and read EEPROM/register data through the Xilinx AXI IIC controller."
+                                    <TextBlock Text="SMA TIMING MODULES" Style="{StaticResource Eyebrow}" />
+                                    <TextBlock Text="Generators &amp; frequency measurement" Style="{StaticResource PageTitle}" Margin="0,5,0,4" />
+                                    <TextBlock Text="Program the four periodic outputs and measure four external frequencies, with direct routing to the front-panel SMA connectors."
                                                Foreground="{StaticResource MutedBrush}" />
                                 </StackPanel>
                                 <StackPanel Grid.Column="1" Orientation="Horizontal" VerticalAlignment="Center">
-                                    <Button x:Name="I2cRefreshButton" Content="Refresh bus" Click="RefreshI2c_Click" Margin="0,0,10,0" />
-                                    <Button x:Name="I2cScanButton" Content="Scan 7-bit bus" Click="ScanI2c_Click"
+                                    <Button Content="SMA routing" Click="OpenSma_Click" Margin="0,0,10,0" />
+                                    <Button Content="Refresh modules" Click="RefreshTiming_Click"
                                             Style="{StaticResource SecondaryButton}" />
                                 </StackPanel>
                             </Grid>
-
-                            <Border Grid.Row="1" Background="#142A29" BorderBrush="#28584F" BorderThickness="1"
-                                    CornerRadius="12" Padding="16,12" Margin="0,22,0,18">
+                            <Border Grid.Row="1" Background="#312919" BorderBrush="#6D5622" BorderThickness="1"
+                                    CornerRadius="12" Padding="16,12" Margin="0,22,0,22">
                                 <Grid><Grid.ColumnDefinitions><ColumnDefinition Width="Auto" /><ColumnDefinition Width="*" /><ColumnDefinition Width="Auto" /></Grid.ColumnDefinitions>
-                                    <TextBlock Text="&#xE73E;" FontFamily="Segoe MDL2 Assets" Foreground="{StaticResource AccentBrush}"
+                                    <TextBlock Text="&#xE7BA;" FontFamily="Segoe MDL2 Assets" Foreground="{StaticResource GoldBrush}"
                                                FontSize="18" VerticalAlignment="Center" Margin="0,0,12,0" />
-                                    <TextBlock Grid.Column="1" Text="Safe read-only mode is active. Address probes and EEPROM-style reads are available; writes are locked until hardware validation is complete."
-                                               Foreground="#B9E8D8" TextWrapping="Wrap" VerticalAlignment="Center" />
-                                    <TextBlock Grid.Column="2" Text="ABI 3" Foreground="{StaticResource AccentBrush}"
+                                    <TextBlock Grid.Column="1" Text="SMA output routing is immediate. Disconnect external sources before routing a generator to a connector. Counter integration time is 0 (off) or 1–255 seconds."
+                                               Foreground="#F0D994" TextWrapping="Wrap" VerticalAlignment="Center" />
+                                    <TextBlock Grid.Column="2" Text="ABI 5" Foreground="{StaticResource GoldBrush}"
                                                FontFamily="Segoe UI Semibold" Margin="16,0,0,0" VerticalAlignment="Center" />
                                 </Grid>
                             </Border>
 
+                            <StackPanel Grid.Row="2">
+                                <TextBlock Text="Signal generators" Style="{StaticResource SectionTitle}" />
+                                <TextBlock Text="Frequency is converted to the nearest whole-nanosecond period. Phase is relative to the PHC-aligned period boundary."
+                                           Foreground="{StaticResource MutedBrush}" Margin="0,5,0,14" />
+                                <UniformGrid Columns="2">
+                                    <Border Style="{StaticResource SubsystemCard}" MinHeight="286">
+                                        <StackPanel>
+                                            <Grid><Grid.ColumnDefinitions><ColumnDefinition Width="Auto" /><ColumnDefinition Width="*" /><ColumnDefinition Width="Auto" /></Grid.ColumnDefinitions>
+                                                <Image Source="Assets/timecard-timing.png" Width="42" Height="42" />
+                                                <StackPanel Grid.Column="1" Margin="12,0"><TextBlock Text="Generator 1" Style="{StaticResource SectionTitle}" />
+                                                    <TextBlock x:Name="Generator1StatusText" Text="NOT QUERIED" Foreground="{StaticResource MutedBrush}" FontSize="10" /></StackPanel>
+                                                <CheckBox x:Name="Generator1EnabledCheckBox" Grid.Column="2" Content="Enabled" VerticalAlignment="Center" IsEnabled="False" />
+                                            </Grid>
+                                            <Grid Margin="0,16,0,10"><Grid.ColumnDefinitions><ColumnDefinition Width="1.35*" /><ColumnDefinition Width="0.65*" /></Grid.ColumnDefinitions>
+                                                <StackPanel Margin="0,0,10,0"><TextBlock Text="FREQUENCY (HZ)" Style="{StaticResource Label}" Margin="0,0,0,5" /><TextBox x:Name="Generator1FrequencyTextBox" Text="10000000" IsEnabled="False" /></StackPanel>
+                                                <StackPanel Grid.Column="1"><TextBlock Text="DUTY (%)" Style="{StaticResource Label}" Margin="0,0,0,5" /><TextBox x:Name="Generator1DutyTextBox" Text="50" IsEnabled="False" /></StackPanel>
+                                            </Grid>
+                                            <Grid Margin="0,0,0,10"><Grid.ColumnDefinitions><ColumnDefinition Width="*" /><ColumnDefinition Width="Auto" /></Grid.ColumnDefinitions>
+                                                <StackPanel Margin="0,0,12,0"><TextBlock Text="PHASE (NS)" Style="{StaticResource Label}" Margin="0,0,0,5" /><TextBox x:Name="Generator1PhaseTextBox" Text="0" IsEnabled="False" /></StackPanel>
+                                                <CheckBox x:Name="Generator1InvertCheckBox" Grid.Column="1" Content="Invert polarity" VerticalAlignment="Bottom" Margin="0,0,0,9" IsEnabled="False" />
+                                            </Grid>
+                                            <TextBlock Text="ROUTE OUTPUT" Style="{StaticResource Label}" Margin="0,0,0,5" />
+                                            <ComboBox x:Name="Generator1RouteCombo" SelectedIndex="0" IsEnabled="False"><ComboBoxItem Tag="0">Keep current route</ComboBoxItem><ComboBoxItem Tag="1">SMA 1</ComboBoxItem><ComboBoxItem Tag="2">SMA 2</ComboBoxItem><ComboBoxItem Tag="3">SMA 3</ComboBoxItem><ComboBoxItem Tag="4">SMA 4</ComboBoxItem></ComboBox>
+                                            <Grid Margin="0,12,0,0"><Grid.ColumnDefinitions><ColumnDefinition Width="*" /><ColumnDefinition Width="Auto" /></Grid.ColumnDefinitions>
+                                                <TextBlock x:Name="Generator1DetailText" Text="Period — · Start —" Foreground="{StaticResource MutedBrush}" FontSize="11" VerticalAlignment="Center" TextWrapping="Wrap" />
+                                                <Button x:Name="Generator1ApplyButton" Grid.Column="1" Tag="1" Content="Apply" Click="ApplySignalGenerator_Click" Padding="16,7" IsEnabled="False" />
+                                            </Grid>
+                                        </StackPanel>
+                                    </Border>
+                                    <Border Style="{StaticResource SubsystemCard}" MinHeight="286">
+                                        <StackPanel>
+                                            <Grid><Grid.ColumnDefinitions><ColumnDefinition Width="Auto" /><ColumnDefinition Width="*" /><ColumnDefinition Width="Auto" /></Grid.ColumnDefinitions>
+                                                <Image Source="Assets/timecard-timing.png" Width="42" Height="42" />
+                                                <StackPanel Grid.Column="1" Margin="12,0"><TextBlock Text="Generator 2" Style="{StaticResource SectionTitle}" /><TextBlock x:Name="Generator2StatusText" Text="NOT QUERIED" Foreground="{StaticResource MutedBrush}" FontSize="10" /></StackPanel>
+                                                <CheckBox x:Name="Generator2EnabledCheckBox" Grid.Column="2" Content="Enabled" VerticalAlignment="Center" IsEnabled="False" />
+                                            </Grid>
+                                            <Grid Margin="0,16,0,10"><Grid.ColumnDefinitions><ColumnDefinition Width="1.35*" /><ColumnDefinition Width="0.65*" /></Grid.ColumnDefinitions>
+                                                <StackPanel Margin="0,0,10,0"><TextBlock Text="FREQUENCY (HZ)" Style="{StaticResource Label}" Margin="0,0,0,5" /><TextBox x:Name="Generator2FrequencyTextBox" Text="10000000" IsEnabled="False" /></StackPanel>
+                                                <StackPanel Grid.Column="1"><TextBlock Text="DUTY (%)" Style="{StaticResource Label}" Margin="0,0,0,5" /><TextBox x:Name="Generator2DutyTextBox" Text="50" IsEnabled="False" /></StackPanel>
+                                            </Grid>
+                                            <Grid Margin="0,0,0,10"><Grid.ColumnDefinitions><ColumnDefinition Width="*" /><ColumnDefinition Width="Auto" /></Grid.ColumnDefinitions>
+                                                <StackPanel Margin="0,0,12,0"><TextBlock Text="PHASE (NS)" Style="{StaticResource Label}" Margin="0,0,0,5" /><TextBox x:Name="Generator2PhaseTextBox" Text="0" IsEnabled="False" /></StackPanel>
+                                                <CheckBox x:Name="Generator2InvertCheckBox" Grid.Column="1" Content="Invert polarity" VerticalAlignment="Bottom" Margin="0,0,0,9" IsEnabled="False" />
+                                            </Grid>
+                                            <TextBlock Text="ROUTE OUTPUT" Style="{StaticResource Label}" Margin="0,0,0,5" />
+                                            <ComboBox x:Name="Generator2RouteCombo" SelectedIndex="0" IsEnabled="False"><ComboBoxItem Tag="0">Keep current route</ComboBoxItem><ComboBoxItem Tag="1">SMA 1</ComboBoxItem><ComboBoxItem Tag="2">SMA 2</ComboBoxItem><ComboBoxItem Tag="3">SMA 3</ComboBoxItem><ComboBoxItem Tag="4">SMA 4</ComboBoxItem></ComboBox>
+                                            <Grid Margin="0,12,0,0"><Grid.ColumnDefinitions><ColumnDefinition Width="*" /><ColumnDefinition Width="Auto" /></Grid.ColumnDefinitions>
+                                                <TextBlock x:Name="Generator2DetailText" Text="Period — · Start —" Foreground="{StaticResource MutedBrush}" FontSize="11" VerticalAlignment="Center" TextWrapping="Wrap" />
+                                                <Button x:Name="Generator2ApplyButton" Grid.Column="1" Tag="2" Content="Apply" Click="ApplySignalGenerator_Click" Padding="16,7" IsEnabled="False" />
+                                            </Grid>
+                                        </StackPanel>
+                                    </Border>
+                                    <Border Style="{StaticResource SubsystemCard}" MinHeight="286">
+                                        <StackPanel>
+                                            <Grid><Grid.ColumnDefinitions><ColumnDefinition Width="Auto" /><ColumnDefinition Width="*" /><ColumnDefinition Width="Auto" /></Grid.ColumnDefinitions>
+                                                <Image Source="Assets/timecard-timing.png" Width="42" Height="42" />
+                                                <StackPanel Grid.Column="1" Margin="12,0"><TextBlock Text="Generator 3" Style="{StaticResource SectionTitle}" /><TextBlock x:Name="Generator3StatusText" Text="NOT QUERIED" Foreground="{StaticResource MutedBrush}" FontSize="10" /></StackPanel>
+                                                <CheckBox x:Name="Generator3EnabledCheckBox" Grid.Column="2" Content="Enabled" VerticalAlignment="Center" IsEnabled="False" />
+                                            </Grid>
+                                            <Grid Margin="0,16,0,10"><Grid.ColumnDefinitions><ColumnDefinition Width="1.35*" /><ColumnDefinition Width="0.65*" /></Grid.ColumnDefinitions>
+                                                <StackPanel Margin="0,0,10,0"><TextBlock Text="FREQUENCY (HZ)" Style="{StaticResource Label}" Margin="0,0,0,5" /><TextBox x:Name="Generator3FrequencyTextBox" Text="10000000" IsEnabled="False" /></StackPanel>
+                                                <StackPanel Grid.Column="1"><TextBlock Text="DUTY (%)" Style="{StaticResource Label}" Margin="0,0,0,5" /><TextBox x:Name="Generator3DutyTextBox" Text="50" IsEnabled="False" /></StackPanel>
+                                            </Grid>
+                                            <Grid Margin="0,0,0,10"><Grid.ColumnDefinitions><ColumnDefinition Width="*" /><ColumnDefinition Width="Auto" /></Grid.ColumnDefinitions>
+                                                <StackPanel Margin="0,0,12,0"><TextBlock Text="PHASE (NS)" Style="{StaticResource Label}" Margin="0,0,0,5" /><TextBox x:Name="Generator3PhaseTextBox" Text="0" IsEnabled="False" /></StackPanel>
+                                                <CheckBox x:Name="Generator3InvertCheckBox" Grid.Column="1" Content="Invert polarity" VerticalAlignment="Bottom" Margin="0,0,0,9" IsEnabled="False" />
+                                            </Grid>
+                                            <TextBlock Text="ROUTE OUTPUT" Style="{StaticResource Label}" Margin="0,0,0,5" />
+                                            <ComboBox x:Name="Generator3RouteCombo" SelectedIndex="0" IsEnabled="False"><ComboBoxItem Tag="0">Keep current route</ComboBoxItem><ComboBoxItem Tag="1">SMA 1</ComboBoxItem><ComboBoxItem Tag="2">SMA 2</ComboBoxItem><ComboBoxItem Tag="3">SMA 3</ComboBoxItem><ComboBoxItem Tag="4">SMA 4</ComboBoxItem></ComboBox>
+                                            <Grid Margin="0,12,0,0"><Grid.ColumnDefinitions><ColumnDefinition Width="*" /><ColumnDefinition Width="Auto" /></Grid.ColumnDefinitions>
+                                                <TextBlock x:Name="Generator3DetailText" Text="Period — · Start —" Foreground="{StaticResource MutedBrush}" FontSize="11" VerticalAlignment="Center" TextWrapping="Wrap" />
+                                                <Button x:Name="Generator3ApplyButton" Grid.Column="1" Tag="3" Content="Apply" Click="ApplySignalGenerator_Click" Padding="16,7" IsEnabled="False" />
+                                            </Grid>
+                                        </StackPanel>
+                                    </Border>
+                                    <Border Style="{StaticResource SubsystemCard}" MinHeight="286">
+                                        <StackPanel>
+                                            <Grid><Grid.ColumnDefinitions><ColumnDefinition Width="Auto" /><ColumnDefinition Width="*" /><ColumnDefinition Width="Auto" /></Grid.ColumnDefinitions>
+                                                <Image Source="Assets/timecard-timing.png" Width="42" Height="42" />
+                                                <StackPanel Grid.Column="1" Margin="12,0"><TextBlock Text="Generator 4" Style="{StaticResource SectionTitle}" /><TextBlock x:Name="Generator4StatusText" Text="NOT QUERIED" Foreground="{StaticResource MutedBrush}" FontSize="10" /></StackPanel>
+                                                <CheckBox x:Name="Generator4EnabledCheckBox" Grid.Column="2" Content="Enabled" VerticalAlignment="Center" IsEnabled="False" />
+                                            </Grid>
+                                            <Grid Margin="0,16,0,10"><Grid.ColumnDefinitions><ColumnDefinition Width="1.35*" /><ColumnDefinition Width="0.65*" /></Grid.ColumnDefinitions>
+                                                <StackPanel Margin="0,0,10,0"><TextBlock Text="FREQUENCY (HZ)" Style="{StaticResource Label}" Margin="0,0,0,5" /><TextBox x:Name="Generator4FrequencyTextBox" Text="10000000" IsEnabled="False" /></StackPanel>
+                                                <StackPanel Grid.Column="1"><TextBlock Text="DUTY (%)" Style="{StaticResource Label}" Margin="0,0,0,5" /><TextBox x:Name="Generator4DutyTextBox" Text="50" IsEnabled="False" /></StackPanel>
+                                            </Grid>
+                                            <Grid Margin="0,0,0,10"><Grid.ColumnDefinitions><ColumnDefinition Width="*" /><ColumnDefinition Width="Auto" /></Grid.ColumnDefinitions>
+                                                <StackPanel Margin="0,0,12,0"><TextBlock Text="PHASE (NS)" Style="{StaticResource Label}" Margin="0,0,0,5" /><TextBox x:Name="Generator4PhaseTextBox" Text="0" IsEnabled="False" /></StackPanel>
+                                                <CheckBox x:Name="Generator4InvertCheckBox" Grid.Column="1" Content="Invert polarity" VerticalAlignment="Bottom" Margin="0,0,0,9" IsEnabled="False" />
+                                            </Grid>
+                                            <TextBlock Text="ROUTE OUTPUT" Style="{StaticResource Label}" Margin="0,0,0,5" />
+                                            <ComboBox x:Name="Generator4RouteCombo" SelectedIndex="0" IsEnabled="False"><ComboBoxItem Tag="0">Keep current route</ComboBoxItem><ComboBoxItem Tag="1">SMA 1</ComboBoxItem><ComboBoxItem Tag="2">SMA 2</ComboBoxItem><ComboBoxItem Tag="3">SMA 3</ComboBoxItem><ComboBoxItem Tag="4">SMA 4</ComboBoxItem></ComboBox>
+                                            <Grid Margin="0,12,0,0"><Grid.ColumnDefinitions><ColumnDefinition Width="*" /><ColumnDefinition Width="Auto" /></Grid.ColumnDefinitions>
+                                                <TextBlock x:Name="Generator4DetailText" Text="Period — · Start —" Foreground="{StaticResource MutedBrush}" FontSize="11" VerticalAlignment="Center" TextWrapping="Wrap" />
+                                                <Button x:Name="Generator4ApplyButton" Grid.Column="1" Tag="4" Content="Apply" Click="ApplySignalGenerator_Click" Padding="16,7" IsEnabled="False" />
+                                            </Grid>
+                                        </StackPanel>
+                                    </Border>
+                                </UniformGrid>
+                            </StackPanel>
+
+                            <StackPanel Grid.Row="3" Margin="0,12,0,0">
+                                <TextBlock Text="Frequency counters" Style="{StaticResource SectionTitle}" />
+                                <TextBlock Text="Route an SMA input to a counter and choose its measurement window. Refresh after the integration interval to read a valid sample."
+                                           Foreground="{StaticResource MutedBrush}" Margin="0,5,0,14" />
+                                <UniformGrid Columns="2">
+                                    <Border Style="{StaticResource SubsystemCard}" MinHeight="220">
+                                        <StackPanel><Grid><Grid.ColumnDefinitions><ColumnDefinition Width="*" /><ColumnDefinition Width="Auto" /></Grid.ColumnDefinitions><TextBlock Text="Frequency 1" Style="{StaticResource SectionTitle}" /><TextBlock x:Name="Frequency1StatusText" Grid.Column="1" Text="NOT QUERIED" Foreground="{StaticResource MutedBrush}" FontSize="10" /></Grid>
+                                            <TextBlock x:Name="Frequency1ValueText" Text="— Hz" Style="{StaticResource MetricValue}" Margin="0,12,0,12" />
+                                            <Grid><Grid.ColumnDefinitions><ColumnDefinition Width="0.8*" /><ColumnDefinition Width="1.2*" /></Grid.ColumnDefinitions><StackPanel Margin="0,0,10,0"><TextBlock Text="INTEGRATION (S)" Style="{StaticResource Label}" Margin="0,0,0,5" /><TextBox x:Name="Frequency1SecondsTextBox" Text="1" IsEnabled="False" /></StackPanel><StackPanel Grid.Column="1"><TextBlock Text="ROUTE INPUT" Style="{StaticResource Label}" Margin="0,0,0,5" /><ComboBox x:Name="Frequency1RouteCombo" SelectedIndex="0" IsEnabled="False"><ComboBoxItem Tag="0">Keep current route</ComboBoxItem><ComboBoxItem Tag="1">SMA 1</ComboBoxItem><ComboBoxItem Tag="2">SMA 2</ComboBoxItem><ComboBoxItem Tag="3">SMA 3</ComboBoxItem><ComboBoxItem Tag="4">SMA 4</ComboBoxItem></ComboBox></StackPanel></Grid>
+                                            <Grid Margin="0,12,0,0"><Grid.ColumnDefinitions><ColumnDefinition Width="*" /><ColumnDefinition Width="Auto" /></Grid.ColumnDefinitions><TextBlock x:Name="Frequency1DetailText" Text="Control — · Status —" Foreground="{StaticResource MutedBrush}" FontSize="11" VerticalAlignment="Center" /><Button x:Name="Frequency1ApplyButton" Grid.Column="1" Tag="1" Content="Apply" Click="ApplyFrequencyCounter_Click" Padding="14,7" IsEnabled="False" /></Grid>
+                                        </StackPanel>
+                                    </Border>
+                                    <Border Style="{StaticResource SubsystemCard}" MinHeight="220">
+                                        <StackPanel><Grid><Grid.ColumnDefinitions><ColumnDefinition Width="*" /><ColumnDefinition Width="Auto" /></Grid.ColumnDefinitions><TextBlock Text="Frequency 2" Style="{StaticResource SectionTitle}" /><TextBlock x:Name="Frequency2StatusText" Grid.Column="1" Text="NOT QUERIED" Foreground="{StaticResource MutedBrush}" FontSize="10" /></Grid>
+                                            <TextBlock x:Name="Frequency2ValueText" Text="— Hz" Style="{StaticResource MetricValue}" Margin="0,12,0,12" />
+                                            <Grid><Grid.ColumnDefinitions><ColumnDefinition Width="0.8*" /><ColumnDefinition Width="1.2*" /></Grid.ColumnDefinitions><StackPanel Margin="0,0,10,0"><TextBlock Text="INTEGRATION (S)" Style="{StaticResource Label}" Margin="0,0,0,5" /><TextBox x:Name="Frequency2SecondsTextBox" Text="1" IsEnabled="False" /></StackPanel><StackPanel Grid.Column="1"><TextBlock Text="ROUTE INPUT" Style="{StaticResource Label}" Margin="0,0,0,5" /><ComboBox x:Name="Frequency2RouteCombo" SelectedIndex="0" IsEnabled="False"><ComboBoxItem Tag="0">Keep current route</ComboBoxItem><ComboBoxItem Tag="1">SMA 1</ComboBoxItem><ComboBoxItem Tag="2">SMA 2</ComboBoxItem><ComboBoxItem Tag="3">SMA 3</ComboBoxItem><ComboBoxItem Tag="4">SMA 4</ComboBoxItem></ComboBox></StackPanel></Grid>
+                                            <Grid Margin="0,12,0,0"><Grid.ColumnDefinitions><ColumnDefinition Width="*" /><ColumnDefinition Width="Auto" /></Grid.ColumnDefinitions><TextBlock x:Name="Frequency2DetailText" Text="Control — · Status —" Foreground="{StaticResource MutedBrush}" FontSize="11" VerticalAlignment="Center" /><Button x:Name="Frequency2ApplyButton" Grid.Column="1" Tag="2" Content="Apply" Click="ApplyFrequencyCounter_Click" Padding="14,7" IsEnabled="False" /></Grid>
+                                        </StackPanel>
+                                    </Border>
+                                    <Border Style="{StaticResource SubsystemCard}" MinHeight="220">
+                                        <StackPanel><Grid><Grid.ColumnDefinitions><ColumnDefinition Width="*" /><ColumnDefinition Width="Auto" /></Grid.ColumnDefinitions><TextBlock Text="Frequency 3" Style="{StaticResource SectionTitle}" /><TextBlock x:Name="Frequency3StatusText" Grid.Column="1" Text="NOT QUERIED" Foreground="{StaticResource MutedBrush}" FontSize="10" /></Grid>
+                                            <TextBlock x:Name="Frequency3ValueText" Text="— Hz" Style="{StaticResource MetricValue}" Margin="0,12,0,12" />
+                                            <Grid><Grid.ColumnDefinitions><ColumnDefinition Width="0.8*" /><ColumnDefinition Width="1.2*" /></Grid.ColumnDefinitions><StackPanel Margin="0,0,10,0"><TextBlock Text="INTEGRATION (S)" Style="{StaticResource Label}" Margin="0,0,0,5" /><TextBox x:Name="Frequency3SecondsTextBox" Text="1" IsEnabled="False" /></StackPanel><StackPanel Grid.Column="1"><TextBlock Text="ROUTE INPUT" Style="{StaticResource Label}" Margin="0,0,0,5" /><ComboBox x:Name="Frequency3RouteCombo" SelectedIndex="0" IsEnabled="False"><ComboBoxItem Tag="0">Keep current route</ComboBoxItem><ComboBoxItem Tag="1">SMA 1</ComboBoxItem><ComboBoxItem Tag="2">SMA 2</ComboBoxItem><ComboBoxItem Tag="3">SMA 3</ComboBoxItem><ComboBoxItem Tag="4">SMA 4</ComboBoxItem></ComboBox></StackPanel></Grid>
+                                            <Grid Margin="0,12,0,0"><Grid.ColumnDefinitions><ColumnDefinition Width="*" /><ColumnDefinition Width="Auto" /></Grid.ColumnDefinitions><TextBlock x:Name="Frequency3DetailText" Text="Control — · Status —" Foreground="{StaticResource MutedBrush}" FontSize="11" VerticalAlignment="Center" /><Button x:Name="Frequency3ApplyButton" Grid.Column="1" Tag="3" Content="Apply" Click="ApplyFrequencyCounter_Click" Padding="14,7" IsEnabled="False" /></Grid>
+                                        </StackPanel>
+                                    </Border>
+                                    <Border Style="{StaticResource SubsystemCard}" MinHeight="220">
+                                        <StackPanel><Grid><Grid.ColumnDefinitions><ColumnDefinition Width="*" /><ColumnDefinition Width="Auto" /></Grid.ColumnDefinitions><TextBlock Text="Frequency 4" Style="{StaticResource SectionTitle}" /><TextBlock x:Name="Frequency4StatusText" Grid.Column="1" Text="NOT QUERIED" Foreground="{StaticResource MutedBrush}" FontSize="10" /></Grid>
+                                            <TextBlock x:Name="Frequency4ValueText" Text="— Hz" Style="{StaticResource MetricValue}" Margin="0,12,0,12" />
+                                            <Grid><Grid.ColumnDefinitions><ColumnDefinition Width="0.8*" /><ColumnDefinition Width="1.2*" /></Grid.ColumnDefinitions><StackPanel Margin="0,0,10,0"><TextBlock Text="INTEGRATION (S)" Style="{StaticResource Label}" Margin="0,0,0,5" /><TextBox x:Name="Frequency4SecondsTextBox" Text="1" IsEnabled="False" /></StackPanel><StackPanel Grid.Column="1"><TextBlock Text="ROUTE INPUT" Style="{StaticResource Label}" Margin="0,0,0,5" /><ComboBox x:Name="Frequency4RouteCombo" SelectedIndex="0" IsEnabled="False"><ComboBoxItem Tag="0">Keep current route</ComboBoxItem><ComboBoxItem Tag="1">SMA 1</ComboBoxItem><ComboBoxItem Tag="2">SMA 2</ComboBoxItem><ComboBoxItem Tag="3">SMA 3</ComboBoxItem><ComboBoxItem Tag="4">SMA 4</ComboBoxItem></ComboBox></StackPanel></Grid>
+                                            <Grid Margin="0,12,0,0"><Grid.ColumnDefinitions><ColumnDefinition Width="*" /><ColumnDefinition Width="Auto" /></Grid.ColumnDefinitions><TextBlock x:Name="Frequency4DetailText" Text="Control — · Status —" Foreground="{StaticResource MutedBrush}" FontSize="11" VerticalAlignment="Center" /><Button x:Name="Frequency4ApplyButton" Grid.Column="1" Tag="4" Content="Apply" Click="ApplyFrequencyCounter_Click" Padding="14,7" IsEnabled="False" /></Grid>
+                                        </StackPanel>
+                                    </Border>
+                                </UniformGrid>
+                            </StackPanel>
+                        </Grid>
+                    </ScrollViewer>
+
+                    <!-- I2C BUS -->
+                    <ScrollViewer x:Name="I2cPage" Visibility="Collapsed" VerticalScrollBarVisibility="Auto">
+                        <Grid Margin="32,28,32,34">
+                            <Grid.RowDefinitions><RowDefinition Height="Auto" /><RowDefinition Height="Auto" /><RowDefinition Height="Auto" /><RowDefinition Height="Auto" /><RowDefinition Height="Auto" /><RowDefinition Height="Auto" /></Grid.RowDefinitions>
+                            <Grid>
+                                <Grid.ColumnDefinitions><ColumnDefinition Width="*" /><ColumnDefinition Width="Auto" /></Grid.ColumnDefinitions>
+                                <StackPanel>
+                                    <TextBlock Text="I&#x00B2;C BUS LAB" Style="{StaticResource Eyebrow}" />
+                                    <TextBlock Text="Route, inspect, and operate the Time Card's I&#x00B2;C fabric" Style="{StaticResource PageTitle}" Margin="0,5,0,4" />
+                                    <TextBlock Text="Control the PCA9546A branches, discover schematic-defined devices, and manage the six subsystem RGB indicators."
+                                               Foreground="{StaticResource MutedBrush}" />
+                                </StackPanel>
+                                <StackPanel Grid.Column="1" Orientation="Horizontal" VerticalAlignment="Center">
+                                    <Button x:Name="I2cRefreshButton" Content="Refresh bus" Click="RefreshI2c_Click" Margin="0,0,10,0" />
+                                    <Button x:Name="I2cScanButton" Content="Scan 7-bit bus" Click="ScanI2c_Click" Style="{StaticResource SecondaryButton}" />
+                                </StackPanel>
+                            </Grid>
+
+                            <Border Grid.Row="1" Background="#142A29" BorderBrush="#28584F" BorderThickness="1" CornerRadius="12" Padding="16,12" Margin="0,22,0,18">
+                                <Grid><Grid.ColumnDefinitions><ColumnDefinition Width="Auto" /><ColumnDefinition Width="*" /><ColumnDefinition Width="Auto" /></Grid.ColumnDefinitions>
+                                    <TextBlock x:Name="I2cModeIcon" Text="&#xE73E;" FontFamily="Segoe MDL2 Assets" Foreground="{StaticResource AccentBrush}" FontSize="18" VerticalAlignment="Center" Margin="0,0,12,0" />
+                                    <TextBlock x:Name="I2cSafetyBannerText" Grid.Column="1" Text="Guarded mode allows reads plus dedicated mux and status-LED operations. Arbitrary I&#x00B2;C writes remain blocked."
+                                               Foreground="#B9E8D8" TextWrapping="Wrap" VerticalAlignment="Center" />
+                                    <TextBlock x:Name="I2cDriverBadgeText" Grid.Column="2" Text="ABI 7" Foreground="{StaticResource AccentBrush}" FontFamily="Segoe UI Semibold" Margin="16,0,0,0" VerticalAlignment="Center" />
+                                </Grid>
+                            </Border>
+
                             <UniformGrid Grid.Row="2" Columns="4" Margin="0,0,0,20">
-                                <Border Style="{StaticResource MetricPanel}"><StackPanel>
-                                    <TextBlock Text="CONTROLLER" Style="{StaticResource Label}" />
-                                    <TextBlock x:Name="I2cControllerStateText" Text="NOT QUERIED" Style="{StaticResource MetricValue}" FontSize="21" Margin="0,8,0,5" />
-                                    <TextBlock x:Name="I2cControllerDetailText" Text="Waiting for ABI 3" Foreground="{StaticResource MutedBrush}" TextWrapping="Wrap" />
-                                </StackPanel></Border>
-                                <Border Style="{StaticResource MetricPanel}"><StackPanel>
-                                    <TextBlock Text="BUS STATE" Style="{StaticResource Label}" />
-                                    <TextBlock x:Name="I2cBusStateText" Text="&#x2014;" Style="{StaticResource MetricValue}" FontSize="21" Margin="0,8,0,5" />
-                                    <TextBlock x:Name="I2cBusDetailText" Text="No sample" Foreground="{StaticResource MutedBrush}" />
-                                </StackPanel></Border>
-                                <Border Style="{StaticResource MetricPanel}"><StackPanel>
-                                    <TextBlock Text="REGISTER WINDOW" Style="{StaticResource Label}" />
-                                    <TextBlock x:Name="I2cOffsetText" Text="&#x2014;" Style="{StaticResource MetricValue}" FontSize="21" Margin="0,8,0,5" />
-                                    <TextBlock x:Name="I2cRegisterText" Text="CR &#x2014; &#x00B7; SR &#x2014;" Foreground="{StaticResource MutedBrush}" FontFamily="Consolas" />
-                                </StackPanel></Border>
-                                <Border Style="{StaticResource MetricPanel}"><StackPanel>
-                                    <TextBlock Text="DISCOVERED" Style="{StaticResource Label}" />
-                                    <TextBlock x:Name="I2cDeviceCountText" Text="&#x2014;" Style="{StaticResource MetricValue}" FontSize="21" Margin="0,8,0,5" />
-                                    <TextBlock x:Name="I2cScanResultText" Text="Known devices not probed" Foreground="{StaticResource MutedBrush}" TextWrapping="Wrap" />
-                                </StackPanel></Border>
+                                <Border Style="{StaticResource MetricPanel}"><StackPanel><TextBlock Text="CONTROLLER" Style="{StaticResource Label}" /><TextBlock x:Name="I2cControllerStateText" Text="NOT QUERIED" Style="{StaticResource MetricValue}" FontSize="21" Margin="0,8,0,5" /><TextBlock x:Name="I2cControllerDetailText" Text="Waiting for a driver sample" Foreground="{StaticResource MutedBrush}" TextWrapping="Wrap" /></StackPanel></Border>
+                                <Border Style="{StaticResource MetricPanel}"><StackPanel><TextBlock Text="BUS STATE" Style="{StaticResource Label}" /><TextBlock x:Name="I2cBusStateText" Text="&#x2014;" Style="{StaticResource MetricValue}" FontSize="21" Margin="0,8,0,5" /><TextBlock x:Name="I2cBusDetailText" Text="No sample" Foreground="{StaticResource MutedBrush}" /></StackPanel></Border>
+                                <Border Style="{StaticResource MetricPanel}"><StackPanel><TextBlock Text="REGISTER WINDOW" Style="{StaticResource Label}" /><TextBlock x:Name="I2cOffsetText" Text="&#x2014;" Style="{StaticResource MetricValue}" FontSize="21" Margin="0,8,0,5" /><TextBlock x:Name="I2cRegisterText" Text="CR &#x2014; &#x00B7; SR &#x2014;" Foreground="{StaticResource MutedBrush}" FontFamily="Consolas" /></StackPanel></Border>
+                                <Border Style="{StaticResource MetricPanel}"><StackPanel><TextBlock Text="DISCOVERED" Style="{StaticResource Label}" /><TextBlock x:Name="I2cDeviceCountText" Text="&#x2014;" Style="{StaticResource MetricValue}" FontSize="21" Margin="0,8,0,5" /><TextBlock x:Name="I2cScanResultText" Text="Known devices not probed" Foreground="{StaticResource MutedBrush}" TextWrapping="Wrap" /></StackPanel></Border>
                             </UniformGrid>
 
-                            <Grid Grid.Row="3">
-                                <Grid.ColumnDefinitions><ColumnDefinition Width="0.82*" /><ColumnDefinition Width="1.18*" /></Grid.ColumnDefinitions>
+                            <Grid Grid.Row="3" Margin="0,0,0,18">
+                                <Grid.ColumnDefinitions><ColumnDefinition Width="1.25*" /><ColumnDefinition Width="0.75*" /></Grid.ColumnDefinitions>
+                                <Border Style="{StaticResource Panel}" Margin="0,0,18,0">
+                                    <StackPanel>
+                                        <Grid><Grid.ColumnDefinitions><ColumnDefinition Width="*" /><ColumnDefinition Width="Auto" /></Grid.ColumnDefinitions><StackPanel><TextBlock Text="PCA9546A downstream routing" Style="{StaticResource SectionTitle}" /><TextBlock Text="U27 &#x00B7; upstream address 0x70 &#x00B7; channels may be combined by the device" Foreground="{StaticResource MutedBrush}" FontSize="11" Margin="0,3,0,0" /></StackPanel><TextBlock x:Name="I2cMuxStatusText" Grid.Column="1" Text="NOT QUERIED" Foreground="{StaticResource MutedBrush}" FontFamily="Segoe UI Semibold" FontSize="10" VerticalAlignment="Center" /></Grid>
+                                        <WrapPanel Margin="0,16,0,14">
+                                            <Button Content="Disconnect all" Tag="0" Click="SelectI2cMux_Click" Style="{StaticResource SecondaryButton}" Margin="0,0,8,8" />
+                                            <Button Content="CH0  MAC" Tag="1" Click="SelectI2cMux_Click" Style="{StaticResource SecondaryButton}" Margin="0,0,8,8" />
+                                            <Button Content="CH1  Sensors" Tag="2" Click="SelectI2cMux_Click" Margin="0,0,8,8" />
+                                            <Button Content="CH2  AN/ADC" Tag="4" Click="SelectI2cMux_Click" Style="{StaticResource SecondaryButton}" Margin="0,0,8,8" />
+                                            <Button Content="CH3  DC" Tag="8" Click="SelectI2cMux_Click" Style="{StaticResource SecondaryButton}" Margin="0,0,8,8" />
+                                        </WrapPanel>
+                                        <UniformGrid Columns="2">
+                                            <Border Background="#0B1926" BorderBrush="{StaticResource BorderBrush}" BorderThickness="1" CornerRadius="9" Padding="12" Margin="0,0,8,8"><StackPanel><TextBlock Text="CH0  MAC CLOCK" FontFamily="Segoe UI Semibold" /><TextBlock Text="Atomic-clock connector I&#x00B2;C; also requires MACSER DIP = I&#x00B2;C." Foreground="{StaticResource MutedBrush}" FontSize="11" TextWrapping="Wrap" Margin="0,4,0,0" /></StackPanel></Border>
+                                            <Border Background="#0B1926" BorderBrush="{StaticResource BorderBrush}" BorderThickness="1" CornerRadius="9" Padding="12" Margin="8,0,0,8"><StackPanel><TextBlock Text="CH1  SENSORS + LEDS" FontFamily="Segoe UI Semibold" /><TextBlock Text="0x29 BNO055 &#x00B7; 0x40/41/44 INA219 &#x00B7; 0x6E IS32FL3207 &#x00B7; 0x76 BME280" Foreground="{StaticResource MutedBrush}" FontSize="11" TextWrapping="Wrap" Margin="0,4,0,0" /></StackPanel></Border>
+                                            <Border Background="#0B1926" BorderBrush="{StaticResource BorderBrush}" BorderThickness="1" CornerRadius="9" Padding="12" Margin="0,8,8,0"><StackPanel><TextBlock Text="CH2  AN / ADC" FontFamily="Segoe UI Semibold" /><TextBlock Text="Analog/ADC expansion I&#x00B2;C branch exposed by the card headers." Foreground="{StaticResource MutedBrush}" FontSize="11" TextWrapping="Wrap" Margin="0,4,0,0" /></StackPanel></Border>
+                                            <Border Background="#0B1926" BorderBrush="{StaticResource BorderBrush}" BorderThickness="1" CornerRadius="9" Padding="12" Margin="8,8,0,0"><StackPanel><TextBlock Text="CH3  DC" FontFamily="Segoe UI Semibold" /><TextBlock Text="DC expansion I&#x00B2;C branch exposed by the card headers." Foreground="{StaticResource MutedBrush}" FontSize="11" TextWrapping="Wrap" Margin="0,4,0,0" /></StackPanel></Border>
+                                        </UniformGrid>
+                                    </StackPanel>
+                                </Border>
+                                <Border Grid.Column="1" Style="{StaticResource Panel}">
+                                    <StackPanel>
+                                        <TextBlock Text="TMUX1072 MAC route" Style="{StaticResource SectionTitle}" />
+                                        <TextBlock Text="U26 is a two-channel I&#x00B2;C / UART signal switch, not the four-branch bus mux." Foreground="{StaticResource MutedBrush}" TextWrapping="Wrap" Margin="0,7,0,14" />
+                                        <Border Background="#2B2413" BorderBrush="#735F27" BorderThickness="1" CornerRadius="9" Padding="13"><StackPanel><TextBlock Text="PHYSICAL DIP CONTROL" Foreground="{StaticResource GoldBrush}" FontFamily="Segoe UI Semibold" FontSize="10" /><TextBlock Text="Set MACSER = 0 for MAC_I2C_SCL/SDA. Set MACSER = 1 for the FPGA MAC UART. The schematic does not route this select signal back to the FPGA, so software cannot change or read it." Foreground="#E9D89B" TextWrapping="Wrap" Margin="0,6,0,0" /></StackPanel></Border>
+                                        <TextBlock Text="The CH0 ACK result is the software-visible confirmation that the physical route is usable." Foreground="{StaticResource CyanBrush}" FontSize="11" TextWrapping="Wrap" Margin="0,14,0,0" />
+                                    </StackPanel>
+                                </Border>
+                            </Grid>
+
+                            <Border Grid.Row="4" Style="{StaticResource Panel}" Margin="0,0,0,18">
+                                <StackPanel>
+                                    <Grid><Grid.ColumnDefinitions><ColumnDefinition Width="*" /><ColumnDefinition Width="Auto" /></Grid.ColumnDefinitions><StackPanel><TextBlock Text="Subsystem RGB status indicators" Style="{StaticResource SectionTitle}" /><TextBlock Text="IS32FL3207 at 0x6E on sensor channel 1 &#x00B7; GNSS 1/2 and IO 1&#x2013;4" Foreground="{StaticResource MutedBrush}" FontSize="11" Margin="0,3,0,0" /></StackPanel><CheckBox x:Name="I2cLedAutoCheckBox" Grid.Column="1" Content="Automatic status mapping" IsChecked="True" Click="I2cLedAuto_Click" VerticalAlignment="Center" /></Grid>
+                                    <Grid Margin="0,18,0,0"><Grid.ColumnDefinitions><ColumnDefinition Width="1.05*" /><ColumnDefinition Width="0.95*" /></Grid.ColumnDefinitions>
+                                        <UniformGrid Columns="3" Margin="0,0,18,0">
+                                            <Border Background="#0B1926" BorderBrush="{StaticResource BorderBrush}" BorderThickness="1" CornerRadius="9" Padding="12" Margin="0,0,8,8"><StackPanel HorizontalAlignment="Center"><Border x:Name="I2cLedGnss1Swatch" Width="34" Height="34" CornerRadius="17" Background="#263342" BorderBrush="#53677C" BorderThickness="1" /><TextBlock Text="GNSS 1" FontFamily="Segoe UI Semibold" Margin="0,8,0,2" HorizontalAlignment="Center" /><TextBlock x:Name="I2cLedGnss1StatusText" Text="WAITING" Foreground="{StaticResource MutedBrush}" FontSize="9" HorizontalAlignment="Center" /></StackPanel></Border>
+                                            <Border Background="#0B1926" BorderBrush="{StaticResource BorderBrush}" BorderThickness="1" CornerRadius="9" Padding="12" Margin="8,0,8,8"><StackPanel HorizontalAlignment="Center"><Border x:Name="I2cLedGnss2Swatch" Width="34" Height="34" CornerRadius="17" Background="#263342" BorderBrush="#53677C" BorderThickness="1" /><TextBlock Text="GNSS 2" FontFamily="Segoe UI Semibold" Margin="0,8,0,2" HorizontalAlignment="Center" /><TextBlock x:Name="I2cLedGnss2StatusText" Text="WAITING" Foreground="{StaticResource MutedBrush}" FontSize="9" HorizontalAlignment="Center" /></StackPanel></Border>
+                                            <Border Background="#0B1926" BorderBrush="{StaticResource BorderBrush}" BorderThickness="1" CornerRadius="9" Padding="12" Margin="8,0,0,8"><StackPanel HorizontalAlignment="Center"><Border x:Name="I2cLedIo1Swatch" Width="34" Height="34" CornerRadius="17" Background="#263342" BorderBrush="#53677C" BorderThickness="1" /><TextBlock Text="IO 1" FontFamily="Segoe UI Semibold" Margin="0,8,0,2" HorizontalAlignment="Center" /><TextBlock x:Name="I2cLedIo1StatusText" Text="WAITING" Foreground="{StaticResource MutedBrush}" FontSize="9" HorizontalAlignment="Center" /></StackPanel></Border>
+                                            <Border Background="#0B1926" BorderBrush="{StaticResource BorderBrush}" BorderThickness="1" CornerRadius="9" Padding="12" Margin="0,8,8,0"><StackPanel HorizontalAlignment="Center"><Border x:Name="I2cLedIo2Swatch" Width="34" Height="34" CornerRadius="17" Background="#263342" BorderBrush="#53677C" BorderThickness="1" /><TextBlock Text="IO 2" FontFamily="Segoe UI Semibold" Margin="0,8,0,2" HorizontalAlignment="Center" /><TextBlock x:Name="I2cLedIo2StatusText" Text="WAITING" Foreground="{StaticResource MutedBrush}" FontSize="9" HorizontalAlignment="Center" /></StackPanel></Border>
+                                            <Border Background="#0B1926" BorderBrush="{StaticResource BorderBrush}" BorderThickness="1" CornerRadius="9" Padding="12" Margin="8,8,8,0"><StackPanel HorizontalAlignment="Center"><Border x:Name="I2cLedIo3Swatch" Width="34" Height="34" CornerRadius="17" Background="#263342" BorderBrush="#53677C" BorderThickness="1" /><TextBlock Text="IO 3" FontFamily="Segoe UI Semibold" Margin="0,8,0,2" HorizontalAlignment="Center" /><TextBlock x:Name="I2cLedIo3StatusText" Text="WAITING" Foreground="{StaticResource MutedBrush}" FontSize="9" HorizontalAlignment="Center" /></StackPanel></Border>
+                                            <Border Background="#0B1926" BorderBrush="{StaticResource BorderBrush}" BorderThickness="1" CornerRadius="9" Padding="12" Margin="8,8,0,0"><StackPanel HorizontalAlignment="Center"><Border x:Name="I2cLedIo4Swatch" Width="34" Height="34" CornerRadius="17" Background="#263342" BorderBrush="#53677C" BorderThickness="1" /><TextBlock Text="IO 4" FontFamily="Segoe UI Semibold" Margin="0,8,0,2" HorizontalAlignment="Center" /><TextBlock x:Name="I2cLedIo4StatusText" Text="WAITING" Foreground="{StaticResource MutedBrush}" FontSize="9" HorizontalAlignment="Center" /></StackPanel></Border>
+                                        </UniformGrid>
+                                        <StackPanel x:Name="I2cLedManualPanel" Grid.Column="1" IsEnabled="False">
+                                            <Grid><Grid.ColumnDefinitions><ColumnDefinition Width="*" /><ColumnDefinition Width="Auto" /></Grid.ColumnDefinitions><StackPanel Margin="0,0,12,0"><TextBlock Text="MANUAL TARGET" Style="{StaticResource Label}" Margin="0,0,0,5" /><ComboBox x:Name="I2cLedSelectionCombo" SelectedIndex="0" SelectionChanged="I2cLedSelection_SelectionChanged"><ComboBoxItem Tag="0">GNSS 1</ComboBoxItem><ComboBoxItem Tag="1">GNSS 2</ComboBoxItem><ComboBoxItem Tag="2">IO 1</ComboBoxItem><ComboBoxItem Tag="3">IO 2</ComboBoxItem><ComboBoxItem Tag="4">IO 3</ComboBoxItem><ComboBoxItem Tag="5">IO 4</ComboBoxItem></ComboBox></StackPanel><Border x:Name="I2cLedPreview" Grid.Column="1" Width="48" Height="48" CornerRadius="24" Background="#263342" BorderBrush="#53677C" BorderThickness="1" VerticalAlignment="Bottom" /></Grid>
+                                            <TextBlock Text="RED" Style="{StaticResource Label}" Margin="0,12,0,2" /><Grid><Slider x:Name="I2cLedRedSlider" Minimum="0" Maximum="255" Value="0" TickFrequency="1" ValueChanged="I2cLedSlider_ValueChanged" /><TextBlock x:Name="I2cLedRedValueText" Text="0" HorizontalAlignment="Right" Foreground="{StaticResource MutedBrush}" Margin="0,-17,0,0" /></Grid>
+                                            <TextBlock Text="GREEN" Style="{StaticResource Label}" Margin="0,8,0,2" /><Grid><Slider x:Name="I2cLedGreenSlider" Minimum="0" Maximum="255" Value="160" TickFrequency="1" ValueChanged="I2cLedSlider_ValueChanged" /><TextBlock x:Name="I2cLedGreenValueText" Text="160" HorizontalAlignment="Right" Foreground="{StaticResource MutedBrush}" Margin="0,-17,0,0" /></Grid>
+                                            <TextBlock Text="BLUE" Style="{StaticResource Label}" Margin="0,8,0,2" /><Grid><Slider x:Name="I2cLedBlueSlider" Minimum="0" Maximum="255" Value="40" TickFrequency="1" ValueChanged="I2cLedSlider_ValueChanged" /><TextBlock x:Name="I2cLedBlueValueText" Text="40" HorizontalAlignment="Right" Foreground="{StaticResource MutedBrush}" Margin="0,-17,0,0" /></Grid>
+                                            <TextBlock Text="GLOBAL CURRENT (SAFETY CAPPED AT 128)" Style="{StaticResource Label}" Margin="0,8,0,2" /><Grid><Slider x:Name="I2cLedCurrentSlider" Minimum="8" Maximum="128" Value="96" TickFrequency="1" ValueChanged="I2cLedSlider_ValueChanged" /><TextBlock x:Name="I2cLedCurrentValueText" Text="96" HorizontalAlignment="Right" Foreground="{StaticResource MutedBrush}" Margin="0,-17,0,0" /></Grid>
+                                            <StackPanel Orientation="Horizontal" HorizontalAlignment="Right" Margin="0,15,0,0"><Button x:Name="I2cLedReadButton" Content="Read" Click="ReadI2cLed_Click" Style="{StaticResource SecondaryButton}" Margin="0,0,8,0" /><Button x:Name="I2cLedOffButton" Content="Off" Click="TurnOffI2cLed_Click" Style="{StaticResource SecondaryButton}" Margin="0,0,8,0" /><Button x:Name="I2cLedApplyButton" Content="Apply color" Click="ApplyI2cLed_Click" /></StackPanel>
+                                        </StackPanel>
+                                    </Grid>
+                                    <TextBlock x:Name="I2cLedOperationText" Text="Automatic mapping: GNSS fix/activity and each SMA connector's configured direction." Foreground="{StaticResource CyanBrush}" FontSize="11" TextWrapping="Wrap" Margin="0,14,0,0" />
+                                </StackPanel>
+                            </Border>
+
+                            <Grid Grid.Row="5">
+                                <Grid.ColumnDefinitions><ColumnDefinition Width="0.72*" /><ColumnDefinition Width="1.28*" /></Grid.ColumnDefinitions>
                                 <StackPanel Margin="0,0,18,0">
                                     <Border Style="{StaticResource Panel}" Margin="0,0,0,16">
                                         <StackPanel>
                                             <TextBlock Text="Onboard devices" Style="{StaticResource SectionTitle}" />
-                                            <TextBlock Text="The Linux Time Card driver declares these devices for this FPGA layout."
+                                            <TextBlock Text="Known devices for this FPGA layout. A probe only tests whether the address acknowledges."
                                                        Foreground="{StaticResource MutedBrush}" Margin="0,6,0,18" TextWrapping="Wrap" />
                                             <Border Background="#0B1926" BorderBrush="{StaticResource BorderBrush}" BorderThickness="1" CornerRadius="10" Padding="14" Margin="0,0,0,10">
                                                 <Grid><Grid.ColumnDefinitions><ColumnDefinition Width="Auto" /><ColumnDefinition Width="*" /><ColumnDefinition Width="Auto" /></Grid.ColumnDefinitions>
                                                     <Image Source="Assets/timecard-i2c.png" Width="38" Height="38" />
-                                                    <StackPanel Grid.Column="1" Margin="12,0">
-                                                        <TextBlock Text="Board configuration EEPROM" FontFamily="Segoe UI Semibold" />
-                                                        <TextBlock Text="24C02 &#x00B7; 7-bit address 0x50" Foreground="{StaticResource MutedBrush}" FontSize="11" />
-                                                    </StackPanel>
-                                                    <StackPanel Grid.Column="2" HorizontalAlignment="Right">
-                                                        <TextBlock x:Name="I2cBoardStatusText" Text="NOT PROBED" Foreground="{StaticResource MutedBrush}" FontSize="10" HorizontalAlignment="Right" />
-                                                        <Button x:Name="I2cBoardReadButton" Content="Read first 32 bytes" Click="ReadBoardEeprom_Click" Style="{StaticResource SecondaryButton}" Padding="10,5" Margin="0,7,0,0" />
-                                                    </StackPanel>
+                                                    <StackPanel Grid.Column="1" Margin="12,0"><TextBlock Text="Board configuration EEPROM" FontFamily="Segoe UI Semibold" /><TextBlock Text="24C02 &#x00B7; address 0x50" Foreground="{StaticResource MutedBrush}" FontSize="11" /></StackPanel>
+                                                    <StackPanel Grid.Column="2" HorizontalAlignment="Right"><TextBlock x:Name="I2cBoardStatusText" Text="NOT PROBED" Foreground="{StaticResource MutedBrush}" FontSize="10" HorizontalAlignment="Right" /><Button x:Name="I2cBoardReadButton" Content="Read page" Click="ReadBoardEeprom_Click" Style="{StaticResource SecondaryButton}" Padding="10,5" Margin="0,7,0,0" /></StackPanel>
                                                 </Grid>
                                             </Border>
                                             <Border Background="#0B1926" BorderBrush="{StaticResource BorderBrush}" BorderThickness="1" CornerRadius="10" Padding="14">
                                                 <Grid><Grid.ColumnDefinitions><ColumnDefinition Width="Auto" /><ColumnDefinition Width="*" /><ColumnDefinition Width="Auto" /></Grid.ColumnDefinitions>
                                                     <Image Source="Assets/timecard-i2c.png" Width="38" Height="38" />
-                                                    <StackPanel Grid.Column="1" Margin="12,0">
-                                                        <TextBlock Text="MAC identity EEPROM" FontFamily="Segoe UI Semibold" />
-                                                        <TextBlock Text="24MAC402 &#x00B7; 7-bit address 0x58" Foreground="{StaticResource MutedBrush}" FontSize="11" />
-                                                        <TextBlock x:Name="I2cSerialNumberText" Text="Card serial not read" Foreground="{StaticResource CyanBrush}"
-                                                                   FontFamily="Cascadia Mono, Consolas" FontSize="12" Margin="0,5,0,0" />
-                                                    </StackPanel>
-                                                    <StackPanel Grid.Column="2" HorizontalAlignment="Right">
-                                                        <TextBlock x:Name="I2cMacStatusText" Text="NOT PROBED" Foreground="{StaticResource MutedBrush}" FontSize="10" HorizontalAlignment="Right" />
-                                                        <Button x:Name="I2cMacReadButton" Content="Read identity bytes" Click="ReadMacEeprom_Click" Style="{StaticResource SecondaryButton}" Padding="10,5" Margin="0,7,0,0" />
-                                                    </StackPanel>
+                                                    <StackPanel Grid.Column="1" Margin="12,0"><TextBlock Text="MAC identity EEPROM" FontFamily="Segoe UI Semibold" /><TextBlock Text="24MAC402 &#x00B7; address 0x58" Foreground="{StaticResource MutedBrush}" FontSize="11" /><TextBlock x:Name="I2cSerialNumberText" Text="Card serial not read" Foreground="{StaticResource CyanBrush}" FontFamily="Cascadia Mono, Consolas" FontSize="12" Margin="0,5,0,0" /></StackPanel>
+                                                    <StackPanel Grid.Column="2" HorizontalAlignment="Right"><TextBlock x:Name="I2cMacStatusText" Text="NOT PROBED" Foreground="{StaticResource MutedBrush}" FontSize="10" HorizontalAlignment="Right" /><Button x:Name="I2cMacReadButton" Content="Read identity" Click="ReadMacEeprom_Click" Style="{StaticResource SecondaryButton}" Padding="10,5" Margin="0,7,0,0" /></StackPanel>
                                                 </Grid>
+                                            </Border>
+                                        </StackPanel>
+                                    </Border>
+
+                                    <Border Style="{StaticResource Panel}">
+                                        <StackPanel>
+                                            <TextBlock Text="Bus explorer" Style="{StaticResource SectionTitle}" />
+                                            <TextBlock Text="ACK map" Style="{StaticResource Label}" Margin="0,12,0,5" />
+                                            <TextBlock x:Name="I2cAddressMapText" Text="Run a scan to map addresses 0x08&#x2013;0x77." Foreground="{StaticResource CyanBrush}" FontFamily="Cascadia Mono, Consolas" TextWrapping="Wrap" />
+                                            <Border Background="#050C14" BorderBrush="{StaticResource BorderBrush}" BorderThickness="1" CornerRadius="8" Padding="12" Margin="0,14,0,0">
+                                                <StackPanel><TextBlock Text="CONTROLLER DIAGNOSTICS" Style="{StaticResource Label}" /><TextBlock x:Name="I2cDiagnosticsText" Text="CR &#x2014;  SR &#x2014;&#x0A;ISR &#x2014;  IER &#x2014;&#x0A;No transaction recorded." Foreground="{StaticResource MutedBrush}" FontFamily="Cascadia Mono, Consolas" FontSize="11" Margin="0,7,0,0" TextWrapping="Wrap" /></StackPanel>
                                             </Border>
                                         </StackPanel>
                                     </Border>
@@ -1150,34 +1639,84 @@
 
                                 <Border Grid.Column="1" Style="{StaticResource Panel}" Padding="0">
                                     <Grid>
-                                        <Grid.RowDefinitions><RowDefinition Height="Auto" /><RowDefinition Height="Auto" /><RowDefinition Height="*" /><RowDefinition Height="Auto" /></Grid.RowDefinitions>
+                                        <Grid.RowDefinitions><RowDefinition Height="Auto" /><RowDefinition Height="Auto" /><RowDefinition Height="Auto" /><RowDefinition Height="*" /><RowDefinition Height="Auto" /></Grid.RowDefinitions>
                                         <Border Background="#102233" BorderBrush="{StaticResource BorderBrush}" BorderThickness="0,0,0,1" CornerRadius="16,16,0,0" Padding="18,14">
-                                            <Grid><Grid.ColumnDefinitions><ColumnDefinition Width="*" /><ColumnDefinition Width="Auto" /></Grid.ColumnDefinitions>
-                                                <StackPanel><TextBlock Text="Register / EEPROM reader" Style="{StaticResource SectionTitle}" />
-                                                    <TextBlock Text="Combined subaddress write + repeated-start read" Foreground="{StaticResource MutedBrush}" FontSize="11" Margin="0,3,0,0" /></StackPanel>
-                                                <TextBlock Grid.Column="1" Text="READ ONLY" Foreground="{StaticResource AccentBrush}" FontFamily="Segoe UI Semibold" FontSize="10" VerticalAlignment="Center" />
-                                            </Grid>
+                                            <Grid><Grid.ColumnDefinitions><ColumnDefinition Width="*" /><ColumnDefinition Width="Auto" /></Grid.ColumnDefinitions><StackPanel><TextBlock Text="Register / EEPROM reader" Style="{StaticResource SectionTitle}" /><TextBlock Text="Combined subaddress write + repeated-start read" Foreground="{StaticResource MutedBrush}" FontSize="11" Margin="0,3,0,0" /></StackPanel><TextBlock Grid.Column="1" Text="READ ONLY" Foreground="{StaticResource AccentBrush}" FontFamily="Segoe UI Semibold" FontSize="10" VerticalAlignment="Center" /></Grid>
                                         </Border>
-                                        <Grid Grid.Row="1" Margin="18,16,18,12">
+                                        <Grid Grid.Row="1" Margin="18,14,18,4">
+                                            <Grid.ColumnDefinitions><ColumnDefinition Width="1.15*" /><ColumnDefinition Width="0.9*" /><ColumnDefinition Width="0.7*" /><ColumnDefinition Width="Auto" /><ColumnDefinition Width="Auto" /><ColumnDefinition Width="Auto" /></Grid.ColumnDefinitions>
+                                            <StackPanel Margin="0,0,10,0"><TextBlock Text="PRESET" Style="{StaticResource Label}" Margin="0,0,0,5" /><ComboBox x:Name="I2cPresetCombo" SelectedIndex="0" SelectionChanged="I2cPreset_SelectionChanged"><ComboBoxItem Tag="custom">Custom transaction</ComboBoxItem><ComboBoxItem Tag="board">Board EEPROM page</ComboBoxItem><ComboBoxItem Tag="identity">MAC identity bytes</ComboBoxItem><ComboBoxItem Tag="imu">BNO055 identity (CH1)</ComboBoxItem><ComboBoxItem Tag="power12">INA219 12 V config (CH1)</ComboBoxItem><ComboBoxItem Tag="environment">BME280 chip ID (CH1)</ComboBoxItem><ComboBoxItem Tag="leddriver">IS32FL3207 control (CH1)</ComboBoxItem><ComboBoxItem Tag="direct">Direct receive</ComboBoxItem></ComboBox></StackPanel>
+                                            <StackPanel Grid.Column="1" Margin="0,0,10,0"><TextBlock Text="DATA VIEW" Style="{StaticResource Label}" Margin="0,0,0,5" /><ComboBox x:Name="I2cDisplayModeCombo" SelectedIndex="0" SelectionChanged="I2cDisplayMode_SelectionChanged"><ComboBoxItem Tag="hexascii">Hex + ASCII</ComboBoxItem><ComboBoxItem Tag="hex">Hex</ComboBoxItem><ComboBoxItem Tag="ascii">ASCII</ComboBoxItem><ComboBoxItem Tag="decimal">Decimal</ComboBoxItem><ComboBoxItem Tag="binary">Binary</ComboBoxItem></ComboBox></StackPanel>
+                                            <StackPanel Grid.Column="2" Margin="0,0,10,0"><TextBlock Text="TIMEOUT" Style="{StaticResource Label}" Margin="0,0,0,5" /><ComboBox x:Name="I2cTimeoutCombo" SelectedIndex="1"><ComboBoxItem Tag="50">50 ms</ComboBoxItem><ComboBoxItem Tag="100">100 ms</ComboBoxItem><ComboBoxItem Tag="250">250 ms</ComboBoxItem></ComboBox></StackPanel>
+                                            <Button x:Name="I2cPreviousButton" Grid.Column="3" Content="Previous" ToolTip="Read the previous page" Click="I2cPrevious_Click" Style="{StaticResource SecondaryButton}" Padding="10,7" Margin="0,19,6,0" />
+                                            <Button x:Name="I2cNextButton" Grid.Column="4" Content="Next" ToolTip="Read the next page" Click="I2cNext_Click" Style="{StaticResource SecondaryButton}" Padding="10,7" Margin="0,19,6,0" />
+                                            <Button x:Name="I2cCopyButton" Grid.Column="5" Content="Copy" Click="CopyI2c_Click" Style="{StaticResource SecondaryButton}" Padding="11,7" Margin="0,19,0,0" IsEnabled="False" />
+                                        </Grid>
+                                        <Grid Grid.Row="2" Margin="18,10,18,12">
                                             <Grid.ColumnDefinitions><ColumnDefinition Width="0.75*" /><ColumnDefinition Width="1*" /><ColumnDefinition Width="0.8*" /><ColumnDefinition Width="0.75*" /><ColumnDefinition Width="Auto" /></Grid.ColumnDefinitions>
-                                            <StackPanel Margin="0,0,10,0"><TextBlock Text="ADDRESS (HEX)" Style="{StaticResource Label}" Margin="0,0,0,5" />
-                                                <TextBox x:Name="I2cAddressTextBox" Text="50" MaxLength="4" /></StackPanel>
-                                            <StackPanel Grid.Column="1" Margin="0,0,10,0"><TextBlock Text="SUBADDRESS (HEX)" Style="{StaticResource Label}" Margin="0,0,0,5" />
-                                                <TextBox x:Name="I2cSubaddressTextBox" Text="00" MaxLength="6" /></StackPanel>
-                                            <StackPanel Grid.Column="2" Margin="0,0,10,0"><TextBlock Text="ADDRESS BYTES" Style="{StaticResource Label}" Margin="0,0,0,5" />
-                                                <ComboBox x:Name="I2cSubaddressLengthCombo" SelectedIndex="1"><ComboBoxItem Tag="0">None</ComboBoxItem><ComboBoxItem Tag="1">1 byte</ComboBoxItem><ComboBoxItem Tag="2">2 bytes</ComboBoxItem></ComboBox></StackPanel>
-                                            <StackPanel Grid.Column="3" Margin="0,0,10,0"><TextBlock Text="READ BYTES" Style="{StaticResource Label}" Margin="0,0,0,5" />
-                                                <TextBox x:Name="I2cLengthTextBox" Text="32" MaxLength="3" /></StackPanel>
+                                            <StackPanel Margin="0,0,10,0"><TextBlock Text="ADDRESS (HEX)" Style="{StaticResource Label}" Margin="0,0,0,5" /><TextBox x:Name="I2cAddressTextBox" Text="50" MaxLength="4" /></StackPanel>
+                                            <StackPanel Grid.Column="1" Margin="0,0,10,0"><TextBlock Text="SUBADDRESS (HEX)" Style="{StaticResource Label}" Margin="0,0,0,5" /><TextBox x:Name="I2cSubaddressTextBox" Text="00" MaxLength="6" /></StackPanel>
+                                            <StackPanel Grid.Column="2" Margin="0,0,10,0"><TextBlock Text="ADDRESS BYTES" Style="{StaticResource Label}" Margin="0,0,0,5" /><ComboBox x:Name="I2cSubaddressLengthCombo" SelectedIndex="1"><ComboBoxItem Tag="0">None</ComboBoxItem><ComboBoxItem Tag="1">1 byte</ComboBoxItem><ComboBoxItem Tag="2">2 bytes</ComboBoxItem></ComboBox></StackPanel>
+                                            <StackPanel Grid.Column="3" Margin="0,0,10,0"><TextBlock Text="READ BYTES" Style="{StaticResource Label}" Margin="0,0,0,5" /><TextBox x:Name="I2cLengthTextBox" Text="32" MaxLength="3" /></StackPanel>
                                             <Button x:Name="I2cReadButton" Grid.Column="4" Content="Read" Click="ReadI2c_Click" MinWidth="78" VerticalAlignment="Bottom" />
                                         </Grid>
-                                        <TextBox x:Name="I2cOutputTextBox" Grid.Row="2" Margin="18,0" MinHeight="220" IsReadOnly="True" AcceptsReturn="True"
-                                                 VerticalScrollBarVisibility="Auto" HorizontalScrollBarVisibility="Auto"
-                                                 FontFamily="Cascadia Mono, Consolas" FontSize="12" Background="#050C14" BorderThickness="0"
-                                                 Padding="14" Text="No I&#x00B2;C data has been read." />
-                                        <Border Grid.Row="3" Background="#0B1926" BorderBrush="{StaticResource BorderBrush}" BorderThickness="0,1,0,0" CornerRadius="0,0,16,16" Padding="18,10">
-                                            <TextBlock x:Name="I2cReadStatusText" Text="Ready for a bounded read (1&#x2013;255 bytes)." Foreground="{StaticResource MutedBrush}" FontSize="11" />
-                                        </Border>
+                                        <TextBox x:Name="I2cOutputTextBox" Grid.Row="3" Margin="18,0" MinHeight="300" IsReadOnly="True" AcceptsReturn="True" VerticalScrollBarVisibility="Auto" HorizontalScrollBarVisibility="Auto" FontFamily="Cascadia Mono, Consolas" FontSize="12" Background="#050C14" BorderThickness="0" Padding="14" Text="No I&#x00B2;C data has been read." />
+                                        <Border Grid.Row="4" Background="#0B1926" BorderBrush="{StaticResource BorderBrush}" BorderThickness="0,1,0,0" CornerRadius="0,0,16,16" Padding="18,10"><TextBlock x:Name="I2cReadStatusText" Text="Ready for a bounded read (1&#x2013;255 bytes)." Foreground="{StaticResource MutedBrush}" FontSize="11" TextWrapping="Wrap" /></Border>
                                     </Grid>
+                                </Border>
+                            </Grid>
+                        </Grid>
+                    </ScrollViewer>
+
+                    <!-- FPGA FLASH -->
+                    <ScrollViewer x:Name="FlashPage" Visibility="Collapsed" VerticalScrollBarVisibility="Auto">
+                        <Grid Margin="32,28,32,34">
+                            <Grid.RowDefinitions><RowDefinition Height="Auto" /><RowDefinition Height="Auto" /><RowDefinition Height="Auto" /><RowDefinition Height="Auto" /></Grid.RowDefinitions>
+                            <Grid>
+                                <Grid.ColumnDefinitions><ColumnDefinition Width="*" /><ColumnDefinition Width="Auto" /></Grid.ColumnDefinitions>
+                                <StackPanel>
+                                    <TextBlock Text="FPGA MAINTENANCE" Style="{StaticResource Eyebrow}" />
+                                    <TextBlock Text="SPI flash firmware update" Style="{StaticResource PageTitle}" Margin="0,5,0,4" />
+                                    <TextBlock Text="Program and verify the FPGA image region without exposing the protected card-configuration area." Foreground="{StaticResource MutedBrush}" />
+                                </StackPanel>
+                                <StackPanel Grid.Column="1" Orientation="Horizontal" VerticalAlignment="Center">
+                                    <Button Content="Back to subsystems" Click="BackToSubsystems_Click" Style="{StaticResource SecondaryButton}" Margin="0,0,10,0" />
+                                    <Button Content="Refresh device" Click="RefreshFlash_Click" />
+                                </StackPanel>
+                            </Grid>
+                            <Border Grid.Row="1" Background="#32200D" BorderBrush="#80591B" BorderThickness="1" CornerRadius="12" Padding="16,13" Margin="0,22,0,18">
+                                <StackPanel Orientation="Horizontal">
+                                    <TextBlock Text="&#xE7BA;" FontFamily="Segoe MDL2 Assets" Foreground="{StaticResource GoldBrush}" FontSize="18" Margin="0,0,12,0" />
+                                    <TextBlock Text="A failed or interrupted update can leave the FPGA unable to boot. Use a compatible image and keep the card powered until verification finishes." Foreground="#FFE0A3" TextWrapping="Wrap" />
+                                </StackPanel>
+                            </Border>
+                            <UniformGrid Grid.Row="2" Columns="4" Margin="0,0,0,18">
+                                <Border Style="{StaticResource MetricCard}"><StackPanel><TextBlock Text="CONTROLLER" Style="{StaticResource Label}" /><TextBlock x:Name="FlashControllerText" Text="NOT QUERIED" Style="{StaticResource MetricValue}" FontSize="17" Margin="0,8,0,0" /></StackPanel></Border>
+                                <Border Style="{StaticResource MetricCard}"><StackPanel><TextBlock Text="JEDEC ID" Style="{StaticResource Label}" /><TextBlock x:Name="FlashJedecText" Text="—" Style="{StaticResource MetricValue}" FontSize="17" Margin="0,8,0,0" /></StackPanel></Border>
+                                <Border Style="{StaticResource MetricCard}"><StackPanel><TextBlock Text="CAPACITY" Style="{StaticResource Label}" /><TextBlock x:Name="FlashCapacityText" Text="—" Style="{StaticResource MetricValue}" FontSize="17" Margin="0,8,0,0" /></StackPanel></Border>
+                                <Border Style="{StaticResource MetricCard}"><StackPanel><TextBlock Text="FPGA REGION" Style="{StaticResource Label}" /><TextBlock x:Name="FlashRegionText" Text="—" Style="{StaticResource MetricValue}" FontSize="17" Margin="0,8,0,0" /></StackPanel></Border>
+                            </UniformGrid>
+                            <Grid Grid.Row="3">
+                                <Grid.ColumnDefinitions><ColumnDefinition Width="1.05*" /><ColumnDefinition Width="0.95*" /></Grid.ColumnDefinitions>
+                                <Border Style="{StaticResource Panel}" Margin="0,0,18,0">
+                                    <StackPanel>
+                                        <TextBlock Text="Firmware image" Style="{StaticResource SectionTitle}" />
+                                        <TextBlock Text="Select an OCPC-wrapped image or a raw FPGA binary. Wrapped images are checked against this card's PCI identity and declared length." Foreground="{StaticResource MutedBrush}" TextWrapping="Wrap" Margin="0,7,0,16" />
+                                        <Button x:Name="FlashChooseButton" Content="Choose firmware image…" Click="ChooseFirmware_Click" HorizontalAlignment="Left" />
+                                        <TextBlock x:Name="FlashImagePathText" Text="No image selected" FontFamily="Segoe UI Semibold" TextWrapping="Wrap" Margin="0,16,0,5" />
+                                        <TextBlock x:Name="FlashImageDetailText" Text="OCPC header and image bounds will be validated before writing." Foreground="{StaticResource MutedBrush}" TextWrapping="Wrap" />
+                                        <TextBlock x:Name="FlashHashText" Text="SHA-256 —" Foreground="{StaticResource MutedBrush}" FontFamily="Cascadia Mono, Consolas" FontSize="11" TextWrapping="Wrap" Margin="0,11,0,0" />
+                                    </StackPanel>
+                                </Border>
+                                <Border Grid.Column="1" Style="{StaticResource Panel}">
+                                    <StackPanel>
+                                        <TextBlock Text="Update &amp; verification" Style="{StaticResource SectionTitle}" />
+                                        <CheckBox x:Name="FlashAcknowledgeCheckBox" Content="I understand that power must not be removed during this operation." Margin="0,14,0,14" Checked="FlashAcknowledge_Changed" Unchecked="FlashAcknowledge_Changed" />
+                                        <Button x:Name="FlashStartButton" Content="Erase, program &amp; verify" Click="FlashFirmware_Click" IsEnabled="False" HorizontalAlignment="Left" />
+                                        <ProgressBar x:Name="FlashProgressBar" Minimum="0" Maximum="100" Value="0" Height="8" Margin="0,20,0,8" />
+                                        <TextBlock x:Name="FlashProgressText" Text="Ready" Foreground="{StaticResource MutedBrush}" />
+                                        <TextBox x:Name="FlashLogTextBox" Margin="0,14,0,0" Height="160" IsReadOnly="True" AcceptsReturn="True" VerticalScrollBarVisibility="Auto" FontFamily="Cascadia Mono, Consolas" FontSize="11" Background="#050C14" BorderThickness="0" Padding="10" Text="Waiting for a compatible flash device and firmware image." />
+                                    </StackPanel>
                                 </Border>
                             </Grid>
                         </Grid>
@@ -1187,12 +1726,14 @@
                     <ScrollViewer x:Name="SubsystemsPage" Visibility="Collapsed" VerticalScrollBarVisibility="Auto">
                         <Grid Margin="32,28,32,34">
                             <Grid.RowDefinitions><RowDefinition Height="Auto" /><RowDefinition Height="Auto" /><RowDefinition Height="Auto" /></Grid.RowDefinitions>
-                            <StackPanel>
-                                <TextBlock Text="DEVICE FABRIC" Style="{StaticResource Eyebrow}" />
-                                <TextBlock Text="Time Card subsystem map" Style="{StaticResource PageTitle}" Margin="0,5,0,4" />
-                                <TextBlock Text="Every function exposed by the Windows bus driver, with honest capability labels for the current ABI."
-                                           Foreground="{StaticResource MutedBrush}" />
-                            </StackPanel>
+                            <Grid><Grid.ColumnDefinitions><ColumnDefinition Width="*" /><ColumnDefinition Width="Auto" /></Grid.ColumnDefinitions>
+                                <StackPanel>
+                                    <TextBlock Text="DEVICE FABRIC" Style="{StaticResource Eyebrow}" />
+                                    <TextBlock Text="Time Card subsystem map" Style="{StaticResource PageTitle}" Margin="0,5,0,4" />
+                                    <TextBlock Text="Every function exposed by the Windows bus driver, with live presence checks and direct links to configuration." Foreground="{StaticResource MutedBrush}" />
+                                </StackPanel>
+                                <Button Grid.Column="1" Content="Refresh presence" Click="RefreshSubsystems_Click" Style="{StaticResource SecondaryButton}" VerticalAlignment="Center" />
+                            </Grid>
                             <Border Grid.Row="1" Style="{StaticResource Panel}" Margin="0,24,0,22">
                                 <Grid><Grid.ColumnDefinitions><ColumnDefinition Width="*" /><ColumnDefinition Width="Auto" /></Grid.ColumnDefinitions>
                                     <StackPanel><TextBlock Text="Device Manager hierarchy" Style="{StaticResource SectionTitle}" />
@@ -1224,7 +1765,9 @@
                                     <TextBlock Text="UART CONTROL" Foreground="{StaticResource GoldBrush}" FontSize="10" /></StackPanel></Border>
                                 <Border Style="{StaticResource SubsystemCard}"><StackPanel><Image Source="Assets/timecard-gnss2.png" Width="46" Height="46" HorizontalAlignment="Left" />
                                     <TextBlock Text="Secondary GNSS Receiver" FontFamily="Segoe UI Semibold" Margin="0,12,0,4" />
-                                    <TextBlock Text="UART CONTROL" Foreground="{StaticResource GoldBrush}" FontSize="10" /></StackPanel></Border>
+                                    <TextBlock x:Name="SubsystemGnss2StatusText" Text="CHECKING UART 1" Foreground="{StaticResource GoldBrush}" FontSize="10" />
+                                    <TextBlock x:Name="SubsystemGnss2DetailText" Text="Presence requires received UART data." Foreground="{StaticResource MutedBrush}" FontSize="10" TextWrapping="Wrap" Margin="0,4,0,0" />
+                                    <Button Content="Open UART" Tag="1" Click="OpenUart_Click" Style="{StaticResource SecondaryButton}" Padding="10,6" Margin="0,10,0,0" /></StackPanel></Border>
                                 <Border Style="{StaticResource SubsystemCard}"><StackPanel><Image Source="Assets/timecard-atomic.png" Width="46" Height="46" HorizontalAlignment="Left" />
                                     <TextBlock Text="Atomic Clock" FontFamily="Segoe UI Semibold" Margin="0,12,0,4" />
                                     <TextBlock Text="LIVE SA53 CONTROL" Foreground="{StaticResource AccentBrush}" FontSize="10" />
@@ -1232,7 +1775,8 @@
                                             Padding="10,6" Margin="0,10,0,0" /></StackPanel></Border>
                                 <Border Style="{StaticResource SubsystemCard}"><StackPanel><Image Source="Assets/timecard-nmea.png" Width="46" Height="46" HorizontalAlignment="Left" />
                                     <TextBlock Text="NMEA Output" FontFamily="Segoe UI Semibold" Margin="0,12,0,4" />
-                                    <TextBlock Text="GENERATOR + UART CONTROL · ABI 4" Foreground="{StaticResource AccentBrush}" FontSize="10" /></StackPanel></Border>
+                                    <TextBlock Text="GENERATOR + UART CONTROL · ABI 4" Foreground="{StaticResource AccentBrush}" FontSize="10" />
+                                    <Button Content="Configure output" Click="OpenNmea_Click" Style="{StaticResource SecondaryButton}" Padding="10,6" Margin="0,10,0,0" /></StackPanel></Border>
                                 <Border Style="{StaticResource SubsystemCard}"><StackPanel><Image Source="Assets/timecard-ptm.png" Width="46" Height="46" HorizontalAlignment="Left" />
                                     <TextBlock Text="PCIe PTM" FontFamily="Segoe UI Semibold" Margin="0,12,0,4" />
                                     <TextBlock Text="DISCOVERED" Foreground="{StaticResource CyanBrush}" FontSize="10" /></StackPanel></Border>
@@ -1242,8 +1786,10 @@
                                     <Button Content="Configure" Click="OpenSma_Click" Style="{StaticResource SecondaryButton}"
                                             Padding="10,6" Margin="0,10,0,0" /></StackPanel></Border>
                                 <Border Style="{StaticResource SubsystemCard}"><StackPanel><Image Source="Assets/timecard-timing.png" Width="46" Height="46" HorizontalAlignment="Left" />
-                                    <TextBlock Text="Timing Generators" FontFamily="Segoe UI Semibold" Margin="0,12,0,4" />
-                                    <TextBlock Text="CONTROL API NEXT" Foreground="{StaticResource MutedBrush}" FontSize="10" /></StackPanel></Border>
+                                    <TextBlock Text="Generators &amp; Frequency Modules" FontFamily="Segoe UI Semibold" Margin="0,12,0,4" TextWrapping="Wrap" />
+                                    <TextBlock Text="GENERATOR + FREQUENCY CONTROL · ABI 5" Foreground="{StaticResource AccentBrush}" FontSize="10" />
+                                    <Button Content="Configure" Click="OpenTiming_Click" Style="{StaticResource SecondaryButton}"
+                                            Padding="10,6" Margin="0,10,0,0" /></StackPanel></Border>
                                 <Border Style="{StaticResource SubsystemCard}"><StackPanel><Image Source="Assets/timecard-i2c.png" Width="46" Height="46" HorizontalAlignment="Left" />
                                     <TextBlock Text="I²C Controller" FontFamily="Segoe UI Semibold" Margin="0,12,0,4" />
                                     <TextBlock Text="READ-ONLY CONTROL · ABI 3" Foreground="{StaticResource AccentBrush}" FontSize="10" />
@@ -1251,7 +1797,8 @@
                                             Padding="10,6" Margin="0,10,0,0" /></StackPanel></Border>
                                 <Border Style="{StaticResource SubsystemCard}"><StackPanel><Image Source="Assets/timecard-flash.png" Width="46" Height="46" HorizontalAlignment="Left" />
                                     <TextBlock Text="FPGA &amp; SPI Flash" FontFamily="Segoe UI Semibold" Margin="0,12,0,4" />
-                                    <TextBlock Text="UPDATE API NEXT" Foreground="{StaticResource MutedBrush}" FontSize="10" /></StackPanel></Border>
+                                    <TextBlock Text="GUARDED UPDATE + VERIFY · ABI 6" Foreground="{StaticResource AccentBrush}" FontSize="10" />
+                                    <Button Content="Update firmware" Click="OpenFlash_Click" Style="{StaticResource SecondaryButton}" Padding="10,6" Margin="0,10,0,0" /></StackPanel></Border>
                             </UniformGrid>
                         </Grid>
                     </ScrollViewer>
@@ -1279,12 +1826,10 @@
                                 </StackPanel></Border>
                                 <Border Grid.Column="1" Style="{StaticResource Panel}"><StackPanel>
                                     <TextBlock Text="Capability roadmap" Style="{StaticResource SectionTitle}" />
-                                    <TextBlock Text="The GUI exposes safe ABI 4 clock-source, NMEA-generator, UART, hierarchy, verified SMA-routing, card-identity, and read-only I²C operations. These controls still require explicit, reviewed kernel additions:"
+                                    <TextBlock Text="The GUI exposes ABI 7 clock-source, NMEA-generator, UART, hierarchy, SMA routing, signal-generator, frequency-counter, card identity, guarded I²C mux/LED operations, and FPGA flash operations. These controls still require explicit, reviewed kernel additions:"
                                                Foreground="{StaticResource MutedBrush}" TextWrapping="Wrap" Margin="0,7,0,16" />
                                     <TextBlock Text="• SMA polarity, termination, and cable-delay calibration" Margin="0,4" />
-                                    <TextBlock Text="• Timestamp/signal generator programming" Margin="0,4" />
                                     <TextBlock Text="• Validated I²C data-write and EEPROM-programming workflow" Margin="0,4" />
-                                    <TextBlock Text="• Validated FPGA/SPI firmware update workflow" Margin="0,4" />
                                     <TextBlock Text="• PTM counters and advanced clock-source selection" Margin="0,4" />
                                 </StackPanel></Border>
                             </Grid>

--- a/DRV/Windows/TimeCardControlCenter/MainWindow.xaml.cs
+++ b/DRV/Windows/TimeCardControlCenter/MainWindow.xaml.cs
@@ -6,6 +6,8 @@ using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using System.Security.Cryptography;
+using System.Security.Principal;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
@@ -25,10 +27,30 @@ namespace TimeCardControlCenter
         private TimeCardClient client;
         private TimeCardSnapshot lastSnapshot;
         private CancellationTokenSource uartMonitorCancellation;
+        private readonly List<UartConsoleEntry> uartConsoleEntries = new List<UartConsoleEntry>();
+        private int uartConsoleHistoryBytes;
         private bool refreshing;
         private bool connecting;
         private bool smaUpdatingUi;
+        private bool timingRefreshing;
         private bool i2cRefreshing;
+        private bool ledAutomationUpdating;
+        private bool ledControlsUpdating;
+        private bool subsystemsRefreshing;
+        private bool flashUpdating;
+        private FlashDeviceStatus lastFlashStatus;
+        private byte[] selectedFlashImage;
+        private string selectedFlashPath;
+        private bool selectedFlashIsRaw;
+        private byte[] lastI2cData;
+        private uint lastI2cAddress;
+        private uint lastI2cSubaddress;
+        private uint lastI2cSubaddressLength;
+        private readonly SmaConnectorState[] lastSmaLedStates = new SmaConnectorState[4];
+        private readonly BoardLedColor[] lastAppliedLedColors = new BoardLedColor[6];
+        private bool? secondaryGnssPresent;
+        private DateTime lastSmaLedRefreshUtc = DateTime.MinValue;
+        private DateTime lastSecondaryLedObservationUtc = DateTime.MinValue;
         private bool atomicRefreshing;
         private Sa53Snapshot lastSa53Snapshot;
         private bool ubloxRefreshing;
@@ -36,14 +58,70 @@ namespace TimeCardControlCenter
         private uint? lastUbloxPort;
         private uint? lastUbloxBaud;
         private DateTime lastConnectionAttemptUtc = DateTime.MinValue;
+        private SignalGeneratorControls[] signalGeneratorControls;
+        private FrequencyCounterControls[] frequencyCounterControls;
+
+        private sealed class SignalGeneratorControls
+        {
+            public TextBlock Status { get; set; }
+            public CheckBox Enabled { get; set; }
+            public TextBox Frequency { get; set; }
+            public TextBox Duty { get; set; }
+            public TextBox Phase { get; set; }
+            public CheckBox Invert { get; set; }
+            public ComboBox Route { get; set; }
+            public TextBlock Detail { get; set; }
+            public Button Apply { get; set; }
+        }
+
+        private sealed class FrequencyCounterControls
+        {
+            public TextBlock Status { get; set; }
+            public TextBlock Value { get; set; }
+            public TextBox Seconds { get; set; }
+            public ComboBox Route { get; set; }
+            public TextBlock Detail { get; set; }
+            public Button Apply { get; set; }
+        }
+
+        private sealed class UartConsoleEntry
+        {
+            public DateTime Timestamp { get; set; }
+            public string Direction { get; set; }
+            public byte[] Data { get; set; }
+            public uint LineStatus { get; set; }
+        }
 
         private sealed class I2cRefreshResult
         {
             public I2cControllerStatus Status { get; set; }
+            public I2cMuxState Mux { get; set; }
             public I2cProbeResult BoardEeprom { get; set; }
             public I2cProbeResult MacEeprom { get; set; }
             public List<uint> Addresses { get; set; }
             public bool FullScan { get; set; }
+        }
+
+        private sealed class BoardLedColor
+        {
+            public BoardLedColor(byte red, byte green, byte blue, string status)
+            {
+                Red = red;
+                Green = green;
+                Blue = blue;
+                Status = status;
+            }
+
+            public byte Red { get; private set; }
+            public byte Green { get; private set; }
+            public byte Blue { get; private set; }
+            public string Status { get; private set; }
+
+            public bool SameColor(BoardLedColor other)
+            {
+                return other != null && Red == other.Red &&
+                    Green == other.Green && Blue == other.Blue;
+            }
         }
 
         private sealed class SmaFunctionChoice
@@ -96,6 +174,20 @@ namespace TimeCardControlCenter
         public MainWindow()
         {
             InitializeComponent();
+            signalGeneratorControls = new[]
+            {
+                new SignalGeneratorControls { Status = Generator1StatusText, Enabled = Generator1EnabledCheckBox, Frequency = Generator1FrequencyTextBox, Duty = Generator1DutyTextBox, Phase = Generator1PhaseTextBox, Invert = Generator1InvertCheckBox, Route = Generator1RouteCombo, Detail = Generator1DetailText, Apply = Generator1ApplyButton },
+                new SignalGeneratorControls { Status = Generator2StatusText, Enabled = Generator2EnabledCheckBox, Frequency = Generator2FrequencyTextBox, Duty = Generator2DutyTextBox, Phase = Generator2PhaseTextBox, Invert = Generator2InvertCheckBox, Route = Generator2RouteCombo, Detail = Generator2DetailText, Apply = Generator2ApplyButton },
+                new SignalGeneratorControls { Status = Generator3StatusText, Enabled = Generator3EnabledCheckBox, Frequency = Generator3FrequencyTextBox, Duty = Generator3DutyTextBox, Phase = Generator3PhaseTextBox, Invert = Generator3InvertCheckBox, Route = Generator3RouteCombo, Detail = Generator3DetailText, Apply = Generator3ApplyButton },
+                new SignalGeneratorControls { Status = Generator4StatusText, Enabled = Generator4EnabledCheckBox, Frequency = Generator4FrequencyTextBox, Duty = Generator4DutyTextBox, Phase = Generator4PhaseTextBox, Invert = Generator4InvertCheckBox, Route = Generator4RouteCombo, Detail = Generator4DetailText, Apply = Generator4ApplyButton }
+            };
+            frequencyCounterControls = new[]
+            {
+                new FrequencyCounterControls { Status = Frequency1StatusText, Value = Frequency1ValueText, Seconds = Frequency1SecondsTextBox, Route = Frequency1RouteCombo, Detail = Frequency1DetailText, Apply = Frequency1ApplyButton },
+                new FrequencyCounterControls { Status = Frequency2StatusText, Value = Frequency2ValueText, Seconds = Frequency2SecondsTextBox, Route = Frequency2RouteCombo, Detail = Frequency2DetailText, Apply = Frequency2ApplyButton },
+                new FrequencyCounterControls { Status = Frequency3StatusText, Value = Frequency3ValueText, Seconds = Frequency3SecondsTextBox, Route = Frequency3RouteCombo, Detail = Frequency3DetailText, Apply = Frequency3ApplyButton },
+                new FrequencyCounterControls { Status = Frequency4StatusText, Value = Frequency4ValueText, Seconds = Frequency4SecondsTextBox, Route = Frequency4RouteCombo, Detail = Frequency4DetailText, Apply = Frequency4ApplyButton }
+            };
             startupArguments = Environment.GetCommandLineArgs();
             refreshTimer = new DispatcherTimer { Interval = TimeSpan.FromSeconds(1) };
             refreshTimer.Tick += RefreshTimer_Tick;
@@ -126,11 +218,17 @@ namespace TimeCardControlCenter
                 UartPortCombo.SelectedIndex = uartPort.Value;
             if (string.IsNullOrWhiteSpace(page))
                 return;
+            if (page.Equals("Flash", StringComparison.OrdinalIgnoreCase))
+            {
+                ShowPage("Flash");
+                return;
+            }
             RadioButton navigation = page.Equals("Clock", StringComparison.OrdinalIgnoreCase) ? ClockNav :
                 page.Equals("Gnss", StringComparison.OrdinalIgnoreCase) ? GnssNav :
                 page.Equals("Atomic", StringComparison.OrdinalIgnoreCase) ? AtomicNav :
                 page.Equals("Uart", StringComparison.OrdinalIgnoreCase) ? UartNav :
                 page.Equals("Sma", StringComparison.OrdinalIgnoreCase) ? SmaNav :
+                page.Equals("Timing", StringComparison.OrdinalIgnoreCase) ? TimingNav :
                 page.Equals("I2c", StringComparison.OrdinalIgnoreCase) ? I2cNav :
                 page.Equals("Subsystems", StringComparison.OrdinalIgnoreCase) ? SubsystemsNav :
                 page.Equals("Diagnostics", StringComparison.OrdinalIgnoreCase) ? DiagnosticsNav :
@@ -142,10 +240,21 @@ namespace TimeCardControlCenter
         private async void Window_Loaded(object sender, RoutedEventArgs e)
         {
             Log("OCP Time Card Control Center started.");
+            string capturePath = StartupArgumentValue(startupArguments, "--capture");
+            if (string.IsNullOrWhiteSpace(capturePath) && !HasAdministratorAccess())
+            {
+                MessageBoxResult elevationChoice = MessageBox.Show(this,
+                    "Time Card Control Center is running without administrator access. " +
+                    "Some hardware features may be unavailable.\n\n" +
+                    "Restart now with administrator access?",
+                    "Administrator access recommended", MessageBoxButton.YesNo,
+                    MessageBoxImage.Information, MessageBoxResult.Yes);
+                if (elevationChoice == MessageBoxResult.Yes && RestartAsAdministrator())
+                    return;
+            }
             refreshTimer.Start();
             await ConnectAsync();
             ApplyStartupView(startupArguments);
-            string capturePath = StartupArgumentValue(startupArguments, "--capture");
             if (!string.IsNullOrWhiteSpace(capturePath))
             {
                 await Task.Delay(300);
@@ -182,6 +291,17 @@ namespace TimeCardControlCenter
                 encoder.Save(output);
         }
 
+        private void Window_Closing(object sender, CancelEventArgs e)
+        {
+            if (!flashUpdating)
+                return;
+            e.Cancel = true;
+            MessageBox.Show(this,
+                "The FPGA flash update is still running. Keep the card powered and wait for verification to finish before closing the Control Center.",
+                "Firmware update in progress", MessageBoxButton.OK,
+                MessageBoxImage.Warning);
+        }
+
         private void Window_Closed(object sender, EventArgs e)
         {
             refreshTimer.Stop();
@@ -214,7 +334,7 @@ namespace TimeCardControlCenter
             try
             {
                 client = await Task.Run(() => new TimeCardClient());
-                SetConnectionState(true, "Hardware connected", false);
+                SetConnectionState(true, "Time Card Connected", false);
                 Log("Connected to \\.\\TimeCard0.");
                 await RefreshSnapshotAsync(true);
                 await RefreshIdentityAsync();
@@ -278,6 +398,7 @@ namespace TimeCardControlCenter
 
             SidebarDriverText.Text = "Driver " + snapshot.DriverVersion + " · ABI " + snapshot.AbiVersion;
             LastRefreshText.Text = "Sampled " + DateTime.Now.ToString("HH:mm:ss", CultureInfo.InvariantCulture);
+            UpdateI2cDriverCompatibility(snapshot);
 
             SyncStatusText.Text = snapshot.IsClockSynchronized ? "IN SYNC" : "NOT LOCKED";
             SyncStatusText.Foreground = snapshot.IsClockSynchronized ? healthyBrush : warningBrush;
@@ -296,6 +417,7 @@ namespace TimeCardControlCenter
                 "HH:mm:ss.fffffff 'UTC'", CultureInfo.InvariantCulture);
             OffsetText.Text = offset;
             SamplingWindowText.Text = sampleWindow;
+            UpdateClockHistory(snapshot, offset, sampleWindow);
             ClockChipText.Text = snapshot.IsClockSynchronized ? "SYNCHRONIZED" : "LIVE · UNLOCKED";
             ClockChipText.Foreground = snapshot.IsClockSynchronized ? healthyBrush : warningBrush;
             HierarchyOverviewText.Text = snapshot.HierarchyRuntimeEnabled ? "ENABLED" : "DISABLED";
@@ -339,6 +461,77 @@ namespace TimeCardControlCenter
             HierarchyPersistedText.Text = snapshot.HierarchyPersisted ? "enabled" : "disabled";
             HierarchyPersistedText.Foreground = snapshot.HierarchyPersisted ? healthyBrush : warningBrush;
             DiagnosticsSummaryText.Text = BuildDiagnostics(snapshot);
+            UpdateBoardLedAutomationAsync(false);
+        }
+
+        private void UpdateClockHistory(TimeCardSnapshot snapshot, string offset,
+                                        string sampleWindow)
+        {
+            OffsetHistoryChart.AddSample(snapshot.OffsetNanoseconds);
+            SamplingHistoryChart.AddSample(snapshot.SamplingWindowNanoseconds);
+            ClockOffsetHistoryChart.AddSample(snapshot.OffsetNanoseconds);
+            ClockSamplingHistoryChart.AddSample(
+                snapshot.SamplingWindowNanoseconds);
+            OffsetHistoryValueText.Text = offset;
+            SamplingHistoryValueText.Text = sampleWindow;
+            ClockOffsetHistoryValueText.Text = offset;
+            ClockSamplingHistoryValueText.Text = sampleWindow;
+
+            if (OffsetHistoryChart.SampleCount < 2)
+            {
+                OffsetHistoryScaleText.Text = string.Format(CultureInfo.InvariantCulture,
+                    "COLLECTING · {0}/{1}", OffsetHistoryChart.SampleCount,
+                    OffsetHistoryChart.Capacity);
+            }
+            else
+            {
+                OffsetHistoryScaleText.Text = "AUTO ZOOM " +
+                    FormatNanoseconds(ToNanoseconds(
+                        OffsetHistoryChart.VisibleMinimum)) + " \u2013 " +
+                    FormatNanoseconds(ToNanoseconds(
+                        OffsetHistoryChart.VisibleMaximum));
+            }
+            ClockOffsetHistoryScaleText.Text = OffsetHistoryScaleText.Text;
+
+            if (SamplingHistoryChart.SampleCount < 2)
+            {
+                SamplingHistoryScaleText.Text = string.Format(CultureInfo.InvariantCulture,
+                    "COLLECTING · {0}/{1}", SamplingHistoryChart.SampleCount,
+                    SamplingHistoryChart.Capacity);
+            }
+            else
+            {
+                SamplingHistoryScaleText.Text = "RANGE " +
+                    FormatNanoseconds(ToNanoseconds(SamplingHistoryChart.Minimum)) +
+                    " \u2013 " +
+                    FormatNanoseconds(ToNanoseconds(SamplingHistoryChart.Maximum));
+            }
+            ClockSamplingHistoryScaleText.Text = SamplingHistoryScaleText.Text;
+        }
+
+        private void ResetClockHistory()
+        {
+            OffsetHistoryChart.Clear();
+            SamplingHistoryChart.Clear();
+            ClockOffsetHistoryChart.Clear();
+            ClockSamplingHistoryChart.Clear();
+            OffsetHistoryValueText.Text = "\u2014";
+            SamplingHistoryValueText.Text = "\u2014";
+            ClockOffsetHistoryValueText.Text = "\u2014";
+            ClockSamplingHistoryValueText.Text = "\u2014";
+            OffsetHistoryScaleText.Text = "WAITING FOR SAMPLES";
+            SamplingHistoryScaleText.Text = "WAITING FOR SAMPLES";
+            ClockOffsetHistoryScaleText.Text = "WAITING FOR SAMPLES";
+            ClockSamplingHistoryScaleText.Text = "WAITING FOR SAMPLES";
+        }
+
+        private static long ToNanoseconds(double value)
+        {
+            if (value >= long.MaxValue)
+                return long.MaxValue;
+            if (value <= long.MinValue)
+                return long.MinValue;
+            return (long)Math.Round(value, MidpointRounding.AwayFromZero);
         }
 
         private void SetConnectionState(bool connected, string text, bool showElevation)
@@ -346,6 +539,8 @@ namespace TimeCardControlCenter
             ConnectionText.Text = text;
             ConnectionDot.Fill = (Brush)FindResource(connected ? "AccentBrush" : "DangerBrush");
             ElevateButton.Visibility = showElevation ? Visibility.Visible : Visibility.Collapsed;
+            if (!connected)
+                ResetClockHistory();
         }
 
         private async void Refresh_Click(object sender, RoutedEventArgs e)
@@ -363,7 +558,7 @@ namespace TimeCardControlCenter
             try
             {
                 await Task.Run(() => client.SetClockFromSystem());
-                Log("PHC set from Windows UTC.");
+                Log("PHC synchronized from the system clock.");
                 await RefreshSnapshotAsync(false);
             }
             catch (Exception ex)
@@ -388,7 +583,7 @@ namespace TimeCardControlCenter
                         "The Time Card PHC currently reports " +
                         cardUtc.ToString("yyyy-MM-dd HH:mm:ss.fff 'UTC'",
                             CultureInfo.InvariantCulture) +
-                        ". Set the PHC from Windows or establish GNSS time before using it to set Windows.",
+                        ". Synchronize the PHC from the system clock or establish GNSS time before using it to set Windows.",
                         "Time Card UTC is not plausible", MessageBoxButton.OK,
                         MessageBoxImage.Warning);
                     return;
@@ -632,8 +827,19 @@ namespace TimeCardControlCenter
 
         private void ClearUart_Click(object sender, RoutedEventArgs e)
         {
+            uartConsoleEntries.Clear();
+            uartConsoleHistoryBytes = 0;
             UartOutputTextBox.Clear();
             UartStatusText.Text = "UART terminal cleared";
+        }
+
+        private void UartFormat_SelectionChanged(object sender, SelectionChangedEventArgs e)
+        {
+            if (UartOutputTextBox == null)
+                return;
+            RenderUartConsole();
+            if (UartStatusText != null && uartConsoleEntries.Count != 0)
+                UartStatusText.Text = "UART display changed to " + SelectedUartDisplayName();
         }
 
         private async void UartPort_SelectionChanged(object sender, SelectionChangedEventArgs e)
@@ -804,6 +1010,7 @@ namespace TimeCardControlCenter
                 lastUbloxSnapshot = null;
                 lastUbloxPort = null;
                 lastUbloxBaud = null;
+                RenderUbloxSkyMap(null);
                 SetUbloxConfigurationEnabled(false);
                 UbloxConnectionText.Text = "RECEIVER UNAVAILABLE";
                 UbloxConnectionText.Foreground = (Brush)FindResource("DangerBrush");
@@ -828,6 +1035,7 @@ namespace TimeCardControlCenter
             lastUbloxSnapshot = null;
             lastUbloxPort = null;
             lastUbloxBaud = null;
+            RenderUbloxSkyMap(null);
             SetUbloxConfigurationEnabled(false);
             UbloxConnectionText.Text = "REFRESH REQUIRED";
             UbloxConnectionText.Foreground = (Brush)FindResource("GoldBrush");
@@ -867,6 +1075,7 @@ namespace TimeCardControlCenter
                 "Position unavailable";
             UbloxSignalSupportText.Text = "Reported support: " +
                 (string.IsNullOrWhiteSpace(snapshot.SupportedGnss) ? "not reported" : snapshot.SupportedGnss);
+            RenderUbloxSkyMap(snapshot);
 
             UbloxRatePanel.IsEnabled = snapshot.RateConfigurationSupported;
             UbloxSignalPanel.IsEnabled = snapshot.SignalConfigurationSupported;
@@ -903,6 +1112,324 @@ namespace TimeCardControlCenter
             SetConfigText(UbloxGsvRateTextBox, snapshot, UbloxClient.CfgMsgNmeaGsvUart1);
             SetConfigText(UbloxRmcRateTextBox, snapshot, UbloxClient.CfgMsgNmeaRmcUart1);
             SetConfigText(UbloxZdaRateTextBox, snapshot, UbloxClient.CfgMsgNmeaZdaUart1);
+        }
+
+        private void UbloxSkyMap_SizeChanged(object sender, SizeChangedEventArgs e)
+        {
+            if (UbloxSkyMapCanvas == null || UbloxSatelliteListPanel == null)
+                return;
+            RenderUbloxSkyMap(lastUbloxSnapshot);
+        }
+
+        private void RenderUbloxSkyMap(UbloxReceiverSnapshot snapshot)
+        {
+            if (UbloxSkyMapCanvas == null || UbloxSatelliteListPanel == null)
+                return;
+
+            Canvas canvas = UbloxSkyMapCanvas;
+            canvas.Children.Clear();
+            UbloxSatelliteListPanel.Children.Clear();
+            double width = canvas.ActualWidth;
+            double height = canvas.ActualHeight;
+            if (width < 120 || height < 120)
+                return;
+
+            double radius = Math.Max(40, Math.Min(width - 54, height - 46) / 2.0);
+            double centerX = width / 2.0;
+            double centerY = height / 2.0 + 3;
+            SolidColorBrush gridBrush = new SolidColorBrush(Color.FromRgb(43, 76, 101));
+            SolidColorBrush axisBrush = new SolidColorBrush(Color.FromRgb(31, 58, 79));
+            SolidColorBrush mutedBrush = new SolidColorBrush(Color.FromRgb(143, 166, 187));
+            gridBrush.Freeze();
+            axisBrush.Freeze();
+            mutedBrush.Freeze();
+
+            RadialGradientBrush skyFill = new RadialGradientBrush();
+            skyFill.GradientStops.Add(new GradientStop(Color.FromRgb(18, 43, 61), 0));
+            skyFill.GradientStops.Add(new GradientStop(Color.FromRgb(7, 17, 31), 1));
+            AddSkyMapCircle(canvas, centerX, centerY, radius, skyFill,
+                gridBrush, 1.4);
+            AddSkyMapLine(canvas, centerX - radius, centerY,
+                centerX + radius, centerY, axisBrush, 1);
+            AddSkyMapLine(canvas, centerX, centerY - radius,
+                centerX, centerY + radius, axisBrush, 1);
+            AddSkyMapCircle(canvas, centerX, centerY, radius * 2.0 / 3.0,
+                Brushes.Transparent, gridBrush, 1);
+            AddSkyMapCircle(canvas, centerX, centerY, radius / 3.0,
+                Brushes.Transparent, gridBrush, 1);
+
+            AddSkyMapText(canvas, "N", centerX - 6, centerY - radius - 24,
+                Brushes.White, 12, FontWeights.Bold);
+            AddSkyMapText(canvas, "E", centerX + radius + 9, centerY - 8,
+                mutedBrush, 11, FontWeights.SemiBold);
+            AddSkyMapText(canvas, "S", centerX - 5, centerY + radius + 7,
+                mutedBrush, 11, FontWeights.SemiBold);
+            AddSkyMapText(canvas, "W", centerX - radius - 23, centerY - 8,
+                mutedBrush, 11, FontWeights.SemiBold);
+            AddSkyMapText(canvas, "60°", centerX + 7,
+                centerY - radius / 3.0 - 13, mutedBrush, 9, FontWeights.Normal);
+            AddSkyMapText(canvas, "30°", centerX + 7,
+                centerY - radius * 2.0 / 3.0 - 13, mutedBrush, 9,
+                FontWeights.Normal);
+            AddSkyMapText(canvas, "ZENITH", centerX + 7, centerY + 4,
+                mutedBrush, 8, FontWeights.Normal);
+
+            IList<UbloxSatelliteInfo> satellites = snapshot == null ?
+                new List<UbloxSatelliteInfo>().AsReadOnly() : snapshot.Satellites;
+            List<UbloxSatelliteInfo> plotted = satellites.Where(satellite =>
+                satellite.ElevationDegrees >= 0 && satellite.ElevationDegrees <= 90 &&
+                satellite.AzimuthDegrees >= 0).ToList();
+
+            foreach (UbloxSatelliteInfo satellite in plotted
+                .OrderBy(item => item.IsUsed ? 1 : 0)
+                .ThenBy(item => item.CarrierToNoise))
+            {
+                int azimuth = ((satellite.AzimuthDegrees % 360) + 360) % 360;
+                double angle = azimuth * Math.PI / 180.0;
+                double distance = radius *
+                    (90.0 - satellite.ElevationDegrees) / 90.0;
+                double markerSize = 18.0 +
+                    Math.Min(satellite.CarrierToNoise, (byte)55) / 55.0 * 12.0;
+                double x = centerX + distance * Math.Sin(angle) - markerSize / 2.0;
+                double y = centerY - distance * Math.Cos(angle) - markerSize / 2.0;
+                Brush color = SkyMapConstellationBrush(satellite.GnssIdentifier);
+                Grid marker = new Grid
+                {
+                    Width = markerSize,
+                    Height = markerSize,
+                    Opacity = satellite.CarrierToNoise == 0 ? 0.4 :
+                        (satellite.IsUsed ? 1.0 : 0.78),
+                    ToolTip = string.Format(CultureInfo.InvariantCulture,
+                        "{0} · {1}\nElevation {2}° · azimuth {3}°\nC/N₀ {4} dB-Hz · {5} · {6}",
+                        satellite.DisplayIdentifier, satellite.Constellation,
+                        satellite.ElevationDegrees, azimuth,
+                        satellite.CarrierToNoise,
+                        satellite.IsUsed ? "used in solution" : "tracked",
+                        satellite.QualityDescription)
+                };
+                marker.Children.Add(new System.Windows.Shapes.Ellipse
+                {
+                    Fill = satellite.CarrierToNoise == 0 ? Brushes.DimGray : color,
+                    Stroke = satellite.IsUsed ? Brushes.White : color,
+                    StrokeThickness = satellite.IsUsed ? 2.4 : 1.1
+                });
+                marker.Children.Add(new TextBlock
+                {
+                    Text = satellite.DisplayIdentifier,
+                    Foreground = Brushes.White,
+                    FontFamily = new FontFamily("Segoe UI Semibold"),
+                    FontSize = satellite.DisplayIdentifier.Length > 3 ? 8 : 9,
+                    HorizontalAlignment = HorizontalAlignment.Center,
+                    VerticalAlignment = VerticalAlignment.Center
+                });
+                Panel.SetZIndex(marker, satellite.IsUsed ? 2 : 1);
+                Canvas.SetLeft(marker, x);
+                Canvas.SetTop(marker, y);
+                canvas.Children.Add(marker);
+            }
+
+            if (plotted.Count == 0)
+                AddSkyMapText(canvas, snapshot == null ? "REFRESH RECEIVER" :
+                    "NO SATELLITES ABOVE HORIZON", centerX - 79, centerY - 8,
+                    mutedBrush, 10, FontWeights.SemiBold);
+
+            PopulateUbloxSatelliteList(satellites);
+            if (snapshot == null)
+            {
+                UbloxSkyMapStatusText.Text = "AWAITING UBX-NAV-SAT";
+                UbloxSkyMapStatusText.Foreground = (Brush)FindResource("GoldBrush");
+                UbloxSkyMapSummaryText.Text =
+                    "Refresh the selected receiver to load satellite geometry.";
+            }
+            else
+            {
+                int used = satellites.Count(item => item.IsUsed);
+                int strong = satellites.Count(item => item.CarrierToNoise >= 35);
+                UbloxSkyMapStatusText.Text = string.Format(CultureInfo.InvariantCulture,
+                    "{0:N0} PLOTTED · {1:HH:mm:ss} UTC", plotted.Count,
+                    snapshot.CapturedAtUtc);
+                UbloxSkyMapStatusText.Foreground = (Brush)FindResource(
+                    satellites.Count == 0 ? "GoldBrush" : "AccentBrush");
+                UbloxSkyMapSummaryText.Text = string.Format(
+                    CultureInfo.InvariantCulture,
+                    "{0:N0} used · {1:N0} reported · {2:N0} at or above 35 dB-Hz. Hover a marker for receiver details.",
+                    used, satellites.Count, strong);
+            }
+        }
+
+        private void PopulateUbloxSatelliteList(IList<UbloxSatelliteInfo> satellites)
+        {
+            if (satellites.Count == 0)
+            {
+                UbloxSatelliteListPanel.Children.Add(new TextBlock
+                {
+                    Text = "No satellite records were returned.",
+                    Foreground = (Brush)FindResource("MutedBrush"),
+                    Margin = new Thickness(0, 8, 0, 0),
+                    TextWrapping = TextWrapping.Wrap
+                });
+                return;
+            }
+
+            int rowIndex = 0;
+            foreach (UbloxSatelliteInfo satellite in satellites
+                .OrderByDescending(item => item.IsUsed)
+                .ThenByDescending(item => item.CarrierToNoise)
+                .ThenBy(item => item.GnssIdentifier)
+                .ThenBy(item => item.SatelliteIdentifier))
+            {
+                Brush color = SkyMapConstellationBrush(satellite.GnssIdentifier);
+                Grid row = new Grid();
+                row.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(54) });
+                row.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(90) });
+                row.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(58) });
+                row.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) });
+
+                StackPanel identifier = new StackPanel
+                {
+                    Orientation = Orientation.Horizontal,
+                    VerticalAlignment = VerticalAlignment.Center
+                };
+                identifier.Children.Add(new System.Windows.Shapes.Ellipse
+                {
+                    Width = 8,
+                    Height = 8,
+                    Fill = color,
+                    Stroke = satellite.IsUsed ? Brushes.White : color,
+                    StrokeThickness = satellite.IsUsed ? 1.4 : 0,
+                    Margin = new Thickness(0, 0, 6, 0)
+                });
+                identifier.Children.Add(new TextBlock
+                {
+                    Text = satellite.DisplayIdentifier,
+                    FontFamily = new FontFamily("Segoe UI Semibold"),
+                    FontSize = 11
+                });
+                row.Children.Add(identifier);
+
+                TextBlock geometry = new TextBlock
+                {
+                    Text = string.Format(CultureInfo.InvariantCulture,
+                        "{0}° / {1}°", satellite.ElevationDegrees,
+                        satellite.AzimuthDegrees),
+                    Foreground = (Brush)FindResource("MutedBrush"),
+                    FontFamily = new FontFamily("Cascadia Mono, Consolas"),
+                    FontSize = 10,
+                    VerticalAlignment = VerticalAlignment.Center
+                };
+                Grid.SetColumn(geometry, 1);
+                row.Children.Add(geometry);
+
+                TextBlock signal = new TextBlock
+                {
+                    Text = satellite.CarrierToNoise.ToString(
+                        CultureInfo.InvariantCulture) + " dB",
+                    Foreground = satellite.CarrierToNoise >= 35 ? color :
+                        (Brush)FindResource("MutedBrush"),
+                    FontSize = 10,
+                    VerticalAlignment = VerticalAlignment.Center
+                };
+                Grid.SetColumn(signal, 2);
+                row.Children.Add(signal);
+
+                ProgressBar bar = new ProgressBar
+                {
+                    Minimum = 0,
+                    Maximum = 60,
+                    Value = Math.Min(60, (int)satellite.CarrierToNoise),
+                    Height = 6,
+                    Foreground = color,
+                    Background = new SolidColorBrush(Color.FromRgb(21, 40, 58)),
+                    BorderThickness = new Thickness(0),
+                    VerticalAlignment = VerticalAlignment.Center,
+                    ToolTip = satellite.QualityDescription
+                };
+                Grid.SetColumn(bar, 3);
+                row.Children.Add(bar);
+
+                Border rowBorder = new Border
+                {
+                    Background = new SolidColorBrush(rowIndex++ % 2 == 0 ?
+                        Color.FromRgb(10, 23, 37) : Color.FromRgb(12, 28, 43)),
+                    CornerRadius = new CornerRadius(6),
+                    Padding = new Thickness(8, 6, 8, 6),
+                    Margin = new Thickness(0, 0, 0, 3),
+                    Child = row,
+                    ToolTip = satellite.Constellation + " · " +
+                        (satellite.IsUsed ? "used in solution" : "tracked")
+                };
+                UbloxSatelliteListPanel.Children.Add(rowBorder);
+            }
+        }
+
+        private static void AddSkyMapCircle(Canvas canvas, double centerX,
+            double centerY, double radius, Brush fill, Brush stroke,
+            double strokeThickness)
+        {
+            System.Windows.Shapes.Ellipse circle =
+                new System.Windows.Shapes.Ellipse
+                {
+                    Width = radius * 2,
+                    Height = radius * 2,
+                    Fill = fill,
+                    Stroke = stroke,
+                    StrokeThickness = strokeThickness,
+                    IsHitTestVisible = false
+                };
+            Canvas.SetLeft(circle, centerX - radius);
+            Canvas.SetTop(circle, centerY - radius);
+            canvas.Children.Add(circle);
+        }
+
+        private static void AddSkyMapLine(Canvas canvas, double x1, double y1,
+            double x2, double y2, Brush stroke, double strokeThickness)
+        {
+            canvas.Children.Add(new System.Windows.Shapes.Line
+            {
+                X1 = x1,
+                Y1 = y1,
+                X2 = x2,
+                Y2 = y2,
+                Stroke = stroke,
+                StrokeThickness = strokeThickness,
+                IsHitTestVisible = false
+            });
+        }
+
+        private static void AddSkyMapText(Canvas canvas, string text,
+            double left, double top, Brush foreground, double fontSize,
+            FontWeight weight)
+        {
+            TextBlock label = new TextBlock
+            {
+                Text = text,
+                Foreground = foreground,
+                FontSize = fontSize,
+                FontWeight = weight,
+                IsHitTestVisible = false
+            };
+            Canvas.SetLeft(label, left);
+            Canvas.SetTop(label, top);
+            canvas.Children.Add(label);
+        }
+
+        private static Brush SkyMapConstellationBrush(byte identifier)
+        {
+            Color color;
+            switch (identifier)
+            {
+                case 0: color = Color.FromRgb(105, 196, 65); break;
+                case 1: color = Color.FromRgb(80, 227, 194); break;
+                case 2: color = Color.FromRgb(76, 201, 240); break;
+                case 3: color = Color.FromRgb(218, 181, 57); break;
+                case 5: color = Color.FromRgb(203, 136, 255); break;
+                case 6: color = Color.FromRgb(255, 102, 122); break;
+                case 7: color = Color.FromRgb(255, 158, 100); break;
+                default: color = Color.FromRgb(143, 166, 187); break;
+            }
+            SolidColorBrush brush = new SolidColorBrush(color);
+            brush.Freeze();
+            return brush;
         }
 
         private async void ApplyUbloxRate_Click(object sender, RoutedEventArgs e)
@@ -1844,6 +2371,9 @@ namespace TimeCardControlCenter
             Button applyButton = GetSmaApplyButton(state.Connector);
             Brush healthyBrush = (Brush)FindResource("AccentBrush");
 
+            if (state.Connector >= 1 && state.Connector <= 4)
+                lastSmaLedStates[(int)state.Connector - 1] = state;
+
             smaUpdatingUi = true;
             try
             {
@@ -1864,6 +2394,7 @@ namespace TimeCardControlCenter
             {
                 smaUpdatingUi = false;
             }
+            UpdateBoardLedAutomationAsync(false);
         }
 
         private void PopulateSmaFunctions(uint connector, SmaDirection direction,
@@ -1992,6 +2523,389 @@ namespace TimeCardControlCenter
             }
         }
 
+        private void OpenTiming_Click(object sender, RoutedEventArgs e)
+        {
+            TimingNav.IsChecked = true;
+        }
+
+        private async void RefreshTiming_Click(object sender, RoutedEventArgs e)
+        {
+            await RefreshTimingAsync();
+        }
+
+        private async Task RefreshTimingAsync()
+        {
+            if (timingRefreshing)
+                return;
+            if (client == null)
+            {
+                SetTimingUnavailable("NOT CONNECTED");
+                return;
+            }
+            if (lastSnapshot == null || lastSnapshot.AbiVersion < 5)
+            {
+                SetTimingUnavailable("DRIVER 1.10 / ABI 5 REQUIRED");
+                return;
+            }
+
+            timingRefreshing = true;
+            SmaConnectorState[] routes = new SmaConnectorState[4];
+            try
+            {
+                for (uint channel = 1; channel <= 4; channel++)
+                {
+                    uint currentChannel = channel;
+                    try
+                    {
+                        SignalGeneratorState state = await Task.Run(() =>
+                            client.GetSignalGenerator(currentChannel));
+                        ApplySignalGeneratorState(state);
+                    }
+                    catch (Exception ex)
+                    {
+                        SetSignalGeneratorUnavailable(channel, "QUERY FAILED");
+                        Log(string.Format(CultureInfo.InvariantCulture,
+                            "Generator {0} query failed: {1}", channel, ex.Message));
+                    }
+
+                    try
+                    {
+                        FrequencyCounterState state = await Task.Run(() =>
+                            client.GetFrequencyCounter(currentChannel));
+                        ApplyFrequencyCounterState(state);
+                    }
+                    catch (Exception ex)
+                    {
+                        SetFrequencyCounterUnavailable(channel, "QUERY FAILED");
+                        Log(string.Format(CultureInfo.InvariantCulture,
+                            "Frequency {0} query failed: {1}", channel, ex.Message));
+                    }
+                }
+
+                for (uint connector = 1; connector <= 4; connector++)
+                {
+                    uint currentConnector = connector;
+                    try
+                    {
+                        routes[connector - 1] = await Task.Run(() =>
+                            client.GetSmaConnector(currentConnector));
+                    }
+                    catch (Exception ex)
+                    {
+                        Log(string.Format(CultureInfo.InvariantCulture,
+                            "Timing route query for SMA {0} failed: {1}",
+                            connector, ex.Message));
+                    }
+                }
+                ApplyTimingRoutes(routes);
+            }
+            finally
+            {
+                timingRefreshing = false;
+            }
+        }
+
+        private async void ApplySignalGenerator_Click(object sender,
+                                                        RoutedEventArgs e)
+        {
+            Button button = sender as Button;
+            uint generator;
+            if (button == null || !uint.TryParse(
+                Convert.ToString(button.Tag, CultureInfo.InvariantCulture),
+                NumberStyles.Integer, CultureInfo.InvariantCulture,
+                out generator) || !EnsureConnected())
+                return;
+            if (lastSnapshot == null || lastSnapshot.AbiVersion < 5)
+            {
+                MessageBox.Show(this,
+                    "Signal-generator control requires Time Card driver 1.10 / ABI 5.",
+                    "Driver update required", MessageBoxButton.OK,
+                    MessageBoxImage.Information);
+                return;
+            }
+
+            SignalGeneratorControls controls = signalGeneratorControls[generator - 1];
+            bool enabled = controls.Enabled.IsChecked == true;
+            bool inverted = controls.Invert.IsChecked == true;
+            ulong period = 0;
+            ulong pulse = 0;
+            ulong phase = 0;
+            try
+            {
+                if (enabled)
+                {
+                    decimal frequency;
+                    if (!decimal.TryParse(controls.Frequency.Text,
+                        NumberStyles.Float, CultureInfo.InvariantCulture,
+                        out frequency) || frequency < 0.000001m ||
+                        frequency > 500000000m)
+                        throw new InvalidOperationException(
+                            "Enter a generator frequency from 0.000001 through 500000000 Hz.");
+                    period = decimal.ToUInt64(decimal.Round(
+                        1000000000m / frequency, 0,
+                        MidpointRounding.AwayFromZero));
+                    uint duty = ParseUnsigned(controls.Duty.Text,
+                        "duty cycle", 1, 99);
+                    pulse = decimal.ToUInt64(decimal.Round(
+                        period * (decimal)duty / 100m, 0,
+                        MidpointRounding.AwayFromZero));
+                    if (pulse == 0 || pulse >= period)
+                        throw new InvalidOperationException(
+                            "The selected frequency and duty cycle cannot be represented at one-nanosecond resolution.");
+                    phase = ParseUnsignedLong(controls.Phase.Text,
+                        "phase", 0, period - 1);
+                }
+
+                uint route = SelectedTimingRoute(controls.Route);
+                if (route != 0)
+                {
+                    MessageBoxResult confirmation = MessageBox.Show(this,
+                        string.Format(CultureInfo.InvariantCulture,
+                            "Route Generator {0} to SMA {1} as an output? Disconnect any external source from this connector first.",
+                            generator, route),
+                        "Confirm generator output", MessageBoxButton.YesNo,
+                        MessageBoxImage.Warning);
+                    if (confirmation != MessageBoxResult.Yes)
+                        return;
+                }
+
+                button.IsEnabled = false;
+                SignalGeneratorState state = await Task.Run(() =>
+                    client.SetSignalGenerator(generator, enabled, period,
+                        pulse, phase, inverted));
+                ApplySignalGeneratorState(state);
+                if (route != 0)
+                {
+                    uint function = 0x0040u << ((int)generator - 1);
+                    SmaConnectorState routed = await Task.Run(() =>
+                        client.SetSmaConnector(route, SmaDirection.Output,
+                                               function));
+                    ApplySmaState(routed);
+                    controls.Route.SelectedIndex = (int)route;
+                }
+                Log(string.Format(CultureInfo.InvariantCulture,
+                    "Generator {0} {1}{2}.", generator,
+                    enabled ? "configured and enabled" : "disabled",
+                    route == 0 ? string.Empty : " on SMA " + route));
+            }
+            catch (Exception ex)
+            {
+                Log(string.Format(CultureInfo.InvariantCulture,
+                    "Generator {0} configuration failed: {1}",
+                    generator, ex.Message));
+                MessageBox.Show(this, ex.Message,
+                    "Unable to configure signal generator",
+                    MessageBoxButton.OK, MessageBoxImage.Error);
+            }
+            finally
+            {
+                button.IsEnabled = true;
+            }
+        }
+
+        private async void ApplyFrequencyCounter_Click(object sender,
+                                                        RoutedEventArgs e)
+        {
+            Button button = sender as Button;
+            uint counter;
+            if (button == null || !uint.TryParse(
+                Convert.ToString(button.Tag, CultureInfo.InvariantCulture),
+                NumberStyles.Integer, CultureInfo.InvariantCulture,
+                out counter) || !EnsureConnected())
+                return;
+            if (lastSnapshot == null || lastSnapshot.AbiVersion < 5)
+                return;
+
+            FrequencyCounterControls controls = frequencyCounterControls[counter - 1];
+            button.IsEnabled = false;
+            try
+            {
+                uint seconds = ParseUnsigned(controls.Seconds.Text,
+                    "integration time", 0, 255);
+                uint route = SelectedTimingRoute(controls.Route);
+                FrequencyCounterState state = await Task.Run(() =>
+                    client.SetFrequencyCounter(counter, seconds));
+                ApplyFrequencyCounterState(state);
+                if (route != 0)
+                {
+                    uint function = 0x0100u << ((int)counter - 1);
+                    SmaConnectorState routed = await Task.Run(() =>
+                        client.SetSmaConnector(route, SmaDirection.Input,
+                                               function));
+                    ApplySmaState(routed);
+                    controls.Route.SelectedIndex = (int)route;
+                }
+                Log(string.Format(CultureInfo.InvariantCulture,
+                    "Frequency counter {0} integration set to {1} second(s){2}.",
+                    counter, seconds, route == 0 ? string.Empty :
+                    " from SMA " + route));
+            }
+            catch (Exception ex)
+            {
+                Log(string.Format(CultureInfo.InvariantCulture,
+                    "Frequency counter {0} configuration failed: {1}",
+                    counter, ex.Message));
+                MessageBox.Show(this, ex.Message,
+                    "Unable to configure frequency counter",
+                    MessageBoxButton.OK, MessageBoxImage.Error);
+            }
+            finally
+            {
+                button.IsEnabled = true;
+            }
+        }
+
+        private void ApplySignalGeneratorState(SignalGeneratorState state)
+        {
+            SignalGeneratorControls controls = signalGeneratorControls[state.Generator - 1];
+            bool available = state.IsPresent;
+            controls.Enabled.IsChecked = state.IsEnabled;
+            controls.Invert.IsChecked = state.IsInverted;
+            if (state.PeriodNanoseconds != 0)
+            {
+                controls.Frequency.Text = state.FrequencyHz.ToString(
+                    "0.#########", CultureInfo.InvariantCulture);
+                controls.Duty.Text = Math.Round(state.DutyPercent).ToString(
+                    "0", CultureInfo.InvariantCulture);
+                controls.Phase.Text = state.PhaseNanoseconds.ToString(
+                    CultureInfo.InvariantCulture);
+            }
+            controls.Status.Text = state.Status != 0 ?
+                string.Format(CultureInfo.InvariantCulture,
+                    "FAULT 0x{0:X8}", state.Status) :
+                state.IsEnabled ? "RUNNING" : "DISABLED";
+            controls.Status.Foreground = state.Status != 0 ?
+                (Brush)FindResource("DangerBrush") :
+                state.IsEnabled ? (Brush)FindResource("AccentBrush") :
+                (Brush)FindResource("MutedBrush");
+            controls.Detail.Text = string.Format(CultureInfo.InvariantCulture,
+                "Period {0:N0} ns · Start {1}.{2:D9} TAI · v{3:X8}",
+                state.PeriodNanoseconds, state.StartSeconds,
+                state.StartNanoseconds, state.Version);
+            controls.Enabled.IsEnabled = available;
+            controls.Frequency.IsEnabled = available;
+            controls.Duty.IsEnabled = available;
+            controls.Phase.IsEnabled = available;
+            controls.Invert.IsEnabled = available;
+            controls.Route.IsEnabled = available;
+            controls.Apply.IsEnabled = available;
+        }
+
+        private void ApplyFrequencyCounterState(FrequencyCounterState state)
+        {
+            FrequencyCounterControls controls = frequencyCounterControls[state.Counter - 1];
+            bool available = state.IsPresent;
+            if (state.IsEnabled)
+                controls.Seconds.Text = state.IntegrationSeconds.ToString(
+                    CultureInfo.InvariantCulture);
+            controls.Value.Text = state.IsValid ?
+                state.FrequencyHz.ToString("N0", CultureInfo.InvariantCulture) + " Hz" :
+                "— Hz";
+            controls.Status.Text = state.HasError ? "ERROR" :
+                state.HasOverrun ? "OVERRUN" :
+                state.IsValid ? "VALID" :
+                state.IsEnabled ? "MEASURING" : "DISABLED";
+            controls.Status.Foreground = state.HasError || state.HasOverrun ?
+                (Brush)FindResource("DangerBrush") :
+                state.IsValid ? (Brush)FindResource("AccentBrush") :
+                (Brush)FindResource("MutedBrush");
+            controls.Detail.Text = string.Format(CultureInfo.InvariantCulture,
+                "Control 0x{0:X8} · Status 0x{1:X8}",
+                state.Control, state.Status);
+            controls.Seconds.IsEnabled = available;
+            controls.Route.IsEnabled = available;
+            controls.Apply.IsEnabled = available;
+        }
+
+        private void ApplyTimingRoutes(IEnumerable<SmaConnectorState> routes)
+        {
+            foreach (SignalGeneratorControls controls in signalGeneratorControls)
+                controls.Route.SelectedIndex = 0;
+            foreach (FrequencyCounterControls controls in frequencyCounterControls)
+                controls.Route.SelectedIndex = 0;
+            foreach (SmaConnectorState route in routes.Where(value => value != null))
+            {
+                if (route.Direction == SmaDirection.Output &&
+                    route.Function >= 0x0040u && route.Function <= 0x0200u)
+                {
+                    for (int index = 0; index < 4; index++)
+                    {
+                        if (route.Function == (0x0040u << index))
+                            signalGeneratorControls[index].Route.SelectedIndex =
+                                (int)route.Connector;
+                    }
+                }
+                if (route.Direction == SmaDirection.Input &&
+                    route.Function >= 0x0100u && route.Function <= 0x0800u)
+                {
+                    for (int index = 0; index < 4; index++)
+                    {
+                        if (route.Function == (0x0100u << index))
+                            frequencyCounterControls[index].Route.SelectedIndex =
+                                (int)route.Connector;
+                    }
+                }
+            }
+        }
+
+        private void SetTimingUnavailable(string status)
+        {
+            for (uint channel = 1; channel <= 4; channel++)
+            {
+                SetSignalGeneratorUnavailable(channel, status);
+                SetFrequencyCounterUnavailable(channel, status);
+            }
+        }
+
+        private void SetSignalGeneratorUnavailable(uint generator, string status)
+        {
+            SignalGeneratorControls controls = signalGeneratorControls[generator - 1];
+            controls.Status.Text = status;
+            controls.Status.Foreground = (Brush)FindResource("GoldBrush");
+            controls.Enabled.IsEnabled = false;
+            controls.Frequency.IsEnabled = false;
+            controls.Duty.IsEnabled = false;
+            controls.Phase.IsEnabled = false;
+            controls.Invert.IsEnabled = false;
+            controls.Route.IsEnabled = false;
+            controls.Apply.IsEnabled = false;
+        }
+
+        private void SetFrequencyCounterUnavailable(uint counter, string status)
+        {
+            FrequencyCounterControls controls = frequencyCounterControls[counter - 1];
+            controls.Status.Text = status;
+            controls.Status.Foreground = (Brush)FindResource("GoldBrush");
+            controls.Value.Text = "— Hz";
+            controls.Seconds.IsEnabled = false;
+            controls.Route.IsEnabled = false;
+            controls.Apply.IsEnabled = false;
+        }
+
+        private static uint SelectedTimingRoute(ComboBox combo)
+        {
+            ComboBoxItem item = combo.SelectedItem as ComboBoxItem;
+            uint route;
+            return item != null && uint.TryParse(
+                Convert.ToString(item.Tag, CultureInfo.InvariantCulture),
+                NumberStyles.Integer, CultureInfo.InvariantCulture,
+                out route) ? route : 0;
+        }
+
+        private static ulong ParseUnsignedLong(string text, string name,
+                                               ulong minimum, ulong maximum)
+        {
+            ulong value;
+            if (!ulong.TryParse(text, NumberStyles.Integer,
+                CultureInfo.InvariantCulture, out value) ||
+                value < minimum || value > maximum)
+                throw new InvalidOperationException(string.Format(
+                    CultureInfo.InvariantCulture,
+                    "Enter a valid {0} between {1} and {2}.",
+                    name, minimum, maximum));
+            return value;
+        }
+
         private async void RefreshI2c_Click(object sender, RoutedEventArgs e)
         {
             await RefreshI2cAsync(false);
@@ -2035,6 +2949,8 @@ namespace TimeCardControlCenter
                         Addresses = new List<uint>(),
                         FullScan = fullScan
                     };
+                    if (lastSnapshot != null && lastSnapshot.AbiVersion >= 7)
+                        value.Mux = activeClient.GetI2cMux();
                     uint first = fullScan ? 0x08u : 0x50u;
                     uint last = fullScan ? 0x77u : 0x58u;
                     for (uint address = first; address <= last; address++)
@@ -2079,6 +2995,9 @@ namespace TimeCardControlCenter
             Brush healthyBrush = (Brush)FindResource("AccentBrush");
             Brush warningBrush = (Brush)FindResource("GoldBrush");
             I2cControllerStatus status = result.Status;
+            bool readsSupported = SupportsReliableI2cReads();
+
+            ApplyI2cMuxState(result.Mux);
 
             I2cControllerStateText.Text = status.IsPresent ?
                 (status.IsEnabled ? "ENABLED" : "PRESENT") : "NOT PRESENT";
@@ -2111,11 +3030,503 @@ namespace TimeCardControlCenter
                 "No addresses acknowledged" :
                 string.Join(", ", result.Addresses.Select(address =>
                     string.Format(CultureInfo.InvariantCulture, "0x{0:X2}", address)));
-            I2cReadButton.IsEnabled = true;
-            I2cBoardReadButton.IsEnabled = result.BoardEeprom != null &&
+            I2cAddressMapText.Text = FormatI2cAddressMap(result);
+            I2cDiagnosticsText.Text = FormatI2cControllerDiagnostics(
+                status, result.FullScan ? "Full 7-bit scan completed." :
+                "Known-device probe completed.");
+            I2cReadButton.IsEnabled = readsSupported;
+            I2cPreviousButton.IsEnabled = readsSupported;
+            I2cNextButton.IsEnabled = readsSupported;
+            I2cBoardReadButton.IsEnabled = readsSupported &&
+                result.BoardEeprom != null &&
                 result.BoardEeprom.IsPresent;
-            I2cMacReadButton.IsEnabled = result.MacEeprom != null &&
+            I2cMacReadButton.IsEnabled = readsSupported &&
+                result.MacEeprom != null &&
                 result.MacEeprom.IsPresent;
+            if (!readsSupported)
+                I2cReadStatusText.Text = "Install Time Card driver 1.13 to enable reliable I\u00B2C reads.";
+        }
+
+        private void UpdateI2cDriverCompatibility(TimeCardSnapshot snapshot)
+        {
+            bool abiSupported = snapshot.AbiVersion >= 3;
+            bool reliableReads = abiSupported &&
+                DriverVersionAtLeast(snapshot.DriverVersion, 1, 11);
+            bool boardControls = snapshot.AbiVersion >= 7;
+            Brush stateBrush = (Brush)FindResource(
+                boardControls ? "AccentBrush" : "GoldBrush");
+
+            I2cModeIcon.Foreground = stateBrush;
+            I2cDriverBadgeText.Foreground = stateBrush;
+            I2cLedAutoCheckBox.IsEnabled = boardControls;
+            I2cLedManualPanel.IsEnabled = boardControls &&
+                I2cLedAutoCheckBox.IsChecked != true;
+            if (boardControls)
+            {
+                I2cDriverBadgeText.Text = "DRIVER " + snapshot.DriverVersion;
+                I2cSafetyBannerText.Text =
+                    "Guarded mode allows reads plus dedicated PCA9546A routing and IS32FL3207 LED updates. Arbitrary I\u00B2C writes remain blocked.";
+                return;
+            }
+
+            if (reliableReads)
+            {
+                I2cDriverBadgeText.Text = "READS ONLY · UPDATE";
+                I2cSafetyBannerText.Text = string.Format(
+                    CultureInfo.InvariantCulture,
+                    "Driver {0} supports reliable reads. Install driver 1.13 / ABI 7 to control the PCA9546A mux and subsystem LEDs.",
+                    snapshot.DriverVersion);
+                return;
+            }
+
+            I2cDriverBadgeText.Text = "UPDATE REQUIRED";
+            I2cSafetyBannerText.Text = abiSupported ? string.Format(
+                CultureInfo.InvariantCulture,
+                "Driver {0} uses the legacy AXI IIC receive sequence that Windows can report as a CRC data error. Install driver 1.13 before reading.",
+                snapshot.DriverVersion) :
+                "This driver predates I\u00B2C control support. Install Time Card driver 1.13 before using the bus workspace.";
+            I2cReadButton.IsEnabled = false;
+            I2cPreviousButton.IsEnabled = false;
+            I2cNextButton.IsEnabled = false;
+            I2cBoardReadButton.IsEnabled = false;
+            I2cMacReadButton.IsEnabled = false;
+            I2cReadStatusText.Text = "Driver update required for I\u00B2C reads.";
+        }
+
+        private bool SupportsReliableI2cReads()
+        {
+            return client != null && lastSnapshot != null &&
+                lastSnapshot.AbiVersion >= 3 &&
+                DriverVersionAtLeast(lastSnapshot.DriverVersion, 1, 11);
+        }
+
+        private bool SupportsI2cBoardControls()
+        {
+            return client != null && lastSnapshot != null &&
+                lastSnapshot.AbiVersion >= 7;
+        }
+
+        private static bool DriverVersionAtLeast(string value, int major,
+                                                 int minor)
+        {
+            Version installed;
+            return Version.TryParse(value, out installed) &&
+                installed.CompareTo(new Version(major, minor)) >= 0;
+        }
+
+        private void ApplyI2cMuxState(I2cMuxState state)
+        {
+            Brush healthyBrush = (Brush)FindResource("AccentBrush");
+            Brush warningBrush = (Brush)FindResource("GoldBrush");
+            if (state == null)
+            {
+                I2cMuxStatusText.Text = "DRIVER 1.13 / ABI 7 REQUIRED";
+                I2cMuxStatusText.Foreground = warningBrush;
+                return;
+            }
+            if (!state.IsPresent)
+            {
+                I2cMuxStatusText.Text = "NO ACK AT 0x70";
+                I2cMuxStatusText.Foreground = warningBrush;
+                return;
+            }
+
+            I2cMuxStatusText.Text = state.ChannelMask == 0 ?
+                "ALL CHANNELS DISCONNECTED" :
+                "ACTIVE · " + FormatI2cMuxMask(state.ChannelMask);
+            I2cMuxStatusText.Foreground = healthyBrush;
+        }
+
+        private static string FormatI2cMuxMask(uint mask)
+        {
+            List<string> channels = new List<string>();
+            if ((mask & 1u) != 0)
+                channels.Add("CH0 MAC");
+            if ((mask & 2u) != 0)
+                channels.Add("CH1 SENSORS");
+            if ((mask & 4u) != 0)
+                channels.Add("CH2 AN/ADC");
+            if ((mask & 8u) != 0)
+                channels.Add("CH3 DC");
+            return channels.Count == 0 ? "NONE" : string.Join(" + ", channels);
+        }
+
+        private async void SelectI2cMux_Click(object sender, RoutedEventArgs e)
+        {
+            Button button = sender as Button;
+            uint channelMask;
+            if (button == null || !uint.TryParse(
+                Convert.ToString(button.Tag, CultureInfo.InvariantCulture),
+                NumberStyles.Integer, CultureInfo.InvariantCulture,
+                out channelMask))
+                return;
+            if (!SupportsI2cBoardControls())
+            {
+                MessageBox.Show(this,
+                    "Install Time Card driver 1.13 / ABI 7 to control the PCA9546A.",
+                    "Driver update required", MessageBoxButton.OK,
+                    MessageBoxImage.Information);
+                return;
+            }
+
+            TimeCardClient activeClient = client;
+            button.IsEnabled = false;
+            I2cMuxStatusText.Text = "APPLYING ROUTE…";
+            try
+            {
+                I2cMuxState state = await Task.Run(
+                    () => activeClient.SetI2cMux(channelMask));
+                if (client != activeClient)
+                    return;
+                ApplyI2cMuxState(state);
+                Log("I2C mux route set to " + FormatI2cMuxMask(channelMask) + ".");
+            }
+            catch (Exception ex)
+            {
+                I2cMuxStatusText.Text = "ROUTE FAILED";
+                I2cMuxStatusText.Foreground = (Brush)FindResource("GoldBrush");
+                I2cLedOperationText.Text = ex.Message;
+                Log("I2C mux route failed: " + ex.Message);
+            }
+            finally
+            {
+                button.IsEnabled = true;
+            }
+        }
+
+        private async void UpdateBoardLedAutomationAsync(bool force)
+        {
+            if (I2cLedAutoCheckBox == null ||
+                I2cLedAutoCheckBox.IsChecked != true || ledAutomationUpdating)
+                return;
+            if (!SupportsI2cBoardControls())
+            {
+                I2cLedOperationText.Text =
+                    "Automatic LED mapping requires Time Card driver 1.13 / ABI 7.";
+                return;
+            }
+
+            ledAutomationUpdating = true;
+            TimeCardClient activeClient = client;
+            try
+            {
+                DateTime now = DateTime.UtcNow;
+                if (lastSnapshot != null && lastSnapshot.AbiVersion >= 2 &&
+                    now - lastSmaLedRefreshUtc >= TimeSpan.FromSeconds(10))
+                {
+                    lastSmaLedRefreshUtc = now;
+                    SmaConnectorState[] routes = await Task.Run(() =>
+                    {
+                        SmaConnectorState[] values = new SmaConnectorState[4];
+                        for (uint connector = 1; connector <= 4; connector++)
+                        {
+                            try
+                            {
+                                values[(int)connector - 1] =
+                                    activeClient.GetSmaConnector(connector);
+                            }
+                            catch
+                            {
+                                values[(int)connector - 1] = null;
+                            }
+                        }
+                        return values;
+                    });
+                    if (client != activeClient)
+                        return;
+                    for (int index = 0; index < routes.Length; index++)
+                        lastSmaLedStates[index] = routes[index];
+                }
+
+                if (lastSnapshot != null && lastSnapshot.AbiVersion >= 6 &&
+                    now - lastSecondaryLedObservationUtc >=
+                    TimeSpan.FromSeconds(10))
+                {
+                    lastSecondaryLedObservationUtc = now;
+                    try
+                    {
+                        UartObservation observation = await Task.Run(
+                            () => activeClient.ObserveUart(1, 1500));
+                        if (client != activeClient)
+                            return;
+                        secondaryGnssPresent = observation.IsPresent &&
+                            observation.HasActivity;
+                    }
+                    catch
+                    {
+                        secondaryGnssPresent = false;
+                    }
+                }
+
+                BoardLedColor[] desired = BuildAutomaticLedColors();
+                for (int index = 0; index < desired.Length; index++)
+                    ApplyBoardLedVisual(index, desired[index]);
+                if (force)
+                    Array.Clear(lastAppliedLedColors, 0,
+                        lastAppliedLedColors.Length);
+
+                List<int> changed = new List<int>();
+                for (int index = 0; index < desired.Length; index++)
+                {
+                    if (!desired[index].SameColor(lastAppliedLedColors[index]))
+                        changed.Add(index);
+                }
+                if (changed.Count == 0)
+                {
+                    I2cLedOperationText.Text =
+                        "Automatic mapping is active · hardware colors are current.";
+                    return;
+                }
+
+                await Task.Run(() =>
+                {
+                    foreach (int index in changed)
+                    {
+                        BoardLedColor color = desired[index];
+                        activeClient.SetBoardLed((uint)index, color.Red,
+                            color.Green, color.Blue, 96);
+                    }
+                });
+                if (client != activeClient)
+                    return;
+                foreach (int index in changed)
+                    lastAppliedLedColors[index] = desired[index];
+                I2cLedOperationText.Text = string.Format(
+                    CultureInfo.InvariantCulture,
+                    "Automatic mapping updated {0} indicator{1}; mux route restored after each update.",
+                    changed.Count, changed.Count == 1 ? string.Empty : "s");
+            }
+            catch (Exception ex)
+            {
+                I2cLedOperationText.Text = "Automatic LED update failed: " + ex.Message;
+                Log("Automatic subsystem LED update failed: " + ex.Message);
+            }
+            finally
+            {
+                ledAutomationUpdating = false;
+            }
+        }
+
+        private BoardLedColor[] BuildAutomaticLedColors()
+        {
+            BoardLedColor[] colors = new BoardLedColor[6];
+            TimeCardSnapshot snapshot = lastSnapshot;
+            colors[0] = snapshot != null && snapshot.GnssFixOk ?
+                new BoardLedColor(0, 180, 30, "FIX LOCKED") :
+                snapshot != null && snapshot.SatelliteDataValid &&
+                snapshot.SeenSatellites != 0 ?
+                    new BoardLedColor(170, 78, 0, "SEARCHING") :
+                    new BoardLedColor(180, 0, 0, "NO FIX");
+            colors[1] = secondaryGnssPresent == true ?
+                new BoardLedColor(0, 165, 30, "UART ACTIVE") :
+                secondaryGnssPresent == false ?
+                    new BoardLedColor(180, 0, 0, "NOT PRESENT") :
+                    new BoardLedColor(145, 64, 0, "UART UNKNOWN");
+
+            for (int index = 0; index < 4; index++)
+            {
+                SmaConnectorState state = lastSmaLedStates[index];
+                if (state == null)
+                    colors[index + 2] = new BoardLedColor(130, 55, 0, "UNKNOWN");
+                else if (!state.IsPresent)
+                    colors[index + 2] = new BoardLedColor(180, 0, 0, "NOT PRESENT");
+                else if (state.IsDisabled || state.Direction == SmaDirection.Disabled)
+                    colors[index + 2] = new BoardLedColor(50, 35, 0, "DISABLED");
+                else if (state.Direction == SmaDirection.Output)
+                    colors[index + 2] = new BoardLedColor(0, 165, 30, "OUTPUT");
+                else
+                    colors[index + 2] = new BoardLedColor(0, 65, 180, "INPUT");
+            }
+            return colors;
+        }
+
+        private void ApplyBoardLedVisual(int led, BoardLedColor color)
+        {
+            Border swatch = GetBoardLedSwatch(led);
+            TextBlock status = GetBoardLedStatusText(led);
+            swatch.Background = new SolidColorBrush(Color.FromRgb(
+                color.Red, color.Green, color.Blue));
+            status.Text = color.Status;
+            status.Foreground = (Brush)FindResource("MutedBrush");
+        }
+
+        private Border GetBoardLedSwatch(int led)
+        {
+            return led == 0 ? I2cLedGnss1Swatch :
+                led == 1 ? I2cLedGnss2Swatch :
+                led == 2 ? I2cLedIo1Swatch :
+                led == 3 ? I2cLedIo2Swatch :
+                led == 4 ? I2cLedIo3Swatch : I2cLedIo4Swatch;
+        }
+
+        private TextBlock GetBoardLedStatusText(int led)
+        {
+            return led == 0 ? I2cLedGnss1StatusText :
+                led == 1 ? I2cLedGnss2StatusText :
+                led == 2 ? I2cLedIo1StatusText :
+                led == 3 ? I2cLedIo2StatusText :
+                led == 4 ? I2cLedIo3StatusText : I2cLedIo4StatusText;
+        }
+
+        private void I2cLedAuto_Click(object sender, RoutedEventArgs e)
+        {
+            bool automatic = I2cLedAutoCheckBox.IsChecked == true;
+            I2cLedManualPanel.IsEnabled = SupportsI2cBoardControls() && !automatic;
+            if (automatic)
+            {
+                Array.Clear(lastAppliedLedColors, 0,
+                    lastAppliedLedColors.Length);
+                UpdateBoardLedAutomationAsync(true);
+            }
+            else
+            {
+                I2cLedOperationText.Text =
+                    "Automatic mapping paused. Select an indicator and apply a manual color.";
+            }
+        }
+
+        private void I2cLedSelection_SelectionChanged(
+            object sender, SelectionChangedEventArgs e)
+        {
+            if (I2cLedSelectionCombo != null && IsInitialized &&
+                I2cLedAutoCheckBox.IsChecked != true)
+                I2cLedOperationText.Text = "Read the selected indicator or apply a new color.";
+        }
+
+        private void I2cLedSlider_ValueChanged(object sender,
+                                                RoutedPropertyChangedEventArgs<double> e)
+        {
+            if (ledControlsUpdating || I2cLedRedSlider == null ||
+                I2cLedGreenSlider == null || I2cLedBlueSlider == null ||
+                I2cLedCurrentSlider == null || I2cLedPreview == null ||
+                I2cLedRedValueText == null || I2cLedGreenValueText == null ||
+                I2cLedBlueValueText == null || I2cLedCurrentValueText == null)
+                return;
+            byte red = (byte)Math.Round(I2cLedRedSlider.Value);
+            byte green = (byte)Math.Round(I2cLedGreenSlider.Value);
+            byte blue = (byte)Math.Round(I2cLedBlueSlider.Value);
+            I2cLedRedValueText.Text = red.ToString(CultureInfo.InvariantCulture);
+            I2cLedGreenValueText.Text = green.ToString(CultureInfo.InvariantCulture);
+            I2cLedBlueValueText.Text = blue.ToString(CultureInfo.InvariantCulture);
+            I2cLedCurrentValueText.Text = Math.Round(
+                I2cLedCurrentSlider.Value).ToString(CultureInfo.InvariantCulture);
+            I2cLedPreview.Background = new SolidColorBrush(
+                Color.FromRgb(red, green, blue));
+        }
+
+        private async void ReadI2cLed_Click(object sender, RoutedEventArgs e)
+        {
+            if (!SupportsI2cBoardControls())
+                return;
+            uint led = SelectedBoardLed();
+            TimeCardClient activeClient = client;
+            I2cLedOperationText.Text = "Reading selected indicator…";
+            try
+            {
+                BoardLedState state = await Task.Run(
+                    () => activeClient.GetBoardLed(led));
+                if (client != activeClient)
+                    return;
+                ApplyManualBoardLedState(state);
+                I2cLedOperationText.Text = string.Format(
+                    CultureInfo.InvariantCulture,
+                    "LED {0} read · RGB {1}/{2}/{3} · global current {4}.",
+                    led + 1, state.Red, state.Green, state.Blue,
+                    state.GlobalCurrent);
+            }
+            catch (Exception ex)
+            {
+                I2cLedOperationText.Text = "LED read failed: " + ex.Message;
+            }
+        }
+
+        private async void ApplyI2cLed_Click(object sender, RoutedEventArgs e)
+        {
+            await SetManualBoardLedAsync(false);
+        }
+
+        private async void TurnOffI2cLed_Click(object sender, RoutedEventArgs e)
+        {
+            await SetManualBoardLedAsync(true);
+        }
+
+        private async Task SetManualBoardLedAsync(bool turnOff)
+        {
+            if (!SupportsI2cBoardControls())
+                return;
+            uint led = SelectedBoardLed();
+            byte red = turnOff ? (byte)0 :
+                (byte)Math.Round(I2cLedRedSlider.Value);
+            byte green = turnOff ? (byte)0 :
+                (byte)Math.Round(I2cLedGreenSlider.Value);
+            byte blue = turnOff ? (byte)0 :
+                (byte)Math.Round(I2cLedBlueSlider.Value);
+            byte current = (byte)Math.Round(I2cLedCurrentSlider.Value);
+            TimeCardClient activeClient = client;
+            SetI2cLedButtonsEnabled(false);
+            I2cLedOperationText.Text = turnOff ?
+                "Turning off selected indicator…" : "Applying selected color…";
+            try
+            {
+                BoardLedState state = await Task.Run(() =>
+                    activeClient.SetBoardLed(led, red, green, blue, current));
+                if (client != activeClient)
+                    return;
+                ApplyManualBoardLedState(state);
+                I2cLedOperationText.Text = string.Format(
+                    CultureInfo.InvariantCulture,
+                    "LED {0} updated · RGB {1}/{2}/{3}; previous PCA9546A route restored.",
+                    led + 1, state.Red, state.Green, state.Blue);
+                Log(string.Format(CultureInfo.InvariantCulture,
+                    "Subsystem LED {0} set to RGB {1}/{2}/{3}.",
+                    led + 1, state.Red, state.Green, state.Blue));
+            }
+            catch (Exception ex)
+            {
+                I2cLedOperationText.Text = "LED update failed: " + ex.Message;
+                Log("Subsystem LED update failed: " + ex.Message);
+            }
+            finally
+            {
+                SetI2cLedButtonsEnabled(true);
+            }
+        }
+
+        private uint SelectedBoardLed()
+        {
+            uint led;
+            return uint.TryParse(GetComboTag(I2cLedSelectionCombo),
+                NumberStyles.Integer, CultureInfo.InvariantCulture,
+                out led) ? led : 0u;
+        }
+
+        private void ApplyManualBoardLedState(BoardLedState state)
+        {
+            ledControlsUpdating = true;
+            try
+            {
+                I2cLedRedSlider.Value = state.Red;
+                I2cLedGreenSlider.Value = state.Green;
+                I2cLedBlueSlider.Value = state.Blue;
+                I2cLedCurrentSlider.Value = state.GlobalCurrent == 0 ?
+                    96 : state.GlobalCurrent;
+            }
+            finally
+            {
+                ledControlsUpdating = false;
+            }
+            I2cLedSlider_ValueChanged(null, null);
+            ApplyBoardLedVisual((int)state.Led,
+                new BoardLedColor(state.Red, state.Green, state.Blue,
+                    state.Red == 0 && state.Green == 0 && state.Blue == 0 ?
+                    "OFF" : "MANUAL"));
+        }
+
+        private void SetI2cLedButtonsEnabled(bool enabled)
+        {
+            I2cLedReadButton.IsEnabled = enabled;
+            I2cLedOffButton.IsEnabled = enabled;
+            I2cLedApplyButton.IsEnabled = enabled;
         }
 
         private void SetI2cUnavailable(string state, string detail)
@@ -2130,12 +3541,128 @@ namespace TimeCardControlCenter
             I2cRegisterText.Text = "CR — · SR —";
             I2cDeviceCountText.Text = "—";
             I2cScanResultText.Text = detail;
+            I2cAddressMapText.Text = "Bus map unavailable.";
+            I2cDiagnosticsText.Text = detail;
             I2cBoardStatusText.Text = "NOT AVAILABLE";
             I2cMacStatusText.Text = "NOT AVAILABLE";
             I2cSerialNumberText.Text = "Card serial unavailable";
+            I2cMuxStatusText.Text = "NOT AVAILABLE";
+            I2cMuxStatusText.Foreground = warningBrush;
+            I2cLedOperationText.Text = detail;
             I2cReadButton.IsEnabled = false;
+            I2cPreviousButton.IsEnabled = false;
+            I2cNextButton.IsEnabled = false;
             I2cBoardReadButton.IsEnabled = false;
             I2cMacReadButton.IsEnabled = false;
+        }
+
+        private static string FormatI2cAddressMap(I2cRefreshResult result)
+        {
+            if (result.Addresses.Count == 0)
+                return result.FullScan ?
+                    "Scan complete · no addresses ACKed." :
+                    "Known-device probe · no addresses ACKed.";
+
+            StringBuilder output = new StringBuilder();
+            output.Append(result.FullScan ? "Full scan" : "Known probes");
+            output.AppendFormat(CultureInfo.InvariantCulture,
+                " · {0} ACK{1}\r\n", result.Addresses.Count,
+                result.Addresses.Count == 1 ? "" : "s");
+            foreach (uint address in result.Addresses)
+            {
+                string name = address == 0x50 ? "board EEPROM" :
+                    address == 0x58 ? "MAC identity" :
+                    address == 0x70 ? "PCA9546A mux" :
+                    address == 0x6e ? "IS32FL3207 status LEDs (CH1)" :
+                    address == 0x29 ? "BNO055 IMU (CH1)" :
+                    address == 0x40 ? "INA219 12 V monitor (CH1)" :
+                    address == 0x41 ? "INA219 5 V monitor (CH1)" :
+                    address == 0x44 ? "INA219 3.3 V monitor (CH1)" :
+                    address == 0x76 ? "BME280 environment (CH1)" :
+                    "unclassified / expansion";
+                output.AppendFormat(CultureInfo.InvariantCulture,
+                    "0x{0:X2}  {1}\r\n", address, name);
+            }
+            return output.ToString().TrimEnd();
+        }
+
+        private static string FormatI2cControllerDiagnostics(
+            I2cControllerStatus status, string operation)
+        {
+            return string.Format(CultureInfo.InvariantCulture,
+                "CR  0x{0:X2}  {1}\r\nSR  0x{2:X2}  {3}\r\n" +
+                "ISR 0x{4:X8}  {5}\r\nIER 0x{6:X8}\r\n" +
+                "TX FIFO {7}  RX FIFO {8}\r\n{9}",
+                status.Control, DecodeI2cControl(status.Control),
+                status.Status, DecodeI2cStatus(status.Status),
+                status.InterruptStatus,
+                DecodeI2cInterrupts(status.InterruptStatus),
+                status.InterruptEnable, status.TxFifoOccupancy,
+                status.RxFifoOccupancy, operation);
+        }
+
+        private static string FormatI2cTransactionDiagnostics(
+            I2cReadResult result, uint subaddress, uint subaddressLength,
+            uint requestedLength, uint timeoutMilliseconds)
+        {
+            return string.Format(CultureInfo.InvariantCulture,
+                "READ 0x{0:X2} / sub 0x{1:X4} ({2} byte{3})\r\n" +
+                "RX {4}/{5} bytes · timeout {6} ms\r\n" +
+                "SR  0x{7:X2}  {8}\r\nISR 0x{9:X8}  {10}",
+                result.Address, subaddress, subaddressLength,
+                subaddressLength == 1 ? "" : "s", result.Data.Length,
+                requestedLength, timeoutMilliseconds,
+                result.ControllerStatus, DecodeI2cStatus(result.ControllerStatus),
+                result.InterruptStatus,
+                DecodeI2cInterrupts(result.InterruptStatus));
+        }
+
+        private static string DecodeI2cControl(uint value)
+        {
+            return DecodeFlags(value, new[]
+            {
+                new KeyValuePair<uint, string>(0x01, "EN"),
+                new KeyValuePair<uint, string>(0x02, "TX_RESET"),
+                new KeyValuePair<uint, string>(0x04, "MASTER"),
+                new KeyValuePair<uint, string>(0x08, "TX"),
+                new KeyValuePair<uint, string>(0x10, "NACK"),
+                new KeyValuePair<uint, string>(0x20, "RESTART")
+            });
+        }
+
+        private static string DecodeI2cStatus(uint value)
+        {
+            return DecodeFlags(value, new[]
+            {
+                new KeyValuePair<uint, string>(0x80, "TX_EMPTY"),
+                new KeyValuePair<uint, string>(0x40, "RX_EMPTY"),
+                new KeyValuePair<uint, string>(0x20, "RX_FULL"),
+                new KeyValuePair<uint, string>(0x10, "TX_FULL"),
+                new KeyValuePair<uint, string>(0x08, "SLAVE_READ"),
+                new KeyValuePair<uint, string>(0x04, "BUS_BUSY"),
+                new KeyValuePair<uint, string>(0x02, "ADDRESSED")
+            });
+        }
+
+        private static string DecodeI2cInterrupts(uint value)
+        {
+            return DecodeFlags(value, new[]
+            {
+                new KeyValuePair<uint, string>(0x01, "ARB_LOST"),
+                new KeyValuePair<uint, string>(0x02, "TX_ERROR/FINAL_NACK"),
+                new KeyValuePair<uint, string>(0x04, "TX_EMPTY"),
+                new KeyValuePair<uint, string>(0x08, "RX_FULL"),
+                new KeyValuePair<uint, string>(0x10, "BUS_NOT_BUSY")
+            });
+        }
+
+        private static string DecodeFlags(uint value,
+            IEnumerable<KeyValuePair<uint, string>> flags)
+        {
+            string decoded = string.Join("|", flags
+                .Where(flag => (value & flag.Key) != 0)
+                .Select(flag => flag.Value));
+            return decoded.Length == 0 ? "none" : decoded;
         }
 
         private async void ReadI2c_Click(object sender, RoutedEventArgs e)
@@ -2143,8 +3670,138 @@ namespace TimeCardControlCenter
             await ExecuteI2cReadAsync();
         }
 
+        private void I2cPreset_SelectionChanged(object sender,
+                                                SelectionChangedEventArgs e)
+        {
+            if (I2cAddressTextBox == null || I2cPresetCombo == null)
+                return;
+            string preset = GetComboTag(I2cPresetCombo);
+            if (preset == "board")
+            {
+                I2cAddressTextBox.Text = "50";
+                I2cSubaddressTextBox.Text = "00";
+                I2cSubaddressLengthCombo.SelectedIndex = 1;
+                I2cLengthTextBox.Text = "32";
+            }
+            else if (preset == "identity")
+            {
+                I2cAddressTextBox.Text = "58";
+                I2cSubaddressTextBox.Text = "00";
+                I2cSubaddressLengthCombo.SelectedIndex = 1;
+                I2cLengthTextBox.Text = "6";
+            }
+            else if (preset == "imu")
+            {
+                I2cAddressTextBox.Text = "29";
+                I2cSubaddressTextBox.Text = "00";
+                I2cSubaddressLengthCombo.SelectedIndex = 1;
+                I2cLengthTextBox.Text = "4";
+            }
+            else if (preset == "power12")
+            {
+                I2cAddressTextBox.Text = "40";
+                I2cSubaddressTextBox.Text = "00";
+                I2cSubaddressLengthCombo.SelectedIndex = 1;
+                I2cLengthTextBox.Text = "2";
+            }
+            else if (preset == "environment")
+            {
+                I2cAddressTextBox.Text = "76";
+                I2cSubaddressTextBox.Text = "D0";
+                I2cSubaddressLengthCombo.SelectedIndex = 1;
+                I2cLengthTextBox.Text = "1";
+            }
+            else if (preset == "leddriver")
+            {
+                I2cAddressTextBox.Text = "6E";
+                I2cSubaddressTextBox.Text = "00";
+                I2cSubaddressLengthCombo.SelectedIndex = 1;
+                I2cLengthTextBox.Text = "8";
+            }
+            else if (preset == "direct")
+            {
+                I2cSubaddressTextBox.Text = "00";
+                I2cSubaddressLengthCombo.SelectedIndex = 0;
+                I2cLengthTextBox.Text = "16";
+            }
+        }
+
+        private void I2cDisplayMode_SelectionChanged(
+            object sender, SelectionChangedEventArgs e)
+        {
+            if (I2cOutputTextBox != null && lastI2cData != null)
+                RenderI2cOutput();
+        }
+
+        private async void I2cPrevious_Click(object sender, RoutedEventArgs e)
+        {
+            await MoveI2cPageAsync(-1);
+        }
+
+        private async void I2cNext_Click(object sender, RoutedEventArgs e)
+        {
+            await MoveI2cPageAsync(1);
+        }
+
+        private async Task MoveI2cPageAsync(int direction)
+        {
+            try
+            {
+                uint subaddressLength = GetI2cSubaddressLength();
+                if (subaddressLength == 0)
+                    throw new InvalidOperationException(
+                        "Page navigation requires a 1-byte or 2-byte subaddress.");
+                uint maximum = subaddressLength == 1 ? 0xffu : 0xffffu;
+                uint current = ParseHex(I2cSubaddressTextBox.Text,
+                    "subaddress", 0, maximum);
+                uint length = ParseUnsigned(I2cLengthTextBox.Text,
+                    "read length", 1, 255);
+                uint next = direction < 0 ?
+                    (current > length ? current - length : 0u) :
+                    Math.Min(maximum, current + length);
+                I2cSubaddressTextBox.Text = next.ToString(
+                    subaddressLength == 1 ? "X2" : "X4",
+                    CultureInfo.InvariantCulture);
+                I2cPresetCombo.SelectedIndex = 0;
+                await ExecuteI2cReadAsync();
+            }
+            catch (Exception ex)
+            {
+                I2cReadStatusText.Text = ex.Message;
+            }
+        }
+
+        private void CopyI2c_Click(object sender, RoutedEventArgs e)
+        {
+            if (!string.IsNullOrEmpty(I2cOutputTextBox.Text))
+            {
+                Clipboard.SetText(I2cOutputTextBox.Text);
+                I2cReadStatusText.Text = "The formatted I²C output was copied.";
+            }
+        }
+
+        private static string GetComboTag(ComboBox combo)
+        {
+            ComboBoxItem item = combo == null ? null :
+                combo.SelectedItem as ComboBoxItem;
+            return item == null ? string.Empty :
+                Convert.ToString(item.Tag, CultureInfo.InvariantCulture);
+        }
+
+        private uint GetI2cSubaddressLength()
+        {
+            string value = GetComboTag(I2cSubaddressLengthCombo);
+            uint result;
+            if (!uint.TryParse(value, NumberStyles.Integer,
+                CultureInfo.InvariantCulture, out result) || result > 2)
+                throw new InvalidOperationException(
+                    "Select a valid subaddress length.");
+            return result;
+        }
+
         private async void ReadBoardEeprom_Click(object sender, RoutedEventArgs e)
         {
+            I2cPresetCombo.SelectedIndex = 1;
             I2cAddressTextBox.Text = "50";
             I2cSubaddressTextBox.Text = "00";
             I2cSubaddressLengthCombo.SelectedIndex = 1;
@@ -2154,6 +3811,7 @@ namespace TimeCardControlCenter
 
         private async void ReadMacEeprom_Click(object sender, RoutedEventArgs e)
         {
+            I2cPresetCombo.SelectedIndex = 2;
             I2cAddressTextBox.Text = "58";
             I2cSubaddressTextBox.Text = "00";
             I2cSubaddressLengthCombo.SelectedIndex = 1;
@@ -2164,10 +3822,12 @@ namespace TimeCardControlCenter
 
         private async Task RefreshIdentityAsync()
         {
-            if (client == null || lastSnapshot == null || lastSnapshot.AbiVersion < 3)
+            if (client == null || lastSnapshot == null ||
+                !SupportsReliableI2cReads())
             {
-                SidebarSerialText.Text = "Driver update required";
-                I2cSerialNumberText.Text = "Card serial requires ABI 3+";
+                SidebarSerialText.Text = "Driver 1.12 required";
+                I2cSerialNumberText.Text =
+                    "Update to driver 1.12 to read the card identity";
                 return;
             }
 
@@ -2211,26 +3871,25 @@ namespace TimeCardControlCenter
         {
             if (!EnsureConnected())
                 return;
-            if (lastSnapshot != null && lastSnapshot.AbiVersion < 3)
+            if (!SupportsReliableI2cReads())
             {
                 MessageBox.Show(this,
-                    "I2C access requires Time Card driver 1.8 or later.",
+                    "Reliable I2C reads require Time Card driver 1.11 or later. " +
+                    "This computer is running driver " +
+                    (lastSnapshot == null ? "an unknown version" :
+                     lastSnapshot.DriverVersion) + ".\n\n" +
+                     "Install the current driver 1.13 package, then restart the Control Center.",
                     "Driver update required", MessageBoxButton.OK,
                     MessageBoxImage.Information);
                 return;
             }
 
+            TimeCardClient activeClient = client;
             try
             {
                 uint address = ParseHex(I2cAddressTextBox.Text,
                     "7-bit I2C address", 0x08, 0x77);
-                ComboBoxItem lengthItem =
-                    I2cSubaddressLengthCombo.SelectedItem as ComboBoxItem;
-                if (lengthItem == null)
-                    throw new InvalidOperationException("Select a subaddress length.");
-                uint subaddressLength = uint.Parse(
-                    Convert.ToString(lengthItem.Tag, CultureInfo.InvariantCulture),
-                    CultureInfo.InvariantCulture);
+                uint subaddressLength = GetI2cSubaddressLength();
                 uint subaddressMaximum = subaddressLength == 2 ? 0xffffu :
                     subaddressLength == 1 ? 0xffu : 0u;
                 uint subaddress = subaddressLength == 0 ? 0u :
@@ -2238,26 +3897,34 @@ namespace TimeCardControlCenter
                         subaddressMaximum);
                 uint length = ParseUnsigned(I2cLengthTextBox.Text,
                     "read length", 1, 255);
-                TimeCardClient activeClient = client;
+                uint timeoutMilliseconds = uint.Parse(
+                    GetComboTag(I2cTimeoutCombo), CultureInfo.InvariantCulture);
 
                 I2cReadButton.IsEnabled = false;
+                I2cPreviousButton.IsEnabled = false;
+                I2cNextButton.IsEnabled = false;
+                I2cCopyButton.IsEnabled = false;
                 I2cBoardReadButton.IsEnabled = false;
                 I2cMacReadButton.IsEnabled = false;
                 I2cReadStatusText.Text = string.Format(CultureInfo.InvariantCulture,
                     "Reading {0} byte(s) from 0x{1:X2}...", length, address);
                 I2cReadResult result = await Task.Run(() =>
                     activeClient.ReadI2c(address, subaddress,
-                        subaddressLength, length, 100));
+                        subaddressLength, length, timeoutMilliseconds));
                 if (client != activeClient)
                     return;
 
-                I2cOutputTextBox.Text = string.Format(CultureInfo.InvariantCulture,
-                    "Device 0x{0:X2} · subaddress 0x{1:X4} ({2} byte{3})\r\n\r\n{4}",
-                    result.Address, subaddress, subaddressLength,
-                    subaddressLength == 1 ? "" : "s",
-                    FormatI2cData(result.Data));
+                lastI2cData = result.Data;
+                lastI2cAddress = result.Address;
+                lastI2cSubaddress = subaddress;
+                lastI2cSubaddressLength = subaddressLength;
+                RenderI2cOutput();
+                I2cCopyButton.IsEnabled = true;
+                I2cDiagnosticsText.Text = FormatI2cTransactionDiagnostics(
+                    result, subaddress, subaddressLength, length,
+                    timeoutMilliseconds);
                 I2cReadStatusText.Text = string.Format(CultureInfo.InvariantCulture,
-                    "Read {0} byte(s) · SR 0x{1:X2} · ISR 0x{2:X8}",
+                    "Read {0} byte(s) · SR 0x{1:X2} · events 0x{2:X8}",
                     result.Data.Length, result.ControllerStatus,
                     result.InterruptStatus);
                 Log(string.Format(CultureInfo.InvariantCulture,
@@ -2266,19 +3933,49 @@ namespace TimeCardControlCenter
             }
             catch (Exception ex)
             {
-                I2cReadStatusText.Text = "Read failed: " + ex.Message;
-                Log("I2C read failed: " + ex.Message);
-                MessageBox.Show(this, ex.Message, "I2C read failed",
+                string failureMessage = DescribeI2cReadFailure(ex);
+                I2cReadStatusText.Text = "Read failed: " + failureMessage;
+                if (client == activeClient && activeClient != null)
+                {
+                    try
+                    {
+                        I2cControllerStatus status = await Task.Run(() =>
+                            activeClient.GetI2cStatus());
+                        I2cDiagnosticsText.Text = FormatI2cControllerDiagnostics(
+                            status, "Last read failed: " + failureMessage);
+                    }
+                    catch (Exception statusError)
+                    {
+                        I2cDiagnosticsText.Text = "Read failed: " + failureMessage +
+                            "\r\nStatus sample failed: " + statusError.Message;
+                    }
+                }
+                Log("I2C read failed: " + failureMessage);
+                MessageBox.Show(this, failureMessage, "I2C read failed",
                     MessageBoxButton.OK, MessageBoxImage.Error);
             }
             finally
             {
-                bool supported = client != null &&
-                    (lastSnapshot == null || lastSnapshot.AbiVersion >= 3);
+                bool supported = SupportsReliableI2cReads();
                 I2cReadButton.IsEnabled = supported;
+                I2cPreviousButton.IsEnabled = supported;
+                I2cNextButton.IsEnabled = supported;
+                I2cCopyButton.IsEnabled = lastI2cData != null;
                 I2cBoardReadButton.IsEnabled = supported;
                 I2cMacReadButton.IsEnabled = supported;
             }
+        }
+
+        private static string DescribeI2cReadFailure(Exception error)
+        {
+            Win32Exception win32 = error as Win32Exception;
+            if (win32 != null && win32.NativeErrorCode == 23)
+            {
+                return "The installed driver returned its legacy I2C short-transfer status. " +
+                    "Windows labels that status as a CRC data error, but this transaction does not use a CRC. " +
+                    "Install Time Card driver 1.13 and retry the read.";
+            }
+            return error.Message;
         }
 
         private static uint ParseHex(string text, string name,
@@ -2298,28 +3995,75 @@ namespace TimeCardControlCenter
             return value;
         }
 
-        private static string FormatI2cData(byte[] data)
+        private void RenderI2cOutput()
+        {
+            if (lastI2cData == null)
+                return;
+            string mode = GetComboTag(I2cDisplayModeCombo);
+            string subaddressText = lastI2cSubaddressLength == 0 ?
+                "direct receive" : string.Format(CultureInfo.InvariantCulture,
+                    "subaddress 0x{0:X4} ({1} byte{2})",
+                    lastI2cSubaddress, lastI2cSubaddressLength,
+                    lastI2cSubaddressLength == 1 ? "" : "s");
+            I2cOutputTextBox.Text = string.Format(CultureInfo.InvariantCulture,
+                "Device 0x{0:X2} · {1} · {2} bytes · {3}\r\n\r\n{4}",
+                lastI2cAddress, subaddressText, lastI2cData.Length,
+                I2cDisplayModeCombo.Text,
+                FormatI2cData(lastI2cData, lastI2cSubaddress, mode));
+        }
+
+        private static string FormatI2cData(byte[] data, uint baseAddress,
+                                            string mode)
         {
             StringBuilder output = new StringBuilder();
-            for (int offset = 0; offset < data.Length; offset += 16)
+            int columns = mode == "binary" ? 4 :
+                mode == "decimal" ? 8 : mode == "ascii" ? 32 : 16;
+            for (int offset = 0; offset < data.Length; offset += columns)
             {
                 output.AppendFormat(CultureInfo.InvariantCulture,
-                    "{0:X4}  ", offset);
-                for (int index = 0; index < 16; index++)
+                    "{0:X4}  ", baseAddress + (uint)offset);
+                int count = Math.Min(columns, data.Length - offset);
+                if (mode == "binary")
                 {
-                    if (offset + index < data.Length)
-                        output.AppendFormat(CultureInfo.InvariantCulture,
-                            "{0:X2} ", data[offset + index]);
-                    else
-                        output.Append("   ");
+                    for (int index = 0; index < count; index++)
+                        output.Append(Convert.ToString(data[offset + index], 2)
+                            .PadLeft(8, '0')).Append(' ');
                 }
-                output.Append(" ");
-                for (int index = 0; index < 16 &&
-                     offset + index < data.Length; index++)
+                else if (mode == "decimal")
                 {
-                    byte value = data[offset + index];
-                    output.Append(value >= 0x20 && value <= 0x7e ?
-                        (char)value : '.');
+                    for (int index = 0; index < count; index++)
+                        output.AppendFormat(CultureInfo.InvariantCulture,
+                            "{0,3} ", data[offset + index]);
+                }
+                else if (mode == "ascii")
+                {
+                    for (int index = 0; index < count; index++)
+                    {
+                        byte value = data[offset + index];
+                        output.Append(value >= 0x20 && value <= 0x7e ?
+                            (char)value : '.');
+                    }
+                }
+                else
+                {
+                    for (int index = 0; index < columns; index++)
+                    {
+                        if (index < count)
+                            output.AppendFormat(CultureInfo.InvariantCulture,
+                                "{0:X2} ", data[offset + index]);
+                        else if (mode == "hexascii")
+                            output.Append("   ");
+                    }
+                    if (mode == "hexascii")
+                    {
+                        output.Append(" ");
+                        for (int index = 0; index < count; index++)
+                        {
+                            byte value = data[offset + index];
+                            output.Append(value >= 0x20 && value <= 0x7e ?
+                                (char)value : '.');
+                        }
+                    }
                 }
                 output.AppendLine();
             }
@@ -2353,23 +4097,64 @@ namespace TimeCardControlCenter
         {
             if (data == null)
                 return;
-            string formatted = FormatUartData(data);
-            string line = string.Format(CultureInfo.InvariantCulture, "[{0:HH:mm:ss.fff}] {1} {2} byte(s) · LSR 0x{3:X2}\r\n{4}{5}",
-                DateTime.Now, direction, data.Length, lineStatus & 0xff, formatted,
-                formatted.EndsWith("\n", StringComparison.Ordinal) ? string.Empty : "\r\n");
-            UartOutputTextBox.AppendText(line);
+            byte[] capturedData = (byte[])data.Clone();
+            UartConsoleEntry entry = new UartConsoleEntry
+            {
+                Timestamp = DateTime.Now,
+                Direction = direction,
+                Data = capturedData,
+                LineStatus = lineStatus
+            };
+            uartConsoleEntries.Add(entry);
+            uartConsoleHistoryBytes += capturedData.Length;
+            while (uartConsoleHistoryBytes > 65536 && uartConsoleEntries.Count > 1)
+            {
+                uartConsoleHistoryBytes -= uartConsoleEntries[0].Data.Length;
+                uartConsoleEntries.RemoveAt(0);
+            }
+            UartOutputTextBox.AppendText(RenderUartConsoleEntry(entry));
             if (UartOutputTextBox.Text.Length > 131072)
-                UartOutputTextBox.Text = UartOutputTextBox.Text.Substring(UartOutputTextBox.Text.Length - 65536);
+                UartOutputTextBox.Text = UartOutputTextBox.Text.Substring(
+                    UartOutputTextBox.Text.Length - 65536);
             UartOutputTextBox.ScrollToEnd();
+        }
+
+        private void RenderUartConsole()
+        {
+            const int maximumCharacters = 131072;
+            List<string> renderedEntries = new List<string>(uartConsoleEntries.Count);
+            int renderedCharacters = 0;
+            for (int index = uartConsoleEntries.Count - 1; index >= 0; index--)
+            {
+                UartConsoleEntry entry = uartConsoleEntries[index];
+                string rendered = RenderUartConsoleEntry(entry);
+                if (renderedCharacters != 0 &&
+                    renderedCharacters + rendered.Length > maximumCharacters)
+                    break;
+                renderedEntries.Add(rendered);
+                renderedCharacters += rendered.Length;
+            }
+            renderedEntries.Reverse();
+            UartOutputTextBox.Text = string.Concat(renderedEntries);
+            UartOutputTextBox.ScrollToEnd();
+        }
+
+        private string RenderUartConsoleEntry(UartConsoleEntry entry)
+        {
+            string formatted = FormatUartData(entry.Data);
+            return string.Format(CultureInfo.InvariantCulture,
+                "[{0:HH:mm:ss.fff}] {1} {2} byte(s) · LSR 0x{3:X2}\r\n{4}{5}",
+                entry.Timestamp, entry.Direction, entry.Data.Length,
+                entry.LineStatus & 0xff, formatted,
+                formatted.EndsWith("\n", StringComparison.Ordinal) ? string.Empty : "\r\n");
         }
 
         private string FormatUartData(byte[] data)
         {
-            ComboBoxItem item = UartFormatCombo.SelectedItem as ComboBoxItem;
-            string mode = item == null ? "Auto" : Convert.ToString(item.Content, CultureInfo.InvariantCulture);
+            string mode = SelectedUartDisplayMode();
             bool printable = data.Length == 0 || data.Count(value => value == 9 || value == 10 || value == 13 ||
                 (value >= 32 && value < 127)) >= data.Length * 0.82;
-            if (mode == "Text" || (mode == "Auto" && printable))
+            if (mode == "Ascii" || (mode == "Auto" && printable))
             {
                 StringBuilder text = new StringBuilder(data.Length);
                 foreach (byte value in data)
@@ -2381,7 +4166,25 @@ namespace TimeCardControlCenter
                 }
                 return text.ToString();
             }
+            if (mode == "Binary")
+                return string.Join(" ", data.Select(value => Convert.ToString(value, 2).PadLeft(8, '0')));
+            if (mode == "Decimal")
+                return string.Join(" ", data.Select(value => value.ToString("D3", CultureInfo.InvariantCulture)));
             return string.Join(" ", data.Select(value => value.ToString("X2", CultureInfo.InvariantCulture)));
+        }
+
+        private string SelectedUartDisplayMode()
+        {
+            ComboBoxItem item = UartFormatCombo.SelectedItem as ComboBoxItem;
+            return item == null ? "Auto" :
+                Convert.ToString(item.Tag, CultureInfo.InvariantCulture);
+        }
+
+        private string SelectedUartDisplayName()
+        {
+            ComboBoxItem item = UartFormatCombo.SelectedItem as ComboBoxItem;
+            return item == null ? "Auto" :
+                Convert.ToString(item.Content, CultureInfo.InvariantCulture);
         }
 
         private uint SelectedUartPort()
@@ -2465,6 +4268,451 @@ namespace TimeCardControlCenter
             LogTextBox.ScrollToEnd();
         }
 
+        private async void OpenNmea_Click(object sender, RoutedEventArgs e)
+        {
+            UartPortCombo.SelectedIndex = 3;
+            UartNav.IsChecked = true;
+            ShowPage("Uart");
+            await RefreshNmeaAsync(false);
+        }
+
+        private async void RefreshSubsystems_Click(object sender,
+                                                     RoutedEventArgs e)
+        {
+            await RefreshSubsystemsAsync();
+        }
+
+        private async Task RefreshSubsystemsAsync()
+        {
+            if (subsystemsRefreshing)
+                return;
+            if (client == null)
+            {
+                SubsystemGnss2StatusText.Text = "NOT PRESENT";
+                SubsystemGnss2StatusText.Foreground =
+                    (Brush)FindResource("GoldBrush");
+                SubsystemGnss2DetailText.Text = "Driver access is unavailable.";
+                return;
+            }
+            if (lastSnapshot == null || lastSnapshot.AbiVersion < 6)
+            {
+                SubsystemGnss2StatusText.Text = "DRIVER 1.12 / ABI 6 REQUIRED";
+                SubsystemGnss2StatusText.Foreground =
+                    (Brush)FindResource("GoldBrush");
+                SubsystemGnss2DetailText.Text =
+                    "Install the current driver for non-destructive UART activity detection.";
+                return;
+            }
+
+            subsystemsRefreshing = true;
+            StopUartMonitor();
+            SubsystemGnss2StatusText.Text = "LISTENING ON UART 1";
+            SubsystemGnss2StatusText.Foreground =
+                (Brush)FindResource("CyanBrush");
+            SubsystemGnss2DetailText.Text =
+                "Waiting up to 1.5 seconds for receiver data…";
+            try
+            {
+                UartObservation observation = await Task.Run(
+                    () => client.ObserveUart(1, 1500));
+                if (observation.IsPresent && observation.HasActivity)
+                {
+                    secondaryGnssPresent = true;
+                    SubsystemGnss2StatusText.Text = "PRESENT · UART DATA";
+                    SubsystemGnss2StatusText.Foreground =
+                        (Brush)FindResource("AccentBrush");
+                    SubsystemGnss2DetailText.Text = string.Format(
+                        CultureInfo.InvariantCulture,
+                        "Received activity detected; line status 0x{0:X2}.",
+                        observation.LineStatus);
+                }
+                else
+                {
+                    secondaryGnssPresent = false;
+                    SubsystemGnss2StatusText.Text = "NOT PRESENT";
+                    SubsystemGnss2StatusText.Foreground =
+                        (Brush)FindResource("GoldBrush");
+                    SubsystemGnss2DetailText.Text =
+                        "No data was received on UART 1 during the observation window.";
+                }
+            }
+            catch (Exception ex)
+            {
+                secondaryGnssPresent = false;
+                SubsystemGnss2StatusText.Text = "NOT PRESENT";
+                SubsystemGnss2StatusText.Foreground =
+                    (Brush)FindResource("GoldBrush");
+                SubsystemGnss2DetailText.Text = "UART observation failed: " + ex.Message;
+                Log("Secondary GNSS UART observation failed: " + ex.Message);
+            }
+            finally
+            {
+                subsystemsRefreshing = false;
+                UpdateBoardLedAutomationAsync(false);
+            }
+        }
+
+        private async void OpenFlash_Click(object sender, RoutedEventArgs e)
+        {
+            ShowPage("Flash");
+            await RefreshFlashAsync(true);
+        }
+
+        private async void RefreshFlash_Click(object sender, RoutedEventArgs e)
+        {
+            await RefreshFlashAsync(true);
+        }
+
+        private void BackToSubsystems_Click(object sender, RoutedEventArgs e)
+        {
+            SubsystemsNav.IsChecked = true;
+            ShowPage("Subsystems");
+        }
+
+        private async Task RefreshFlashAsync(bool showError)
+        {
+            if (flashUpdating)
+                return;
+            lastFlashStatus = null;
+            FlashControllerText.Text = "QUERYING";
+            FlashControllerText.Foreground = (Brush)FindResource("CyanBrush");
+            FlashJedecText.Text = "—";
+            FlashCapacityText.Text = "—";
+            FlashRegionText.Text = "—";
+            if (client == null || lastSnapshot == null)
+            {
+                FlashControllerText.Text = "NOT CONNECTED";
+                FlashControllerText.Foreground = (Brush)FindResource("GoldBrush");
+                FlashLogTextBox.Text = "Connect to the Time Card driver before querying SPI flash.";
+                UpdateFlashStartState();
+                return;
+            }
+            if (lastSnapshot.AbiVersion < 6)
+            {
+                FlashControllerText.Text = "ABI 6 REQUIRED";
+                FlashControllerText.Foreground = (Brush)FindResource("GoldBrush");
+                FlashLogTextBox.Text = "Install Time Card driver 1.12 or newer to enable guarded FPGA firmware updates.";
+                UpdateFlashStartState();
+                return;
+            }
+
+            try
+            {
+                FlashDeviceStatus status = await Task.Run(() => client.GetFlashStatus());
+                lastFlashStatus = status;
+                FlashControllerText.Text = status.IsSupported ? "READY" : "UNSUPPORTED";
+                FlashControllerText.Foreground = (Brush)FindResource(
+                    status.IsSupported ? "AccentBrush" : "GoldBrush");
+                FlashJedecText.Text = status.IsIdentified ? string.Format(
+                    CultureInfo.InvariantCulture, "0x{0:X6}", status.JedecId) : "NOT IDENTIFIED";
+                FlashCapacityText.Text = status.CapacityBytes == 0 ? "—" :
+                    string.Format(CultureInfo.InvariantCulture, "{0:N0} MiB",
+                        status.CapacityBytes / 1048576.0);
+                FlashRegionText.Text = status.CapacityBytes <= status.FirmwareOffset ? "—" :
+                    string.Format(CultureInfo.InvariantCulture, "0x{0:X8} · {1:N0} MiB",
+                        status.FirmwareOffset,
+                        (status.CapacityBytes - status.FirmwareOffset) / 1048576.0);
+                FlashLogTextBox.Text = string.Format(CultureInfo.InvariantCulture,
+                    "SPI controller 0x{0:X8}\r\nFIFO depth {1} byte(s)\r\nErase {2:N0} bytes · page {3:N0} bytes\r\nController status 0x{4:X8} · flash status 0x{5:X2}",
+                    status.ControllerOffset, status.FifoDepth, status.EraseSize,
+                    status.PageSize, status.ControllerStatus, status.FlashStatus);
+            }
+            catch (Exception ex)
+            {
+                FlashControllerText.Text = "QUERY FAILED";
+                FlashControllerText.Foreground = (Brush)FindResource("GoldBrush");
+                FlashLogTextBox.Text = ex.Message;
+                Log("SPI flash query failed: " + ex.Message);
+                if (showError)
+                    MessageBox.Show(this, ex.Message, "Unable to query SPI flash",
+                        MessageBoxButton.OK, MessageBoxImage.Error);
+            }
+            finally
+            {
+                UpdateFlashStartState();
+            }
+        }
+
+        private void ChooseFirmware_Click(object sender, RoutedEventArgs e)
+        {
+            Microsoft.Win32.OpenFileDialog dialog = new Microsoft.Win32.OpenFileDialog
+            {
+                Title = "Select FPGA firmware image",
+                Filter = "FPGA firmware (*.bin;*.fw;*.bit)|*.bin;*.fw;*.bit|All files (*.*)|*.*",
+                CheckFileExists = true,
+                Multiselect = false
+            };
+            if (dialog.ShowDialog(this) != true)
+                return;
+
+            try
+            {
+                byte[] file = File.ReadAllBytes(dialog.FileName);
+                if (file.Length == 0)
+                    throw new InvalidDataException("The selected firmware image is empty.");
+
+                bool wrapped = file.Length >= 4 && file[0] == (byte)'O' &&
+                    file[1] == (byte)'C' && file[2] == (byte)'P' &&
+                    file[3] == (byte)'C';
+                byte[] image;
+                string detail;
+                if (wrapped)
+                {
+                    if (file.Length < 16)
+                        throw new InvalidDataException("The OCPC firmware header is truncated.");
+                    ushort vendor = ReadBigEndian16(file, 4);
+                    ushort device = ReadBigEndian16(file, 6);
+                    uint declaredSize = ReadBigEndian32(file, 8);
+                    ushort hardwareRevision = ReadBigEndian16(file, 12);
+                    ushort expectedCrc = ReadBigEndian16(file, 14);
+                    if (vendor != 0x1d9b || device != 0x0400)
+                        throw new InvalidDataException(string.Format(
+                            CultureInfo.InvariantCulture,
+                            "This image targets PCI {0:X4}:{1:X4}, not the Time Card 1D9B:0400.",
+                            vendor, device));
+                    if (declaredSize != file.Length - 16)
+                        throw new InvalidDataException("The OCPC image length does not match its header.");
+                    ushort actualCrc = Crc16(file, 16, (int)declaredSize);
+                    if (expectedCrc != actualCrc)
+                        throw new InvalidDataException(string.Format(
+                            CultureInfo.InvariantCulture,
+                            "The OCPC CRC is invalid (expected 0x{0:X4}, calculated 0x{1:X4}).",
+                            expectedCrc, actualCrc));
+                    image = new byte[declaredSize];
+                    Buffer.BlockCopy(file, 16, image, 0, image.Length);
+                    detail = string.Format(CultureInfo.InvariantCulture,
+                        "Validated OCPC image · PCI 1D9B:0400 · hardware revision 0x{0:X4} · CRC 0x{1:X4} · {2:N0} bytes",
+                        hardwareRevision, actualCrc, image.Length);
+                }
+                else
+                {
+                    image = file;
+                    detail = string.Format(CultureInfo.InvariantCulture,
+                        "Raw image · no hardware identity or CRC header · {0:N0} bytes",
+                        image.Length);
+                }
+
+                if (lastFlashStatus != null && lastFlashStatus.CapacityBytes >
+                    lastFlashStatus.FirmwareOffset && image.LongLength >
+                    lastFlashStatus.CapacityBytes - lastFlashStatus.FirmwareOffset)
+                    throw new InvalidDataException("The firmware image does not fit in the protected FPGA image region.");
+
+                selectedFlashImage = image;
+                selectedFlashPath = dialog.FileName;
+                selectedFlashIsRaw = !wrapped;
+                FlashImagePathText.Text = Path.GetFileName(dialog.FileName);
+                FlashImageDetailText.Text = detail;
+                using (SHA256 sha = SHA256.Create())
+                    FlashHashText.Text = "SHA-256 " +
+                        BitConverter.ToString(sha.ComputeHash(image)).Replace("-", string.Empty);
+                FlashAcknowledgeCheckBox.IsChecked = false;
+                FlashProgressBar.Value = 0;
+                FlashProgressText.Text = "Image validated; acknowledgement required.";
+                FlashLogTextBox.Text = wrapped ?
+                    "OCPC wrapper validated. The 16-byte wrapper will not be written to flash." :
+                    "RAW IMAGE WARNING: compatibility cannot be established from the file. Confirm its source before continuing.";
+                UpdateFlashStartState();
+            }
+            catch (Exception ex)
+            {
+                selectedFlashImage = null;
+                selectedFlashPath = null;
+                selectedFlashIsRaw = false;
+                FlashImagePathText.Text = "Image rejected";
+                FlashImageDetailText.Text = ex.Message;
+                FlashHashText.Text = "SHA-256 —";
+                UpdateFlashStartState();
+                MessageBox.Show(this, ex.Message, "Invalid firmware image",
+                    MessageBoxButton.OK, MessageBoxImage.Error);
+            }
+        }
+
+        private void FlashAcknowledge_Changed(object sender, RoutedEventArgs e)
+        {
+            if (IsInitialized)
+                UpdateFlashStartState();
+        }
+
+        private void UpdateFlashStartState()
+        {
+            if (FlashStartButton == null)
+                return;
+            FlashStartButton.IsEnabled = !flashUpdating && client != null &&
+                lastSnapshot != null && lastSnapshot.AbiVersion >= 6 &&
+                lastFlashStatus != null && lastFlashStatus.IsSupported &&
+                selectedFlashImage != null && selectedFlashImage.Length != 0 &&
+                FlashAcknowledgeCheckBox.IsChecked == true;
+            FlashChooseButton.IsEnabled = !flashUpdating;
+        }
+
+        private async void FlashFirmware_Click(object sender, RoutedEventArgs e)
+        {
+            if (!FlashStartButton.IsEnabled || selectedFlashImage == null ||
+                lastFlashStatus == null)
+                return;
+            if (selectedFlashImage.LongLength > lastFlashStatus.CapacityBytes -
+                lastFlashStatus.FirmwareOffset)
+            {
+                MessageBox.Show(this, "The firmware image does not fit in the FPGA image region.",
+                    "Image too large", MessageBoxButton.OK, MessageBoxImage.Error);
+                return;
+            }
+
+            string rawWarning = selectedFlashIsRaw ?
+                "\n\nThis is a raw image with no OCPC hardware identity or CRC wrapper." : string.Empty;
+            MessageBoxResult confirmation = MessageBox.Show(this,
+                "Erase the current FPGA firmware, program " +
+                Path.GetFileName(selectedFlashPath) +
+                ", and verify every byte? Do not remove power during this operation." + rawWarning,
+                "Confirm FPGA firmware update", MessageBoxButton.YesNo,
+                MessageBoxImage.Warning, MessageBoxResult.No);
+            if (confirmation != MessageBoxResult.Yes)
+                return;
+
+            flashUpdating = true;
+            UpdateFlashStartState();
+            FlashAcknowledgeCheckBox.IsEnabled = false;
+            FlashProgressBar.Value = 0;
+            FlashLogTextBox.Clear();
+            FlashAppendLog("Firmware region starts at physical flash offset " +
+                string.Format(CultureInfo.InvariantCulture, "0x{0:X8}.",
+                    lastFlashStatus.FirmwareOffset));
+            try
+            {
+                byte[] image = (byte[])selectedFlashImage.Clone();
+                FlashDeviceStatus status = lastFlashStatus;
+                TimeCardClient operationClient = client;
+                await Task.Run(() => ProgramAndVerifyFlash(operationClient,
+                    status, image));
+                FlashReportProgress("Verified · power-cycle the card to load the new FPGA image.", 100);
+                FlashAppendLog("UPDATE COMPLETE. Read-back matches the selected firmware image.");
+                Log("FPGA firmware update completed and verified: " +
+                    Path.GetFileName(selectedFlashPath));
+                MessageBox.Show(this,
+                    "The FPGA firmware was programmed and verified. Power-cycle or reboot the card to load the new image.",
+                    "Firmware update complete", MessageBoxButton.OK,
+                    MessageBoxImage.Information);
+            }
+            catch (Exception ex)
+            {
+                FlashProgressText.Text = "FAILED · keep the card powered and retry with a known-good image";
+                FlashAppendLog("FAILED: " + ex.Message);
+                Log("FPGA firmware update failed: " + ex.Message);
+                MessageBox.Show(this,
+                    ex.Message + "\n\nThe previous FPGA image may be incomplete. Keep the card powered and retry with a known-good image.",
+                    "Firmware update failed", MessageBoxButton.OK,
+                    MessageBoxImage.Error);
+            }
+            finally
+            {
+                flashUpdating = false;
+                FlashAcknowledgeCheckBox.IsEnabled = true;
+                UpdateFlashStartState();
+            }
+        }
+
+        private void ProgramAndVerifyFlash(TimeCardClient operationClient,
+            FlashDeviceStatus status, byte[] image)
+        {
+            int eraseSize = checked((int)status.EraseSize);
+            int pageSize = checked((int)status.PageSize);
+            if (eraseSize <= 0 || pageSize <= 0 || pageSize > 256)
+                throw new InvalidOperationException("The flash geometry reported by the driver is invalid.");
+            int eraseCount = (image.Length + eraseSize - 1) / eraseSize;
+            int programCount = (image.Length + pageSize - 1) / pageSize;
+            int verifyCount = (image.Length + 255) / 256;
+            int totalOperations = eraseCount + programCount + verifyCount;
+            int completed = 0;
+
+            for (int sector = 0; sector < eraseCount; sector++)
+            {
+                uint offset = checked((uint)(sector * eraseSize));
+                FlashReportProgress(string.Format(CultureInfo.InvariantCulture,
+                    "Erasing sector {0:N0} of {1:N0}…", sector + 1, eraseCount),
+                    completed * 100.0 / totalOperations);
+                operationClient.EraseFlashSector(offset, status.EraseSize);
+                completed++;
+                FlashAppendLog(string.Format(CultureInfo.InvariantCulture,
+                    "Erased relative offset 0x{0:X8}", offset));
+            }
+
+            for (int offset = 0; offset < image.Length; offset += pageSize)
+            {
+                int length = Math.Min(pageSize, image.Length - offset);
+                byte[] page = new byte[length];
+                Buffer.BlockCopy(image, offset, page, 0, length);
+                FlashReportProgress(string.Format(CultureInfo.InvariantCulture,
+                    "Programming {0:N0} of {1:N0} bytes…", offset + length,
+                    image.Length), completed * 100.0 / totalOperations);
+                operationClient.ProgramFlashPage((uint)offset, page);
+                completed++;
+            }
+            FlashAppendLog(string.Format(CultureInfo.InvariantCulture,
+                "Programmed {0:N0} bytes.", image.Length));
+
+            for (int offset = 0; offset < image.Length; offset += 256)
+            {
+                int length = Math.Min(256, image.Length - offset);
+                FlashReportProgress(string.Format(CultureInfo.InvariantCulture,
+                    "Verifying {0:N0} of {1:N0} bytes…", offset + length,
+                    image.Length), completed * 100.0 / totalOperations);
+                byte[] actual = operationClient.ReadFlash((uint)offset,
+                    (uint)length);
+                for (int index = 0; index < length; index++)
+                {
+                    if (actual[index] != image[offset + index])
+                        throw new InvalidDataException(string.Format(
+                            CultureInfo.InvariantCulture,
+                            "Read-back mismatch at relative flash offset 0x{0:X8} (expected 0x{1:X2}, read 0x{2:X2}).",
+                            offset + index, image[offset + index], actual[index]));
+                }
+                completed++;
+            }
+        }
+
+        private void FlashReportProgress(string message, double percent)
+        {
+            Dispatcher.Invoke(new Action(() =>
+            {
+                FlashProgressText.Text = message;
+                FlashProgressBar.Value = Math.Max(0, Math.Min(100, percent));
+            }));
+        }
+
+        private void FlashAppendLog(string message)
+        {
+            Dispatcher.Invoke(new Action(() =>
+            {
+                FlashLogTextBox.AppendText(string.Format(CultureInfo.InvariantCulture,
+                    "[{0:HH:mm:ss}] {1}\r\n", DateTime.Now, message));
+                FlashLogTextBox.ScrollToEnd();
+            }));
+        }
+
+        private static ushort ReadBigEndian16(byte[] value, int offset)
+        {
+            return (ushort)((value[offset] << 8) | value[offset + 1]);
+        }
+
+        private static uint ReadBigEndian32(byte[] value, int offset)
+        {
+            return ((uint)value[offset] << 24) | ((uint)value[offset + 1] << 16) |
+                ((uint)value[offset + 2] << 8) | value[offset + 3];
+        }
+
+        private static ushort Crc16(byte[] value, int offset, int length)
+        {
+            ushort crc = 0xffff;
+            for (int index = 0; index < length; index++)
+            {
+                crc ^= value[offset + index];
+                for (int bit = 0; bit < 8; bit++)
+                    crc = (ushort)(((crc & 1) != 0) ?
+                        ((crc >> 1) ^ 0xa001) : (crc >> 1));
+            }
+            return crc;
+        }
+
         private async void Navigate_Checked(object sender, RoutedEventArgs e)
         {
             RadioButton button = sender as RadioButton;
@@ -2480,8 +4728,12 @@ namespace TimeCardControlCenter
                 await RefreshNmeaAsync(false);
             else if (page == "Sma")
                 await RefreshSmaAsync();
+            else if (page == "Timing")
+                await RefreshTimingAsync();
             else if (page == "I2c")
                 await RefreshI2cAsync(false);
+            else if (page == "Subsystems")
+                await RefreshSubsystemsAsync();
         }
 
         private void ShowPage(string name)
@@ -2494,18 +4746,27 @@ namespace TimeCardControlCenter
             AtomicPage.Visibility = name == "Atomic" ? Visibility.Visible : Visibility.Collapsed;
             UartPage.Visibility = name == "Uart" ? Visibility.Visible : Visibility.Collapsed;
             SmaPage.Visibility = name == "Sma" ? Visibility.Visible : Visibility.Collapsed;
+            TimingPage.Visibility = name == "Timing" ? Visibility.Visible : Visibility.Collapsed;
             I2cPage.Visibility = name == "I2c" ? Visibility.Visible : Visibility.Collapsed;
+            FlashPage.Visibility = name == "Flash" ? Visibility.Visible : Visibility.Collapsed;
             SubsystemsPage.Visibility = name == "Subsystems" ? Visibility.Visible : Visibility.Collapsed;
             DiagnosticsPage.Visibility = name == "Diagnostics" ? Visibility.Visible : Visibility.Collapsed;
             string title = name == "Gnss" ? "GNSS & Time-of-Day" :
                 name == "Atomic" ? "Atomic Clock" :
                 name == "Uart" ? "UART Console" :
                 name == "Sma" ? "SMA Connectors" :
+                name == "Timing" ? "Generators & Frequency" :
+                name == "Flash" ? "FPGA SPI Flash" :
                 name == "I2c" ? "I²C Bus" : name;
             TopPageTitle.Text = title;
         }
 
         private void Elevate_Click(object sender, RoutedEventArgs e)
+        {
+            RestartAsAdministrator();
+        }
+
+        private bool RestartAsAdministrator()
         {
             try
             {
@@ -2513,15 +4774,68 @@ namespace TimeCardControlCenter
                 {
                     FileName = Assembly.GetEntryAssembly().Location,
                     UseShellExecute = true,
-                    Verb = "runas"
+                    Verb = "runas",
+                    Arguments = string.Join(" ", startupArguments.Skip(1).Select(QuoteProcessArgument))
                 };
                 Process.Start(startInfo);
                 Application.Current.Shutdown();
+                return true;
             }
             catch (Win32Exception ex)
             {
                 Log("Elevation was not completed: " + ex.Message);
+                return false;
             }
+        }
+
+        private static bool HasAdministratorAccess()
+        {
+            try
+            {
+                using (WindowsIdentity identity = WindowsIdentity.GetCurrent())
+                {
+                    WindowsPrincipal principal = new WindowsPrincipal(identity);
+                    return principal.IsInRole(WindowsBuiltInRole.Administrator);
+                }
+            }
+            catch
+            {
+                return false;
+            }
+        }
+
+        private static string QuoteProcessArgument(string argument)
+        {
+            if (string.IsNullOrEmpty(argument))
+                return "\"\"";
+            if (!argument.Any(character => char.IsWhiteSpace(character) || character == '\"'))
+                return argument;
+
+            StringBuilder quoted = new StringBuilder("\"");
+            int backslashes = 0;
+            foreach (char character in argument)
+            {
+                if (character == '\\')
+                {
+                    backslashes++;
+                    continue;
+                }
+
+                if (character == '\"')
+                {
+                    quoted.Append('\\', (backslashes * 2) + 1);
+                    quoted.Append('\"');
+                    backslashes = 0;
+                    continue;
+                }
+
+                quoted.Append('\\', backslashes);
+                backslashes = 0;
+                quoted.Append(character);
+            }
+            quoted.Append('\\', backslashes * 2);
+            quoted.Append('\"');
+            return quoted.ToString();
         }
 
         private void ConnectionChip_Click(object sender, RoutedEventArgs e)

--- a/DRV/Windows/TimeCardControlCenter/Models.cs
+++ b/DRV/Windows/TimeCardControlCenter/Models.cs
@@ -125,6 +125,36 @@ namespace TimeCardControlCenter
     }
 
     [StructLayout(LayoutKind.Sequential)]
+    internal struct TimeCardI2cMuxControlRaw
+    {
+        public uint Size;
+        public uint ChannelMask;
+        public uint Present;
+        public uint ControllerStatus;
+        public uint InterruptStatus;
+        public uint Reserved0;
+        public uint Reserved1;
+        public uint Reserved2;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    internal struct TimeCardLedControlRaw
+    {
+        public uint Size;
+        public uint Led;
+        public uint Flags;
+        public uint Red;
+        public uint Green;
+        public uint Blue;
+        public uint GlobalCurrent;
+        public uint MuxChannelMask;
+        public uint ControllerStatus;
+        public uint InterruptStatus;
+        public uint Reserved0;
+        public uint Reserved1;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
     internal struct TimeCardClockSourceRaw
     {
         public uint Size;
@@ -167,6 +197,79 @@ namespace TimeCardControlCenter
         public byte Serial5;
         public byte Reserved0;
         public byte Reserved1;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    internal struct TimeCardSignalControlRaw
+    {
+        public uint Size;
+        public uint Generator;
+        public uint Flags;
+        public uint Status;
+        public uint Version;
+        public uint RepeatCount;
+        public uint StartNanoseconds;
+        public uint Reserved;
+        public ulong PeriodNanoseconds;
+        public ulong PulseNanoseconds;
+        public ulong PhaseNanoseconds;
+        public ulong StartSeconds;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    internal struct TimeCardFrequencyControlRaw
+    {
+        public uint Size;
+        public uint Counter;
+        public uint Flags;
+        public uint IntegrationSeconds;
+        public uint FrequencyHz;
+        public uint Control;
+        public uint Status;
+        public uint Reserved;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    internal struct TimeCardFlashStatusRaw
+    {
+        public uint Size;
+        public uint Flags;
+        public uint Offset;
+        public uint JedecId;
+        public uint CapacityBytes;
+        public uint FirmwareOffset;
+        public uint EraseSize;
+        public uint PageSize;
+        public uint ControllerStatus;
+        public uint FlashStatus;
+        public uint FifoDepth;
+        public uint Reserved0;
+        public uint Reserved1;
+        public uint Reserved2;
+        public uint Reserved3;
+        public uint Reserved4;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    internal struct TimeCardFlashRangeRaw
+    {
+        public uint Size;
+        public uint Offset;
+        public uint Length;
+        public uint Reserved;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    internal struct TimeCardUartObserveRaw
+    {
+        public uint Size;
+        public uint Port;
+        public uint TimeoutMilliseconds;
+        public uint Flags;
+        public uint LineStatus;
+        public uint Reserved0;
+        public uint Reserved1;
+        public uint Reserved2;
     }
 
     public enum SmaDirection : uint
@@ -267,6 +370,50 @@ namespace TimeCardControlCenter
         public uint InterruptStatus { get; private set; }
     }
 
+    public sealed class I2cMuxState
+    {
+        internal I2cMuxState(TimeCardI2cMuxControlRaw value)
+        {
+            ChannelMask = value.ChannelMask;
+            IsPresent = value.Present != 0;
+            ControllerStatus = value.ControllerStatus;
+            InterruptStatus = value.InterruptStatus;
+        }
+
+        public uint ChannelMask { get; private set; }
+        public bool IsPresent { get; private set; }
+        public uint ControllerStatus { get; private set; }
+        public uint InterruptStatus { get; private set; }
+    }
+
+    public sealed class BoardLedState
+    {
+        internal BoardLedState(TimeCardLedControlRaw value)
+        {
+            Led = value.Led;
+            IsPresent = (value.Flags & 1u) != 0;
+            IsEnabled = (value.Flags & 2u) != 0;
+            Red = (byte)value.Red;
+            Green = (byte)value.Green;
+            Blue = (byte)value.Blue;
+            GlobalCurrent = (byte)value.GlobalCurrent;
+            MuxChannelMask = value.MuxChannelMask;
+            ControllerStatus = value.ControllerStatus;
+            InterruptStatus = value.InterruptStatus;
+        }
+
+        public uint Led { get; private set; }
+        public bool IsPresent { get; private set; }
+        public bool IsEnabled { get; private set; }
+        public byte Red { get; private set; }
+        public byte Green { get; private set; }
+        public byte Blue { get; private set; }
+        public byte GlobalCurrent { get; private set; }
+        public uint MuxChannelMask { get; private set; }
+        public uint ControllerStatus { get; private set; }
+        public uint InterruptStatus { get; private set; }
+    }
+
     public sealed class NmeaOutputState
     {
         internal NmeaOutputState(TimeCardNmeaControlRaw value)
@@ -306,6 +453,124 @@ namespace TimeCardControlCenter
         public bool IsValid { get; private set; }
         public byte[] SerialBytes { get; private set; }
         public string SerialNumber { get; private set; }
+    }
+
+    public sealed class SignalGeneratorState
+    {
+        internal SignalGeneratorState(TimeCardSignalControlRaw value)
+        {
+            Generator = value.Generator;
+            IsPresent = (value.Flags & 1u) != 0;
+            IsEnabled = (value.Flags & 2u) != 0;
+            IsInverted = (value.Flags & 4u) != 0;
+            Status = value.Status;
+            Version = value.Version;
+            RepeatCount = value.RepeatCount;
+            PeriodNanoseconds = value.PeriodNanoseconds;
+            PulseNanoseconds = value.PulseNanoseconds;
+            PhaseNanoseconds = value.PhaseNanoseconds;
+            StartSeconds = value.StartSeconds;
+            StartNanoseconds = value.StartNanoseconds;
+        }
+
+        public uint Generator { get; private set; }
+        public bool IsPresent { get; private set; }
+        public bool IsEnabled { get; private set; }
+        public bool IsInverted { get; private set; }
+        public uint Status { get; private set; }
+        public uint Version { get; private set; }
+        public uint RepeatCount { get; private set; }
+        public ulong PeriodNanoseconds { get; private set; }
+        public ulong PulseNanoseconds { get; private set; }
+        public ulong PhaseNanoseconds { get; private set; }
+        public ulong StartSeconds { get; private set; }
+        public uint StartNanoseconds { get; private set; }
+        public double FrequencyHz
+        {
+            get { return PeriodNanoseconds == 0 ? 0 : 1000000000.0 / PeriodNanoseconds; }
+        }
+        public double DutyPercent
+        {
+            get { return PeriodNanoseconds == 0 ? 0 : PulseNanoseconds * 100.0 / PeriodNanoseconds; }
+        }
+    }
+
+    public sealed class FrequencyCounterState
+    {
+        internal FrequencyCounterState(TimeCardFrequencyControlRaw value)
+        {
+            Counter = value.Counter;
+            IsPresent = (value.Flags & 1u) != 0;
+            IsEnabled = (value.Flags & 2u) != 0;
+            IsValid = (value.Flags & 4u) != 0;
+            HasError = (value.Flags & 8u) != 0;
+            HasOverrun = (value.Flags & 16u) != 0;
+            IntegrationSeconds = value.IntegrationSeconds;
+            FrequencyHz = value.FrequencyHz;
+            Control = value.Control;
+            Status = value.Status;
+        }
+
+        public uint Counter { get; private set; }
+        public bool IsPresent { get; private set; }
+        public bool IsEnabled { get; private set; }
+        public bool IsValid { get; private set; }
+        public bool HasError { get; private set; }
+        public bool HasOverrun { get; private set; }
+        public uint IntegrationSeconds { get; private set; }
+        public uint FrequencyHz { get; private set; }
+        public uint Control { get; private set; }
+        public uint Status { get; private set; }
+    }
+
+    public sealed class FlashDeviceStatus
+    {
+        internal FlashDeviceStatus(TimeCardFlashStatusRaw value)
+        {
+            IsPresent = (value.Flags & 1u) != 0;
+            IsIdentified = (value.Flags & 2u) != 0;
+            IsSupported = (value.Flags & 4u) != 0;
+            UsesFourByteAddressing = (value.Flags & 8u) != 0;
+            ControllerOffset = value.Offset;
+            JedecId = value.JedecId;
+            CapacityBytes = value.CapacityBytes;
+            FirmwareOffset = value.FirmwareOffset;
+            EraseSize = value.EraseSize;
+            PageSize = value.PageSize;
+            ControllerStatus = value.ControllerStatus;
+            FlashStatus = value.FlashStatus;
+            FifoDepth = value.FifoDepth;
+        }
+
+        public bool IsPresent { get; private set; }
+        public bool IsIdentified { get; private set; }
+        public bool IsSupported { get; private set; }
+        public bool UsesFourByteAddressing { get; private set; }
+        public uint ControllerOffset { get; private set; }
+        public uint JedecId { get; private set; }
+        public uint CapacityBytes { get; private set; }
+        public uint FirmwareOffset { get; private set; }
+        public uint EraseSize { get; private set; }
+        public uint PageSize { get; private set; }
+        public uint ControllerStatus { get; private set; }
+        public uint FlashStatus { get; private set; }
+        public uint FifoDepth { get; private set; }
+    }
+
+    public sealed class UartObservation
+    {
+        internal UartObservation(TimeCardUartObserveRaw value)
+        {
+            Port = value.Port;
+            IsPresent = (value.Flags & 1u) != 0;
+            HasActivity = (value.Flags & 2u) != 0;
+            LineStatus = value.LineStatus;
+        }
+
+        public uint Port { get; private set; }
+        public bool IsPresent { get; private set; }
+        public bool HasActivity { get; private set; }
+        public uint LineStatus { get; private set; }
     }
 
     public sealed class TimeCardSnapshot

--- a/DRV/Windows/TimeCardControlCenter/Properties/AssemblyInfo.cs
+++ b/DRV/Windows/TimeCardControlCenter/Properties/AssemblyInfo.cs
@@ -9,5 +9,5 @@ using System.Windows;
 [assembly: AssemblyCopyright("Copyright © Open Compute Project contributors")]
 [assembly: ComVisible(false)]
 [assembly: ThemeInfo(ResourceDictionaryLocation.None, ResourceDictionaryLocation.SourceAssembly)]
-[assembly: AssemblyVersion("1.9.0.0")]
-[assembly: AssemblyFileVersion("1.9.0.0")]
+[assembly: AssemblyVersion("1.13.0.0")]
+[assembly: AssemblyFileVersion("1.13.0.0")]

--- a/DRV/Windows/TimeCardControlCenter/README.md
+++ b/DRV/Windows/TimeCardControlCenter/README.md
@@ -18,13 +18,16 @@ it does not shell out to `timecardctl` or scrape Device Manager.
 - Decoded GNSS fix and seen/locked satellite counts from the ToD engine.
 - Direct u-blox receiver discovery and UBX telemetry, including model,
   firmware/protocol, fix, UTC, position accuracy, visible/used satellites,
-  constellation counts, and average carrier-to-noise level. Compatible
+  constellation counts, average carrier-to-noise level, and a vendor-style
+  polar sky map with per-satellite elevation, azimuth, signal strength,
+  constellation, tracking quality, and solution-use state. Compatible
   configuration-database receivers expose navigation rate and platform model,
   constellation selection, TP1 timing, and UART 1 message-rate controls.
-- Guarded one-shot synchronization in both directions between Windows UTC and
+- Guarded one-shot synchronization in both directions between system UTC and
   the Time Card PHC.
-- Polled UART configuration, monitoring, text/hex display, and text or binary
-  transmission for GNSS, GNSS2, atomic-clock, and NMEA ports.
+- Polled UART configuration and monitoring with Auto, ASCII, hexadecimal,
+  decimal, and binary display modes, plus text or binary transmission for
+  GNSS, GNSS2, atomic-clock, and NMEA ports.
 - FPGA NMEA sentence-generator enable, baud, and polarity configuration with
   one-click synchronized UART monitoring.
 - A dedicated Microchip MAC-SA53 workspace with live identity, physics-lock,
@@ -34,12 +37,22 @@ it does not shell out to `timecardctl` or scrape Device Manager.
   thresholds, PPS quantization correction, and the time-of-day counter.
 - Four-connector SMA routing with input/output menus, named FPGA timing
   signals, fixed-direction detection, raw-map readback, and output warnings.
-- A read-only I2C workbench with AXI IIC health, known-device probing, full
-  7-bit discovery, a bounded EEPROM/register hex and ASCII reader, and the
+- A dedicated timing workspace for four PHC-aligned periodic signal generators
+  and four frequency counters, with frequency, duty, phase, polarity,
+  integration-window, and direct SMA routing controls.
+- A non-programming I2C workbench with AXI IIC health, known-device probing,
+  full 7-bit discovery, EEPROM/register presets and paging, adjustable timeout,
+  hex/ASCII/decimal/binary views, decoded transaction diagnostics, and the
   unique card serial from the 24MAC402 identity EEPROM.
 - Runtime and persistent Device Manager subsystem-hierarchy controls.
+- A guarded FPGA SPI-flash workspace with JEDEC/geometry discovery, OCPC
+  vendor/device/length/CRC validation, explicit raw-image warnings, protected
+  4 KiB erase and page programming, progress reporting, and full read-back
+  verification.
 - Copyable engineering diagnostics and an in-application session log.
-- A subsystem capability map using the same artwork as Device Manager.
+- A subsystem capability map using the same artwork as Device Manager, direct
+  links to NMEA and generator/frequency configuration, and a non-destructive
+  UART activity check that reports GNSS2 as `NOT PRESENT` when it is silent.
 
 ## Build
 
@@ -75,6 +88,7 @@ automation:
 TimeCardControlCenter.exe --page Clock
 TimeCardControlCenter.exe --page Uart --uart-port=3
 TimeCardControlCenter.exe --page Sma
+TimeCardControlCenter.exe --page Timing
 ```
 
 For repeatable documentation and visual regression checks, `--capture` renders
@@ -100,6 +114,10 @@ UART framing is currently 8N1. Reads and writes are limited to 256 bytes, and
 timeouts are clamped to five seconds. An idle read is treated as a normal
 zero-byte monitor sample rather than an application error.
 
+The display selector can automatically choose a readable representation or
+show every byte explicitly as ASCII, hexadecimal, decimal, or binary. Changing
+the selection re-renders the retained console history without another read.
+
 The UART selectors use an application-owned dark template so their selected
 values, editable baud field, and dropdown entries remain readable regardless
 of the active Windows theme.
@@ -123,12 +141,17 @@ remove PHC synchronization. Time-of-Day/GNSS is the normal Time Card setting.
 ## Clock synchronization
 
 The **Overview** workspace provides both synchronization directions. **Sync
-from Windows** writes the current Windows UTC value to the PHC. **Sync from
+from System Clock** writes the current system UTC value to the PHC. **Sync from
 Time Card** reads a fresh bracketed PHC cross-timestamp and sets Windows UTC
 from the card after explicit confirmation. The second operation requires
 administrator privileges and is blocked when the PHC date is outside 2020 to
 2100, preventing an uninitialized clock such as 1970 from replacing a valid
 system time. Windows accepts this one-shot value at millisecond resolution.
+
+The **Overview** and **Precision Clock** workspaces retain matching 60-second
+histories for measured system-clock offset and cross-timestamp sampling
+uncertainty. Offset plots remain centered on zero with a stable minimum
+vertical range and expand automatically when the measured offset grows.
 
 ## u-blox GNSS configuration
 
@@ -140,6 +163,13 @@ many other u-blox generations. The recommended RCB-F9T normally uses UART 0 at
 115,200 baud on the Time Card; the host baud selector can communicate with a
 receiver at another existing baud without changing the receiver's own port
 configuration.
+
+The satellite sky map decodes every repeated `UBX-NAV-SAT` block. It uses the
+standard north-up polar layout with zenith at the center and the horizon at the
+outer ring. Marker color identifies the constellation, marker size follows
+C/N₀, and a white outline identifies a satellite used in the navigation
+solution. The adjacent scrollable signal table exposes elevation, azimuth,
+C/N₀, and tracking quality for every reported satellite.
 
 Receivers supporting `UBX-CFG-VALGET` and `UBX-CFG-VALSET` expose four
 independently detected control groups:
@@ -198,24 +228,84 @@ Routing changes are immediate. Disconnect externally driven equipment before
 changing a connector to output. The application asks for confirmation before
 applying any output route.
 
+## Generators and frequency counters
+
+Driver 1.10 / ABI 5 exposes four bounded periodic-output modules and four
+frequency counters without permitting arbitrary MMIO. Each generator accepts
+a frequency, 1–99% duty cycle, phase in nanoseconds, and polarity. The driver
+converts these into period and pulse widths, schedules the next start against
+the PHC, and applies the same disable/program/enable sequence used by Linux
+`ptp_ocp`. A generator can be routed directly to any compatible SMA output.
+
+Each frequency counter accepts an integration window of 0 (disabled) or
+1–255 seconds. The workspace decodes valid, error, and overrun states and can
+route any front-panel SMA input to `FREQ1` through `FREQ4`.
+
 ## I2C workbench
 
 Driver ABI 3 adds bounded Xilinx AXI IIC status, address-only probe, and read
 operations using the register layout and transfer flow used by Linux
 `i2c-xiic`. The application recognizes the board 24C02 EEPROM at `0x50` and
 the 24MAC402 identity EEPROM at `0x58`, can scan all normal 7-bit addresses,
-and displays reads as hex plus ASCII. The six bytes at MAC EEPROM offset zero
-are formatted as the card's unique serial number, the same mapping used by
-Linux `ptp_ocp` and its `serialnum` attribute.
+and displays reads as hex plus ASCII, hex, ASCII, decimal, or binary. Presets,
+previous/next page navigation, a 50/100/250 ms timeout selector, copy, an ACK
+map, and decoded control/status/interrupt flags support bus diagnosis. The six
+bytes at MAC EEPROM offset zero are formatted as the card's unique serial
+number, the same mapping used by Linux `ptp_ocp` and its `serialnum` attribute.
 
 Reads support no subaddress or a one- or two-byte subaddress followed by a
 repeated start. Transfers are limited to 255 bytes and a bounded timeout.
-I2C data writes and EEPROM programming remain intentionally unavailable until
-they have been validated on hardware.
+Driver 1.11 fixes the repeated-start receive race by separating the subaddress
+and receive phases, servicing the AXI IIC receive watermark before interpreting
+its shared `TX_ERROR`/final-NACK bit, advancing the watermark across FIFO-sized
+chunks, and retrying once after controller reset for transient failures. Native
+Win32 error text and a post-failure controller snapshot are shown if a read
+still fails. The Control Center requires driver 1.11 or newer for reads and
+identifies older drivers before they can surface the misleading Windows CRC
+error; the current supported package is driver 1.13.
+
+Driver 1.13 / ABI 7 adds dedicated controls for the schematic's U27 PCA9546A
+at `0x70`. Channel 0 is the MAC-clock branch, channel 1 contains the onboard
+sensors and RGB LED driver, channel 2 is the analog/ADC expansion branch, and
+channel 3 is the DC expansion branch. The workspace shows the selected mask,
+offers safe single-branch shortcuts, annotates full scans with the expected
+BNO055, INA219, BME280, and IS32FL3207 addresses, and provides matching read
+presets.
+
+U26, the TMUX1072 near the MAC connector, is controlled by the physical
+`MACSER` DIP only; the select net is not routed to the FPGA. The workspace
+therefore explains that channel 0 also requires `MACSER=0` instead of exposing
+a non-functional software toggle.
+
+The IS32FL3207 at `0x6e` drives six common-anode RGB indicators: GNSS1 uses
+OUT1â€“3, GNSS2 OUT4â€“6, and IO1 through IO4 use OUT7â€“18 in groups of three.
+Manual RGB/current controls and automatic status mapping are available.
+Automatic mode uses green for a GNSS fix or configured SMA output, blue for an
+SMA input, amber for searching/unknown/disabled states, and red for missing or
+failed status. LED transactions temporarily select sensor channel 1 and then
+restore the user's PCA9546A mask. The driver caps global current at 128 and
+does not expose a general data-write or EEPROM-programming IOCTL.
+
+## FPGA SPI flash
+
+Driver 1.12 / ABI 6 exposes only the FPGA firmware portion of SPI-NOR. The
+configuration area below physical offset `0x00400000` cannot be addressed by
+the public IOCTLs. Erases are fixed to aligned 4 KiB sectors, programs cannot
+cross the reported 256-byte page boundary, and reads/programs are limited to
+256 bytes per request.
+
+The workspace accepts the `OCPC` wrapper used by Linux `ptp_ocp`; it verifies
+the PCI identity (`1D9B:0400`), declared payload length, and CRC16 before
+stripping the wrapper. Raw images are allowed only with a prominent warning
+and the same explicit acknowledgement as wrapped images. An update erases the
+required sectors, programs every page, then reads and compares every payload
+byte. Closing the application is blocked while this operation runs. Keep the
+card powered throughout and power-cycle it only after verification succeeds.
 
 ## Driver API roadmap
 
 The current ABI deliberately does not expose arbitrary register writes for
-SMA polarity/calibration, signal generators, I2C data writes, flash, or PTM.
+SMA polarity/calibration, I2C data writes, the protected flash configuration
+region, or PTM.
 Those controls should be enabled only after dedicated, validated kernel IOCTLs
 are added using the Linux driver behavior as the reference.

--- a/DRV/Windows/TimeCardControlCenter/RollingTelemetryChart.cs
+++ b/DRV/Windows/TimeCardControlCenter/RollingTelemetryChart.cs
@@ -1,0 +1,290 @@
+using System;
+using System.Collections.Generic;
+using System.Windows;
+using System.Windows.Media;
+
+namespace TimeCardControlCenter
+{
+    public sealed class RollingTelemetryChart : FrameworkElement
+    {
+        public static readonly DependencyProperty LineBrushProperty = DependencyProperty.Register(
+            "LineBrush", typeof(Brush), typeof(RollingTelemetryChart),
+            new FrameworkPropertyMetadata(Brushes.DeepSkyBlue,
+                FrameworkPropertyMetadataOptions.AffectsRender));
+
+        public static readonly DependencyProperty AreaBrushProperty = DependencyProperty.Register(
+            "AreaBrush", typeof(Brush), typeof(RollingTelemetryChart),
+            new FrameworkPropertyMetadata(Brushes.Transparent,
+                FrameworkPropertyMetadataOptions.AffectsRender));
+
+        public static readonly DependencyProperty CenterZeroProperty = DependencyProperty.Register(
+            "CenterZero", typeof(bool), typeof(RollingTelemetryChart),
+            new FrameworkPropertyMetadata(false,
+                FrameworkPropertyMetadataOptions.AffectsRender));
+
+        public static readonly DependencyProperty MinimumCenteredExtentProperty =
+            DependencyProperty.Register(
+                "MinimumCenteredExtent", typeof(double),
+                typeof(RollingTelemetryChart),
+                new FrameworkPropertyMetadata(0.0,
+                    FrameworkPropertyMetadataOptions.AffectsRender));
+
+        public static readonly DependencyProperty MinimumRangeProperty =
+            DependencyProperty.Register(
+                "MinimumRange", typeof(double),
+                typeof(RollingTelemetryChart),
+                new FrameworkPropertyMetadata(0.0,
+                    FrameworkPropertyMetadataOptions.AffectsRender));
+
+        private readonly List<double> samples = new List<double>();
+        private int capacity = 60;
+
+        public RollingTelemetryChart()
+        {
+            SnapsToDevicePixels = true;
+            Focusable = false;
+        }
+
+        public Brush LineBrush
+        {
+            get { return (Brush)GetValue(LineBrushProperty); }
+            set { SetValue(LineBrushProperty, value); }
+        }
+
+        public Brush AreaBrush
+        {
+            get { return (Brush)GetValue(AreaBrushProperty); }
+            set { SetValue(AreaBrushProperty, value); }
+        }
+
+        public bool CenterZero
+        {
+            get { return (bool)GetValue(CenterZeroProperty); }
+            set { SetValue(CenterZeroProperty, value); }
+        }
+
+        public double MinimumCenteredExtent
+        {
+            get { return (double)GetValue(MinimumCenteredExtentProperty); }
+            set { SetValue(MinimumCenteredExtentProperty, value); }
+        }
+
+        public double MinimumRange
+        {
+            get { return (double)GetValue(MinimumRangeProperty); }
+            set { SetValue(MinimumRangeProperty, value); }
+        }
+
+        public int Capacity
+        {
+            get { return capacity; }
+            set
+            {
+                capacity = Math.Max(2, value);
+                TrimToCapacity();
+                InvalidateVisual();
+            }
+        }
+
+        public int SampleCount { get { return samples.Count; } }
+
+        public double Minimum
+        {
+            get
+            {
+                if (samples.Count == 0)
+                    return 0;
+                double value = samples[0];
+                for (int index = 1; index < samples.Count; index++)
+                    value = Math.Min(value, samples[index]);
+                return value;
+            }
+        }
+
+        public double Maximum
+        {
+            get
+            {
+                if (samples.Count == 0)
+                    return 0;
+                double value = samples[0];
+                for (int index = 1; index < samples.Count; index++)
+                    value = Math.Max(value, samples[index]);
+                return value;
+            }
+        }
+
+        public double VisibleMinimum
+        {
+            get
+            {
+                double minimum;
+                double maximum;
+                GetScaleBounds(out minimum, out maximum);
+                return minimum;
+            }
+        }
+
+        public double VisibleMaximum
+        {
+            get
+            {
+                double minimum;
+                double maximum;
+                GetScaleBounds(out minimum, out maximum);
+                return maximum;
+            }
+        }
+
+        public void AddSample(double value)
+        {
+            if (double.IsNaN(value) || double.IsInfinity(value))
+                return;
+            samples.Add(value);
+            TrimToCapacity();
+            InvalidateVisual();
+        }
+
+        public void Clear()
+        {
+            samples.Clear();
+            InvalidateVisual();
+        }
+
+        protected override void OnRender(DrawingContext drawingContext)
+        {
+            base.OnRender(drawingContext);
+            if (ActualWidth < 2 || ActualHeight < 2)
+                return;
+
+            Rect plot = new Rect(0.5, 0.5,
+                Math.Max(1, ActualWidth - 1), Math.Max(1, ActualHeight - 1));
+            Pen gridPen = new Pen(new SolidColorBrush(Color.FromArgb(38, 143, 166, 187)), 1);
+            gridPen.Freeze();
+
+            for (int index = 0; index <= 4; index++)
+            {
+                double x = plot.Left + (plot.Width * index / 4.0);
+                double y = plot.Top + (plot.Height * index / 4.0);
+                drawingContext.DrawLine(gridPen, new Point(x, plot.Top), new Point(x, plot.Bottom));
+                drawingContext.DrawLine(gridPen, new Point(plot.Left, y), new Point(plot.Right, y));
+            }
+
+            if (samples.Count == 0)
+                return;
+
+            double minimum;
+            double maximum;
+            GetScaleBounds(out minimum, out maximum);
+
+            if (minimum < 0 && maximum > 0)
+            {
+                double zeroY = ValueToY(0, minimum, maximum, plot);
+                Pen zeroPen = new Pen(new SolidColorBrush(Color.FromArgb(82, 76, 201, 240)), 1);
+                zeroPen.Freeze();
+                drawingContext.DrawLine(zeroPen,
+                    new Point(plot.Left, zeroY), new Point(plot.Right, zeroY));
+            }
+
+            Point[] points = new Point[samples.Count];
+            for (int index = 0; index < samples.Count; index++)
+            {
+                double x = samples.Count == 1 ? plot.Right :
+                    plot.Left + (plot.Width * index / (samples.Count - 1.0));
+                points[index] = new Point(x,
+                    ValueToY(samples[index], minimum, maximum, plot));
+            }
+
+            drawingContext.PushClip(new RectangleGeometry(plot));
+
+            StreamGeometry area = new StreamGeometry();
+            using (StreamGeometryContext context = area.Open())
+            {
+                context.BeginFigure(new Point(points[0].X, plot.Bottom), true, true);
+                context.LineTo(points[0], true, false);
+                for (int index = 1; index < points.Length; index++)
+                    context.LineTo(points[index], true, false);
+                context.LineTo(new Point(points[points.Length - 1].X, plot.Bottom), true, false);
+            }
+            area.Freeze();
+            drawingContext.DrawGeometry(AreaBrush, null, area);
+
+            if (points.Length > 1)
+            {
+                StreamGeometry line = new StreamGeometry();
+                using (StreamGeometryContext context = line.Open())
+                {
+                    context.BeginFigure(points[0], false, false);
+                    for (int index = 1; index < points.Length; index++)
+                        context.LineTo(points[index], true, false);
+                }
+                line.Freeze();
+                Pen linePen = new Pen(LineBrush, 2.15)
+                {
+                    StartLineCap = PenLineCap.Round,
+                    EndLineCap = PenLineCap.Round,
+                    LineJoin = PenLineJoin.Round
+                };
+                drawingContext.DrawGeometry(null, linePen, line);
+            }
+
+            Point latest = points[points.Length - 1];
+            drawingContext.DrawEllipse(new SolidColorBrush(Color.FromArgb(44, 255, 255, 255)),
+                null, latest, 5.5, 5.5);
+            drawingContext.DrawEllipse(LineBrush, null, latest, 2.8, 2.8);
+            drawingContext.Pop();
+        }
+
+        private void TrimToCapacity()
+        {
+            while (samples.Count > capacity)
+                samples.RemoveAt(0);
+        }
+
+        private void GetScaleBounds(out double minimum, out double maximum)
+        {
+            minimum = Minimum;
+            maximum = Maximum;
+            if (CenterZero)
+            {
+                double extent = Math.Max(Math.Abs(minimum), Math.Abs(maximum));
+                // Keep the largest offset comfortably inside the plot while
+                // preserving a stable scale when the clock is nearly aligned.
+                extent = Math.Max(extent * 1.30,
+                    Math.Max(0, MinimumCenteredExtent));
+                if (extent < 1)
+                    extent = 1;
+                minimum = -extent;
+                maximum = extent;
+                return;
+            }
+
+            double range = maximum - minimum;
+            if (MinimumRange > 0)
+            {
+                /*
+                 * Detail mode follows the observed band instead of forcing
+                 * zero into view.  A small floor prevents integer-nanosecond
+                 * noise from expanding to the full chart height.
+                 */
+                double center = minimum + range / 2.0;
+                double visibleRange = Math.Max(range, MinimumRange);
+                double detailPadding = visibleRange * 0.12;
+                minimum = center - visibleRange / 2.0 - detailPadding;
+                maximum = center + visibleRange / 2.0 + detailPadding;
+                return;
+            }
+            double padding = range > 0 ? range * 0.14 :
+                Math.Max(Math.Abs(maximum) * 0.08, 1);
+            minimum -= padding;
+            maximum += padding;
+        }
+
+        private static double ValueToY(double value, double minimum,
+                                       double maximum, Rect plot)
+        {
+            double normalized = (value - minimum) / (maximum - minimum);
+            return plot.Bottom - (normalized * plot.Height);
+        }
+    }
+}

--- a/DRV/Windows/TimeCardControlCenter/SplashWindow.xaml
+++ b/DRV/Windows/TimeCardControlCenter/SplashWindow.xaml
@@ -1,0 +1,244 @@
+<Window x:Class="TimeCardControlCenter.SplashWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        Title="OCP Time Card Control Center"
+        Width="760" Height="460"
+        WindowStyle="None" ResizeMode="NoResize"
+        WindowStartupLocation="CenterScreen"
+        AllowsTransparency="True" Background="Transparent"
+        ShowInTaskbar="True" Icon="Assets/timecard-app.ico"
+        TextOptions.TextFormattingMode="Display"
+        TextOptions.TextRenderingMode="ClearType">
+    <Window.Resources>
+        <PowerEase x:Key="EntranceEase" EasingMode="EaseOut" Power="4" />
+        <CubicEase x:Key="ProgressEase" EasingMode="EaseInOut" />
+
+        <Storyboard x:Key="SplashEntrance">
+            <DoubleAnimation Storyboard.TargetName="SplashRoot"
+                             Storyboard.TargetProperty="Opacity"
+                             From="0" To="1" Duration="0:0:0.32" />
+            <DoubleAnimation Storyboard.TargetName="SplashScale"
+                             Storyboard.TargetProperty="ScaleX"
+                             From="0.965" To="1" Duration="0:0:0.48"
+                             EasingFunction="{StaticResource EntranceEase}" />
+            <DoubleAnimation Storyboard.TargetName="SplashScale"
+                             Storyboard.TargetProperty="ScaleY"
+                             From="0.965" To="1" Duration="0:0:0.48"
+                             EasingFunction="{StaticResource EntranceEase}" />
+            <DoubleAnimation Storyboard.TargetName="LogoFloat"
+                             Storyboard.TargetProperty="Y"
+                             From="2" To="-5" BeginTime="0:0:0.45"
+                             Duration="0:0:1.8" AutoReverse="True"
+                             RepeatBehavior="Forever" />
+            <DoubleAnimation Storyboard.TargetName="LogoGlow"
+                             Storyboard.TargetProperty="Opacity"
+                             From="0.35" To="0.78" BeginTime="0:0:0.35"
+                             Duration="0:0:1.35" AutoReverse="True"
+                             RepeatBehavior="Forever" />
+            <DoubleAnimation Storyboard.TargetName="StatusPulse"
+                             Storyboard.TargetProperty="Opacity"
+                             From="0.32" To="1" Duration="0:0:0.62"
+                             AutoReverse="True" RepeatBehavior="Forever" />
+            <DoubleAnimation Storyboard.TargetName="ProgressFill"
+                             Storyboard.TargetProperty="Width"
+                             From="0" To="296" BeginTime="0:0:0.15"
+                             Duration="0:0:2.75"
+                             EasingFunction="{StaticResource ProgressEase}" />
+            <DoubleAnimation Storyboard.TargetName="ShimmerTranslate"
+                             Storyboard.TargetProperty="X"
+                             From="-180" To="360" BeginTime="0:0:0.18"
+                             Duration="0:0:1.35"
+                             EasingFunction="{StaticResource ProgressEase}" />
+        </Storyboard>
+    </Window.Resources>
+
+    <Window.Triggers>
+        <EventTrigger RoutedEvent="Window.Loaded">
+            <BeginStoryboard Storyboard="{StaticResource SplashEntrance}" />
+        </EventTrigger>
+    </Window.Triggers>
+
+    <Grid x:Name="SplashRoot" Margin="30" Opacity="0"
+          RenderTransformOrigin="0.5,0.5">
+        <Grid.RenderTransform>
+            <ScaleTransform x:Name="SplashScale" ScaleX="0.965" ScaleY="0.965" />
+        </Grid.RenderTransform>
+
+        <Border CornerRadius="28" Background="#06101C">
+            <Border.Effect>
+                <DropShadowEffect Color="#02060C" BlurRadius="32"
+                                  ShadowDepth="10" Opacity="0.75" />
+            </Border.Effect>
+        </Border>
+
+        <Border CornerRadius="28" BorderBrush="#365875" BorderThickness="1">
+            <Border.Background>
+                <LinearGradientBrush StartPoint="0,0" EndPoint="1,1">
+                    <GradientStop Color="#0C2135" Offset="0" />
+                    <GradientStop Color="#081522" Offset="0.52" />
+                    <GradientStop Color="#07111D" Offset="1" />
+                </LinearGradientBrush>
+            </Border.Background>
+
+            <Grid ClipToBounds="True">
+                <Canvas IsHitTestVisible="False" Opacity="0.72">
+                    <Ellipse Width="360" Height="360" Canvas.Left="-150" Canvas.Top="-120">
+                        <Ellipse.Fill>
+                            <RadialGradientBrush Center="0.5,0.5" GradientOrigin="0.5,0.5">
+                                <GradientStop Color="#554CC9F0" Offset="0" />
+                                <GradientStop Color="#004CC9F0" Offset="1" />
+                            </RadialGradientBrush>
+                        </Ellipse.Fill>
+                    </Ellipse>
+                    <Ellipse Width="300" Height="300" Canvas.Left="520" Canvas.Top="230">
+                        <Ellipse.Fill>
+                            <RadialGradientBrush Center="0.5,0.5" GradientOrigin="0.5,0.5">
+                                <GradientStop Color="#3069C441" Offset="0" />
+                                <GradientStop Color="#0069C441" Offset="1" />
+                            </RadialGradientBrush>
+                        </Ellipse.Fill>
+                    </Ellipse>
+                    <Path Data="M 424,52 L 610,52 Q 630,52 630,72 L 630,92 L 682,92"
+                          Stroke="#344CC9F0" StrokeThickness="1" />
+                    <Path Data="M 468,76 L 560,76 Q 578,76 578,94 L 578,116 L 684,116"
+                          Stroke="#244CC9F0" StrokeThickness="1" />
+                    <Path Data="M 472,342 L 602,342 Q 622,342 622,322 L 622,302 L 684,302"
+                          Stroke="#2869C441" StrokeThickness="1" />
+                    <Ellipse Width="5" Height="5" Canvas.Left="678" Canvas.Top="89" Fill="#684CC9F0" />
+                    <Ellipse Width="5" Height="5" Canvas.Left="678" Canvas.Top="299" Fill="#7069C441" />
+                </Canvas>
+
+                <Grid Margin="42,34">
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="250" />
+                        <ColumnDefinition Width="*" />
+                    </Grid.ColumnDefinitions>
+
+                    <Border Width="238" Height="294" HorizontalAlignment="Left"
+                            VerticalAlignment="Center" CornerRadius="24"
+                            BorderBrush="#294861" BorderThickness="1"
+                            Background="#A00A1929">
+                        <Grid x:Name="LogoPanel" ClipToBounds="True">
+                            <Ellipse x:Name="LogoGlow" Width="172" Height="172" Opacity="0.35">
+                                <Ellipse.Fill>
+                                    <RadialGradientBrush>
+                                        <GradientStop Color="#994CC9F0" Offset="0" />
+                                        <GradientStop Color="#004CC9F0" Offset="1" />
+                                    </RadialGradientBrush>
+                                </Ellipse.Fill>
+                                <Ellipse.Effect>
+                                    <BlurEffect Radius="22" />
+                                </Ellipse.Effect>
+                            </Ellipse>
+
+                            <Image Width="190" Height="136" Source="Assets/timecard-logo.png"
+                                   Stretch="Uniform" RenderOptions.BitmapScalingMode="HighQuality"
+                                   HorizontalAlignment="Center" VerticalAlignment="Center">
+                                <Image.RenderTransform>
+                                    <TranslateTransform x:Name="LogoFloat" />
+                                </Image.RenderTransform>
+                                <Image.Effect>
+                                    <DropShadowEffect Color="#4CC9F0" BlurRadius="16"
+                                                      ShadowDepth="0" Opacity="0.35" />
+                                </Image.Effect>
+                            </Image>
+
+                            <Rectangle Width="92" Height="360" Opacity="0.16"
+                                       HorizontalAlignment="Left" VerticalAlignment="Center">
+                                <Rectangle.Fill>
+                                    <LinearGradientBrush StartPoint="0,0" EndPoint="1,0">
+                                        <GradientStop Color="#00FFFFFF" Offset="0" />
+                                        <GradientStop Color="#B0FFFFFF" Offset="0.5" />
+                                        <GradientStop Color="#00FFFFFF" Offset="1" />
+                                    </LinearGradientBrush>
+                                </Rectangle.Fill>
+                                <Rectangle.RenderTransform>
+                                    <TransformGroup>
+                                        <RotateTransform Angle="14" />
+                                        <TranslateTransform x:Name="ShimmerTranslate" X="-180" />
+                                    </TransformGroup>
+                                </Rectangle.RenderTransform>
+                            </Rectangle>
+
+                            <Border Height="32" Margin="18" Padding="12,0"
+                                    VerticalAlignment="Bottom" CornerRadius="16"
+                                    Background="#CC0C2133" BorderBrush="#31516C"
+                                    BorderThickness="1">
+                                <StackPanel Orientation="Horizontal" HorizontalAlignment="Center">
+                                    <TextBlock Text="&#xE916;" FontFamily="Segoe MDL2 Assets"
+                                               Foreground="#DAB539" FontSize="13"
+                                               VerticalAlignment="Center" Margin="0,0,8,0" />
+                                    <TextBlock Text="PRECISION TIMING" Foreground="#C7D8E6"
+                                               FontFamily="Segoe UI Semibold" FontSize="10"
+                                               VerticalAlignment="Center" />
+                                </StackPanel>
+                            </Border>
+                        </Grid>
+                    </Border>
+
+                    <Grid Grid.Column="1" Margin="42,8,0,8">
+                        <Grid.RowDefinitions>
+                            <RowDefinition Height="Auto" />
+                            <RowDefinition Height="*" />
+                            <RowDefinition Height="Auto" />
+                        </Grid.RowDefinitions>
+
+                        <StackPanel>
+                            <TextBlock Text="OPEN COMPUTE PROJECT" Foreground="#69C441"
+                                       FontFamily="Segoe UI Semibold" FontSize="11" />
+                            <TextBlock Text="Time Card" Margin="0,12,0,0"
+                                       Foreground="#F4F8FC" FontFamily="Segoe UI Semibold"
+                                       FontSize="42" />
+                            <TextBlock Text="Control Center" Margin="1,-3,0,0"
+                                       Foreground="#A9BED0" FontFamily="Segoe UI Light"
+                                       FontSize="24" />
+                            <Border Width="58" Height="3" CornerRadius="2" Margin="1,18,0,17"
+                                    HorizontalAlignment="Left" Background="#69C441" />
+                            <TextBlock Width="300" HorizontalAlignment="Left"
+                                       Text="Precision synchronization, hardware control, and diagnostics in one workspace."
+                                       TextWrapping="Wrap" LineHeight="20"
+                                       Foreground="#91A8BC" FontSize="13" />
+                        </StackPanel>
+
+                        <StackPanel Grid.Row="2">
+                            <Grid Margin="0,0,0,11">
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="Auto" />
+                                    <ColumnDefinition Width="*" />
+                                    <ColumnDefinition Width="Auto" />
+                                </Grid.ColumnDefinitions>
+                                <Ellipse x:Name="StatusPulse" Width="8" Height="8"
+                                         Fill="#69C441" VerticalAlignment="Center"
+                                         Margin="0,0,10,0">
+                                    <Ellipse.Effect>
+                                        <DropShadowEffect Color="#69C441" BlurRadius="8"
+                                                          ShadowDepth="0" Opacity="0.8" />
+                                    </Ellipse.Effect>
+                                </Ellipse>
+                                <TextBlock x:Name="SplashStatusText" Grid.Column="1"
+                                           Text="Starting Control Center" Foreground="#C7D8E6"
+                                           FontSize="12" VerticalAlignment="Center" />
+                                <TextBlock x:Name="VersionText" Grid.Column="2"
+                                           Foreground="#617A90" FontSize="10"
+                                           VerticalAlignment="Center" />
+                            </Grid>
+
+                            <Border Width="296" Height="4" HorizontalAlignment="Left"
+                                    CornerRadius="2" Background="#1D344A" ClipToBounds="True">
+                                <Border x:Name="ProgressFill" Width="0" Height="4"
+                                        HorizontalAlignment="Left" CornerRadius="2">
+                                    <Border.Background>
+                                        <LinearGradientBrush StartPoint="0,0" EndPoint="1,0">
+                                            <GradientStop Color="#4CC9F0" Offset="0" />
+                                            <GradientStop Color="#69C441" Offset="1" />
+                                        </LinearGradientBrush>
+                                    </Border.Background>
+                                </Border>
+                            </Border>
+                        </StackPanel>
+                    </Grid>
+                </Grid>
+            </Grid>
+        </Border>
+    </Grid>
+</Window>

--- a/DRV/Windows/TimeCardControlCenter/SplashWindow.xaml.cs
+++ b/DRV/Windows/TimeCardControlCenter/SplashWindow.xaml.cs
@@ -1,0 +1,37 @@
+using System;
+using System.Reflection;
+using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Media.Animation;
+
+namespace TimeCardControlCenter
+{
+    public partial class SplashWindow : Window
+    {
+        public SplashWindow()
+        {
+            InitializeComponent();
+            Version version = Assembly.GetExecutingAssembly().GetName().Version;
+            VersionText.Text = string.Format("VERSION {0}.{1}.{2}",
+                version.Major, version.Minor, version.Build);
+        }
+
+        public void SetStatus(string status)
+        {
+            SplashStatusText.Text = status;
+        }
+
+        public async Task CloseAnimatedAsync()
+        {
+            DoubleAnimation fade = new DoubleAnimation
+            {
+                To = 0,
+                Duration = TimeSpan.FromMilliseconds(220),
+                EasingFunction = new CubicEase { EasingMode = EasingMode.EaseIn }
+            };
+            SplashRoot.BeginAnimation(OpacityProperty, fade);
+            await Task.Delay(230);
+            Close();
+        }
+    }
+}

--- a/DRV/Windows/TimeCardControlCenter/TimeCardClient.cs
+++ b/DRV/Windows/TimeCardControlCenter/TimeCardClient.cs
@@ -23,6 +23,9 @@ namespace TimeCardControlCenter
         private const int MaximumI2cTransfer = 255;
         private const int I2cTransferHeaderSize = 20;
         private const int I2cTransferBufferSize = 276;
+        private const int MaximumFlashTransfer = 256;
+        private const int FlashTransferHeaderSize = 16;
+        private const int FlashTransferBufferSize = 272;
 
         private static readonly uint IoctlSetTime = ControlCode(1, FileWriteAccess);
         private static readonly uint IoctlGetInfo = ControlCode(2, FileReadAccess);
@@ -40,6 +43,19 @@ namespace TimeCardControlCenter
         private static readonly uint IoctlNmeaQuery = ControlCode(14, FileReadAccess | FileWriteAccess);
         private static readonly uint IoctlNmeaSet = ControlCode(15, FileReadAccess | FileWriteAccess);
         private static readonly uint IoctlGetIdentity = ControlCode(16, FileReadAccess);
+        private static readonly uint IoctlSignalQuery = ControlCode(17, FileReadAccess | FileWriteAccess);
+        private static readonly uint IoctlSignalSet = ControlCode(18, FileReadAccess | FileWriteAccess);
+        private static readonly uint IoctlFrequencyQuery = ControlCode(19, FileReadAccess | FileWriteAccess);
+        private static readonly uint IoctlFrequencySet = ControlCode(20, FileReadAccess | FileWriteAccess);
+        private static readonly uint IoctlFlashQuery = ControlCode(21, FileReadAccess);
+        private static readonly uint IoctlFlashRead = ControlCode(22, FileReadAccess | FileWriteAccess);
+        private static readonly uint IoctlFlashErase = ControlCode(23, FileReadAccess | FileWriteAccess);
+        private static readonly uint IoctlFlashProgram = ControlCode(24, FileReadAccess | FileWriteAccess);
+        private static readonly uint IoctlUartObserve = ControlCode(25, FileReadAccess | FileWriteAccess);
+        private static readonly uint IoctlI2cMuxQuery = ControlCode(26, FileReadAccess);
+        private static readonly uint IoctlI2cMuxSet = ControlCode(27, FileReadAccess | FileWriteAccess);
+        private static readonly uint IoctlLedQuery = ControlCode(28, FileReadAccess | FileWriteAccess);
+        private static readonly uint IoctlLedSet = ControlCode(29, FileReadAccess | FileWriteAccess);
 
         private readonly object gate = new object();
         private SafeFileHandle handle;
@@ -111,7 +127,7 @@ namespace TimeCardControlCenter
             if (utc.Year < 2020 || utc.Year > 2100)
                 throw new InvalidOperationException(
                     "The Time Card PHC does not contain a plausible UTC date. " +
-                    "Set the PHC from Windows or establish GNSS time first.");
+                    "Synchronize the PHC from the system clock or establish GNSS time first.");
 
             NativeSystemTime systemTime = new NativeSystemTime
             {
@@ -168,6 +184,146 @@ namespace TimeCardControlCenter
         {
             return new TimeCardIdentity(
                 GetOutput<TimeCardIdentityRaw>(IoctlGetIdentity));
+        }
+
+        public SignalGeneratorState GetSignalGenerator(uint generator)
+        {
+            return CallSignalGenerator(IoctlSignalQuery, generator, false,
+                0, 0, 0, false);
+        }
+
+        public SignalGeneratorState SetSignalGenerator(uint generator,
+            bool enabled, ulong periodNanoseconds, ulong pulseNanoseconds,
+            ulong phaseNanoseconds, bool inverted)
+        {
+            return CallSignalGenerator(IoctlSignalSet, generator, enabled,
+                periodNanoseconds, pulseNanoseconds, phaseNanoseconds,
+                inverted);
+        }
+
+        private SignalGeneratorState CallSignalGenerator(uint code,
+            uint generator, bool enabled, ulong periodNanoseconds,
+            ulong pulseNanoseconds, ulong phaseNanoseconds, bool inverted)
+        {
+            if (generator == 0 || generator > 4)
+                throw new ArgumentOutOfRangeException("generator");
+            TimeCardSignalControlRaw request = new TimeCardSignalControlRaw
+            {
+                Size = (uint)Marshal.SizeOf(typeof(TimeCardSignalControlRaw)),
+                Generator = generator,
+                Flags = (enabled ? 2u : 0u) | (inverted ? 4u : 0u),
+                PeriodNanoseconds = periodNanoseconds,
+                PulseNanoseconds = pulseNanoseconds,
+                PhaseNanoseconds = phaseNanoseconds
+            };
+            byte[] output = Call(code, StructToBytes(request),
+                Marshal.SizeOf(typeof(TimeCardSignalControlRaw)));
+            return new SignalGeneratorState(
+                BytesToStruct<TimeCardSignalControlRaw>(output));
+        }
+
+        public FrequencyCounterState GetFrequencyCounter(uint counter)
+        {
+            return CallFrequencyCounter(IoctlFrequencyQuery, counter, 0);
+        }
+
+        public FrequencyCounterState SetFrequencyCounter(uint counter,
+                                                          uint integrationSeconds)
+        {
+            if (integrationSeconds > 255)
+                throw new ArgumentOutOfRangeException("integrationSeconds");
+            return CallFrequencyCounter(IoctlFrequencySet, counter,
+                integrationSeconds);
+        }
+
+        private FrequencyCounterState CallFrequencyCounter(uint code,
+            uint counter, uint integrationSeconds)
+        {
+            if (counter == 0 || counter > 4)
+                throw new ArgumentOutOfRangeException("counter");
+            TimeCardFrequencyControlRaw request = new TimeCardFrequencyControlRaw
+            {
+                Size = (uint)Marshal.SizeOf(typeof(TimeCardFrequencyControlRaw)),
+                Counter = counter,
+                IntegrationSeconds = integrationSeconds
+            };
+            byte[] output = Call(code, StructToBytes(request),
+                Marshal.SizeOf(typeof(TimeCardFrequencyControlRaw)));
+            return new FrequencyCounterState(
+                BytesToStruct<TimeCardFrequencyControlRaw>(output));
+        }
+
+        public FlashDeviceStatus GetFlashStatus()
+        {
+            return new FlashDeviceStatus(
+                GetOutput<TimeCardFlashStatusRaw>(IoctlFlashQuery));
+        }
+
+        public byte[] ReadFlash(uint offset, uint length)
+        {
+            if (length == 0 || length > MaximumFlashTransfer)
+                throw new ArgumentOutOfRangeException("length");
+            TimeCardFlashRangeRaw request = new TimeCardFlashRangeRaw
+            {
+                Size = (uint)Marshal.SizeOf(typeof(TimeCardFlashRangeRaw)),
+                Offset = offset,
+                Length = length
+            };
+            byte[] output = Call(IoctlFlashRead, StructToBytes(request),
+                FlashTransferBufferSize);
+            if (output.Length < FlashTransferHeaderSize)
+                throw new InvalidOperationException("The driver returned a truncated flash response.");
+            uint returnedOffset = BitConverter.ToUInt32(output, 4);
+            uint returnedLength = BitConverter.ToUInt32(output, 8);
+            if (returnedOffset != offset || returnedLength != length ||
+                output.Length < FlashTransferHeaderSize + returnedLength)
+                throw new InvalidOperationException("The driver returned an invalid flash range.");
+            byte[] data = new byte[returnedLength];
+            Buffer.BlockCopy(output, FlashTransferHeaderSize, data, 0,
+                (int)returnedLength);
+            return data;
+        }
+
+        public void EraseFlashSector(uint offset, uint eraseSize)
+        {
+            if (eraseSize == 0)
+                throw new ArgumentOutOfRangeException("eraseSize");
+            TimeCardFlashRangeRaw request = new TimeCardFlashRangeRaw
+            {
+                Size = (uint)Marshal.SizeOf(typeof(TimeCardFlashRangeRaw)),
+                Offset = offset,
+                Length = eraseSize
+            };
+            Call(IoctlFlashErase, StructToBytes(request), 16);
+        }
+
+        public void ProgramFlashPage(uint offset, byte[] data)
+        {
+            if (data == null)
+                throw new ArgumentNullException("data");
+            if (data.Length == 0 || data.Length > MaximumFlashTransfer)
+                throw new ArgumentOutOfRangeException("data");
+            byte[] input = new byte[FlashTransferHeaderSize + data.Length];
+            Buffer.BlockCopy(BitConverter.GetBytes((uint)input.Length), 0, input, 0, 4);
+            Buffer.BlockCopy(BitConverter.GetBytes(offset), 0, input, 4, 4);
+            Buffer.BlockCopy(BitConverter.GetBytes((uint)data.Length), 0, input, 8, 4);
+            Buffer.BlockCopy(data, 0, input, FlashTransferHeaderSize, data.Length);
+            Call(IoctlFlashProgram, input, 16);
+        }
+
+        public UartObservation ObserveUart(uint port, uint timeoutMilliseconds)
+        {
+            if (port > 3)
+                throw new ArgumentOutOfRangeException("port");
+            TimeCardUartObserveRaw request = new TimeCardUartObserveRaw
+            {
+                Size = (uint)Marshal.SizeOf(typeof(TimeCardUartObserveRaw)),
+                Port = port,
+                TimeoutMilliseconds = Math.Min(timeoutMilliseconds, 5000u)
+            };
+            byte[] output = Call(IoctlUartObserve, StructToBytes(request),
+                Marshal.SizeOf(typeof(TimeCardUartObserveRaw)));
+            return new UartObservation(BytesToStruct<TimeCardUartObserveRaw>(output));
         }
 
         public void ConfigureUart(uint port, uint baud)
@@ -577,6 +733,62 @@ namespace TimeCardControlCenter
                 controllerStatus, interruptStatus);
         }
 
+        public I2cMuxState GetI2cMux()
+        {
+            return new I2cMuxState(
+                GetOutput<TimeCardI2cMuxControlRaw>(IoctlI2cMuxQuery));
+        }
+
+        public I2cMuxState SetI2cMux(uint channelMask)
+        {
+            if ((channelMask & ~0x0fu) != 0)
+                throw new ArgumentOutOfRangeException("channelMask");
+            TimeCardI2cMuxControlRaw request = new TimeCardI2cMuxControlRaw
+            {
+                Size = (uint)Marshal.SizeOf(typeof(TimeCardI2cMuxControlRaw)),
+                ChannelMask = channelMask
+            };
+            byte[] output = Call(IoctlI2cMuxSet, StructToBytes(request),
+                Marshal.SizeOf(typeof(TimeCardI2cMuxControlRaw)));
+            return new I2cMuxState(
+                BytesToStruct<TimeCardI2cMuxControlRaw>(output));
+        }
+
+        public BoardLedState GetBoardLed(uint led)
+        {
+            if (led >= 6)
+                throw new ArgumentOutOfRangeException("led");
+            TimeCardLedControlRaw request = new TimeCardLedControlRaw
+            {
+                Size = (uint)Marshal.SizeOf(typeof(TimeCardLedControlRaw)),
+                Led = led
+            };
+            byte[] output = Call(IoctlLedQuery, StructToBytes(request),
+                Marshal.SizeOf(typeof(TimeCardLedControlRaw)));
+            return new BoardLedState(BytesToStruct<TimeCardLedControlRaw>(output));
+        }
+
+        public BoardLedState SetBoardLed(uint led, byte red, byte green,
+                                         byte blue, byte globalCurrent)
+        {
+            if (led >= 6)
+                throw new ArgumentOutOfRangeException("led");
+            if (globalCurrent == 0 || globalCurrent > 128)
+                throw new ArgumentOutOfRangeException("globalCurrent");
+            TimeCardLedControlRaw request = new TimeCardLedControlRaw
+            {
+                Size = (uint)Marshal.SizeOf(typeof(TimeCardLedControlRaw)),
+                Led = led,
+                Red = red,
+                Green = green,
+                Blue = blue,
+                GlobalCurrent = globalCurrent
+            };
+            byte[] output = Call(IoctlLedSet, StructToBytes(request),
+                Marshal.SizeOf(typeof(TimeCardLedControlRaw)));
+            return new BoardLedState(BytesToStruct<TimeCardLedControlRaw>(output));
+        }
+
         private TimeCardHierarchyRaw SetHierarchyRaw(uint action, bool persist)
         {
             TimeCardHierarchyRaw request = new TimeCardHierarchyRaw
@@ -630,8 +842,13 @@ namespace TimeCardControlCenter
                     input == null ? 0 : input.Length, output, outputSize,
                     out returned, IntPtr.Zero);
                 if (!success)
-                    throw new Win32Exception(Marshal.GetLastWin32Error(),
-                        string.Format("Time Card IOCTL 0x{0:X8} failed.", code));
+                {
+                    int error = Marshal.GetLastWin32Error();
+                    string systemMessage = new Win32Exception(error).Message;
+                    throw new Win32Exception(error, string.Format(
+                        "Time Card IOCTL 0x{0:X8} failed with Win32 error {1}: {2}",
+                        code, error, systemMessage));
+                }
                 if (output != null && returned < outputSize)
                     Array.Resize(ref output, returned);
                 return output ?? new byte[0];

--- a/DRV/Windows/TimeCardControlCenter/TimeCardControlCenter.csproj
+++ b/DRV/Windows/TimeCardControlCenter/TimeCardControlCenter.csproj
@@ -49,11 +49,19 @@
       <Generator>MSBuild:Compile</Generator>
       <SubType>Designer</SubType>
     </Page>
+    <Page Include="SplashWindow.xaml">
+      <Generator>MSBuild:Compile</Generator>
+      <SubType>Designer</SubType>
+    </Page>
     <Compile Include="App.xaml.cs">
       <DependentUpon>App.xaml</DependentUpon>
     </Compile>
     <Compile Include="MainWindow.xaml.cs">
       <DependentUpon>MainWindow.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="RollingTelemetryChart.cs" />
+    <Compile Include="SplashWindow.xaml.cs">
+      <DependentUpon>SplashWindow.xaml</DependentUpon>
     </Compile>
     <Compile Include="Models.cs" />
     <Compile Include="Sa53Client.cs" />

--- a/DRV/Windows/TimeCardControlCenter/UbloxClient.cs
+++ b/DRV/Windows/TimeCardControlCenter/UbloxClient.cs
@@ -6,6 +6,53 @@ using System.Text;
 
 namespace TimeCardControlCenter
 {
+    public sealed class UbloxSatelliteInfo
+    {
+        internal UbloxSatelliteInfo(byte gnssIdentifier, byte satelliteIdentifier,
+            byte carrierToNoise, int elevationDegrees, int azimuthDegrees,
+            uint flags, string constellation, string displayIdentifier)
+        {
+            GnssIdentifier = gnssIdentifier;
+            SatelliteIdentifier = satelliteIdentifier;
+            CarrierToNoise = carrierToNoise;
+            ElevationDegrees = elevationDegrees;
+            AzimuthDegrees = azimuthDegrees;
+            Flags = flags;
+            Constellation = constellation;
+            DisplayIdentifier = displayIdentifier;
+            IsUsed = (flags & 0x08u) != 0;
+            QualityIndicator = (byte)(flags & 0x07u);
+        }
+
+        public byte GnssIdentifier { get; private set; }
+        public byte SatelliteIdentifier { get; private set; }
+        public byte CarrierToNoise { get; private set; }
+        public int ElevationDegrees { get; private set; }
+        public int AzimuthDegrees { get; private set; }
+        public uint Flags { get; private set; }
+        public string Constellation { get; private set; }
+        public string DisplayIdentifier { get; private set; }
+        public bool IsUsed { get; private set; }
+        public byte QualityIndicator { get; private set; }
+
+        public string QualityDescription
+        {
+            get
+            {
+                switch (QualityIndicator)
+                {
+                    case 0: return "No signal";
+                    case 1: return "Searching";
+                    case 2: return "Acquired";
+                    case 3: return "Unusable";
+                    case 4: return "Code locked";
+                    case 5: return "Carrier locked";
+                    default: return "Tracked";
+                }
+            }
+        }
+    }
+
     public sealed class UbloxReceiverSnapshot
     {
         private readonly Dictionary<uint, ulong> configuration;
@@ -16,6 +63,8 @@ namespace TimeCardControlCenter
             this.configuration = configuration;
             List<string> warningList = warnings as List<string> ?? new List<string>(warnings);
             Warnings = warningList.AsReadOnly();
+            Satellites = new List<UbloxSatelliteInfo>().AsReadOnly();
+            CapturedAtUtc = DateTime.UtcNow;
         }
 
         public string SoftwareVersion { get; internal set; }
@@ -31,6 +80,8 @@ namespace TimeCardControlCenter
         public int SatellitesVisible { get; internal set; }
         public double AverageCno { get; internal set; }
         public string ConstellationSummary { get; internal set; }
+        public IList<UbloxSatelliteInfo> Satellites { get; internal set; }
+        public DateTime CapturedAtUtc { get; internal set; }
         public DateTime? Utc { get; internal set; }
         public uint TimeAccuracyNanoseconds { get; internal set; }
         public double Latitude { get; internal set; }
@@ -348,12 +399,20 @@ namespace TimeCardControlCenter
             int cnoTotal = 0;
             int cnoCount = 0;
             Dictionary<byte, int> constellations = new Dictionary<byte, int>();
+            List<UbloxSatelliteInfo> satellites = new List<UbloxSatelliteInfo>();
             for (int index = 0; index < count; index++)
             {
                 int offset = 8 + index * 12;
                 byte gnss = payload[offset];
+                byte satelliteIdentifier = payload[offset + 1];
                 byte cno = payload[offset + 2];
+                int elevation = unchecked((sbyte)payload[offset + 3]);
+                int azimuth = unchecked((short)ReadUInt16(payload, offset + 4));
                 uint flags = ReadUInt32(payload, offset + 8);
+                satellites.Add(new UbloxSatelliteInfo(gnss,
+                    satelliteIdentifier, cno, elevation, azimuth, flags,
+                    GnssName(gnss), SatellitePrefix(gnss) +
+                    satelliteIdentifier.ToString(CultureInfo.InvariantCulture)));
                 if ((flags & 0x08) != 0)
                     used++;
                 if (cno != 0)
@@ -366,6 +425,8 @@ namespace TimeCardControlCenter
                 constellations[gnss] = value + 1;
             }
             snapshot.SatellitesVisible = count;
+            snapshot.Satellites = satellites.AsReadOnly();
+            snapshot.CapturedAtUtc = DateTime.UtcNow;
             snapshot.AverageCno = cnoCount == 0 ? 0 : cnoTotal / (double)cnoCount;
             snapshot.ConstellationSummary = string.Join(" · ", constellations
                 .OrderBy(item => item.Key)
@@ -452,6 +513,21 @@ namespace TimeCardControlCenter
                 case 6: return "GLONASS";
                 case 7: return "NavIC";
                 default: return "GNSS " + identifier.ToString(CultureInfo.InvariantCulture);
+            }
+        }
+
+        private static string SatellitePrefix(byte identifier)
+        {
+            switch (identifier)
+            {
+                case 0: return "G";
+                case 1: return "S";
+                case 2: return "E";
+                case 3: return "C";
+                case 5: return "Q";
+                case 6: return "R";
+                case 7: return "I";
+                default: return "?";
             }
         }
 

--- a/DRV/Windows/driver.c
+++ b/DRV/Windows/driver.c
@@ -43,6 +43,8 @@ TimeCardSelectLayout(PDEVICE_CONTEXT context)
     ULONG uartOffsets[TIMECARD_UART_COUNT];
     ULONG smaMap1Offset;
     ULONG smaMap2Offset;
+    ULONG signalBaseOffset;
+    ULONG frequencyBaseOffset;
     BOOLEAN useMsix = context->InterruptMessages > 1;
     ULONG i;
 
@@ -57,7 +59,10 @@ TimeCardSelectLayout(PDEVICE_CONTEXT context)
         uartOffsets[TIMECARD_UART_NMEA] = TIMECARD_UART_NMEA_OFFSET_MSIX;
         smaMap1Offset = TIMECARD_SMA_MAP1_OFFSET_MSIX;
         smaMap2Offset = TIMECARD_SMA_MAP2_OFFSET_MSIX;
+        signalBaseOffset = TIMECARD_SIGNAL_BASE_MSIX;
+        frequencyBaseOffset = TIMECARD_FREQUENCY_BASE_MSIX;
         context->I2cOffset = TIMECARD_I2C_OFFSET_MSIX;
+        context->FlashOffset = TIMECARD_FLASH_OFFSET_MSIX;
     } else {
         context->Layout = TIMECARD_LAYOUT_MSI;
         context->ClockOffset = TIMECARD_CLOCK_OFFSET_MSI;
@@ -69,7 +74,10 @@ TimeCardSelectLayout(PDEVICE_CONTEXT context)
         uartOffsets[TIMECARD_UART_NMEA] = TIMECARD_UART_NMEA_OFFSET_MSI;
         smaMap1Offset = TIMECARD_SMA_MAP1_OFFSET_MSI;
         smaMap2Offset = TIMECARD_SMA_MAP2_OFFSET_MSI;
+        signalBaseOffset = TIMECARD_SIGNAL_BASE_MSI;
+        frequencyBaseOffset = TIMECARD_FREQUENCY_BASE_MSI;
         context->I2cOffset = TIMECARD_I2C_OFFSET_MSI;
+        context->FlashOffset = TIMECARD_FLASH_OFFSET_MSI;
     }
 
     if (!TimeCardRangeFits(context->Bar0Length, context->ClockOffset,
@@ -96,6 +104,27 @@ TimeCardSelectLayout(PDEVICE_CONTEXT context)
     context->NmeaOut = NULL;
     context->I2c = NULL;
     context->I2cKnownDeviceMask = 0;
+    context->Flash = NULL;
+    context->FlashJedecId = 0;
+    context->FlashCapacity = 0;
+    context->FlashFifoDepth = 0;
+    for (i = 0; i < TIMECARD_SIGNAL_COUNT; ++i) {
+        ULONG signalOffset = signalBaseOffset +
+                             i * TIMECARD_REGISTER_WINDOW_SIZE;
+        ULONG frequencyOffset = frequencyBaseOffset +
+                                i * TIMECARD_REGISTER_WINDOW_SIZE;
+
+        context->Signal[i] = TimeCardRangeFits(
+            context->Bar0Length, signalOffset,
+            sizeof(TIMECARD_SIGNAL_REG)) ?
+            (volatile TIMECARD_SIGNAL_REG *)(context->Bar0Base +
+                                              signalOffset) : NULL;
+        context->Frequency[i] = TimeCardRangeFits(
+            context->Bar0Length, frequencyOffset,
+            sizeof(TIMECARD_FREQUENCY_REG)) ?
+            (volatile TIMECARD_FREQUENCY_REG *)(context->Bar0Base +
+                                                 frequencyOffset) : NULL;
+    }
     if (TimeCardRangeFits(context->Bar0Length, smaMap1Offset,
                           sizeof(TIMECARD_GPIO_REG)) &&
         TimeCardRangeFits(context->Bar0Length, smaMap2Offset,
@@ -117,6 +146,12 @@ TimeCardSelectLayout(PDEVICE_CONTEXT context)
     if (TimeCardRangeFits(context->Bar0Length, context->I2cOffset,
                           TIMECARD_REGISTER_WINDOW_SIZE)) {
         context->I2c = context->Bar0Base + context->I2cOffset;
+    }
+
+    /* The Xilinx SPI controller owns the FPGA firmware region of SPI-NOR. */
+    if (TimeCardRangeFits(context->Bar0Length, context->FlashOffset,
+                          TIMECARD_REGISTER_WINDOW_SIZE)) {
+        context->Flash = context->Bar0Base + context->FlashOffset;
     }
     return STATUS_SUCCESS;
 }
@@ -274,6 +309,14 @@ TimeCardEvtReleaseHardware(WDFDEVICE device,
     context->SmaMap1 = NULL;
     context->SmaMap2 = NULL;
     context->I2c = NULL;
+    context->Flash = NULL;
+    context->FlashJedecId = 0;
+    context->FlashCapacity = 0;
+    context->FlashFifoDepth = 0;
+    for (i = 0; i < TIMECARD_SIGNAL_COUNT; ++i) {
+        context->Signal[i] = NULL;
+        context->Frequency[i] = NULL;
+    }
     for (i = 0; i < TIMECARD_UART_COUNT; ++i)
         context->Uart[i] = NULL;
     if (context->Bar0Base != NULL) {

--- a/DRV/Windows/flash.c
+++ b/DRV/Windows/flash.c
@@ -1,0 +1,515 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+/* Guarded Xilinx SPI / SPI-NOR access for FPGA firmware updates. */
+
+#include "timecard.h"
+
+#define XSPI_DGIER_OFFSET 0x01cu
+#define XSPI_IIER_OFFSET  0x028u
+#define XSPI_RESETR_OFFSET 0x040u
+#define XSPI_CR_OFFSET    0x060u
+#define XSPI_SR_OFFSET    0x064u
+#define XSPI_TXD_OFFSET   0x068u
+#define XSPI_RXD_OFFSET   0x06cu
+#define XSPI_SSR_OFFSET   0x070u
+
+#define XSPI_RESET_VALUE 0x0000000au
+#define XSPI_CR_ENABLE 0x002u
+#define XSPI_CR_MASTER 0x004u
+#define XSPI_CR_TXFIFO_RESET 0x020u
+#define XSPI_CR_RXFIFO_RESET 0x040u
+#define XSPI_CR_MANUAL_SELECT 0x080u
+#define XSPI_CR_TRANS_INHIBIT 0x100u
+#define XSPI_SR_RX_EMPTY 0x001u
+#define XSPI_SR_TX_EMPTY 0x004u
+#define XSPI_SR_TX_FULL  0x008u
+#define XSPI_SR_MODE_FAULT 0x010u
+
+#define SPI_NOR_WRITE_ENABLE 0x06u
+#define SPI_NOR_READ_STATUS  0x05u
+#define SPI_NOR_READ_ID      0x9fu
+#define SPI_NOR_RESET_ENABLE 0x66u
+#define SPI_NOR_RESET        0x99u
+#define SPI_NOR_READ         0x03u
+#define SPI_NOR_PAGE_PROGRAM 0x02u
+#define SPI_NOR_ERASE_4K     0x20u
+#define SPI_NOR_READ_4BYTE         0x13u
+#define SPI_NOR_PAGE_PROGRAM_4BYTE 0x12u
+#define SPI_NOR_ERASE_4K_4BYTE     0x21u
+
+#define SPI_NOR_STATUS_BUSY 0x01u
+#define SPI_NOR_STATUS_WEL  0x02u
+#define TIMECARD_FLASH_TRANSFER_POLL_US 5u
+#define TIMECARD_FLASH_TRANSFER_POLLS 100000u
+#define TIMECARD_FLASH_PROGRAM_TIMEOUT_MS 2000u
+#define TIMECARD_FLASH_ERASE_TIMEOUT_MS 10000u
+
+static ULONG
+TimeCardFlashRead32(PDEVICE_CONTEXT context, ULONG offset)
+{
+    return READ_REGISTER_ULONG((volatile ULONG *)(context->Flash + offset));
+}
+
+static VOID
+TimeCardFlashWrite32(PDEVICE_CONTEXT context, ULONG offset, ULONG value)
+{
+    WRITE_REGISTER_ULONG((volatile ULONG *)(context->Flash + offset), value);
+}
+
+static VOID
+TimeCardFlashDelayMilliseconds(ULONG milliseconds)
+{
+    LARGE_INTEGER interval;
+
+    interval.QuadPart = -10000;
+    while (milliseconds-- != 0)
+        KeDelayExecutionThread(KernelMode, FALSE, &interval);
+}
+
+static ULONG
+TimeCardFlashBaseControl(VOID)
+{
+    return XSPI_CR_MANUAL_SELECT | XSPI_CR_MASTER | XSPI_CR_ENABLE |
+           XSPI_CR_TRANS_INHIBIT;
+}
+
+static NTSTATUS
+TimeCardFlashInitialize(PDEVICE_CONTEXT context)
+{
+    ULONG depth = 0;
+    ULONG control = TimeCardFlashBaseControl();
+
+    if (!context->HardwareReady || context->Flash == NULL)
+        return STATUS_DEVICE_NOT_READY;
+
+    TimeCardFlashWrite32(context, XSPI_RESETR_OFFSET, XSPI_RESET_VALUE);
+    TimeCardFlashWrite32(context, XSPI_DGIER_OFFSET, 0);
+    TimeCardFlashWrite32(context, XSPI_IIER_OFFSET, 0);
+    TimeCardFlashWrite32(context, XSPI_SSR_OFFSET, 0xffffffffu);
+    TimeCardFlashWrite32(context, XSPI_CR_OFFSET,
+                         control | XSPI_CR_TXFIFO_RESET |
+                         XSPI_CR_RXFIFO_RESET);
+    TimeCardFlashWrite32(context, XSPI_CR_OFFSET, control);
+
+    /* Detect one-, 16-, or 256-byte FIFOs while the transmitter is inhibited. */
+    while (depth < TIMECARD_FLASH_MAX_TRANSFER) {
+        ULONG status = TimeCardFlashRead32(context, XSPI_SR_OFFSET);
+
+        if ((status & XSPI_SR_TX_FULL) != 0)
+            break;
+        TimeCardFlashWrite32(context, XSPI_TXD_OFFSET, 0);
+        ++depth;
+    }
+    if (depth == 0)
+        return STATUS_DEVICE_HARDWARE_ERROR;
+
+    TimeCardFlashWrite32(context, XSPI_RESETR_OFFSET, XSPI_RESET_VALUE);
+    TimeCardFlashWrite32(context, XSPI_DGIER_OFFSET, 0);
+    TimeCardFlashWrite32(context, XSPI_IIER_OFFSET, 0);
+    TimeCardFlashWrite32(context, XSPI_SSR_OFFSET, 0xffffffffu);
+    TimeCardFlashWrite32(context, XSPI_CR_OFFSET,
+                         control | XSPI_CR_TXFIFO_RESET |
+                         XSPI_CR_RXFIFO_RESET);
+    TimeCardFlashWrite32(context, XSPI_CR_OFFSET, control);
+    context->FlashFifoDepth = depth;
+    return STATUS_SUCCESS;
+}
+
+static NTSTATUS
+TimeCardFlashSpiTransfer(PDEVICE_CONTEXT context, const UCHAR *transmit,
+                         UCHAR *receive, ULONG length)
+{
+    ULONG control = TimeCardFlashBaseControl();
+    ULONG offset = 0;
+    NTSTATUS result = STATUS_SUCCESS;
+
+    if (length == 0 || context->FlashFifoDepth == 0)
+        return STATUS_INVALID_DEVICE_STATE;
+
+    TimeCardFlashWrite32(context, XSPI_CR_OFFSET,
+                         control | XSPI_CR_TXFIFO_RESET |
+                         XSPI_CR_RXFIFO_RESET);
+    TimeCardFlashWrite32(context, XSPI_CR_OFFSET, control);
+    TimeCardFlashWrite32(context, XSPI_SSR_OFFSET, 0xfffffffeu);
+
+    while (offset < length) {
+        ULONG chunk = length - offset;
+        ULONG i;
+        ULONG polls;
+        ULONG status = 0;
+
+        if (chunk > context->FlashFifoDepth)
+            chunk = context->FlashFifoDepth;
+        for (i = 0; i < chunk; ++i) {
+            ULONG value = transmit == NULL ? 0u : transmit[offset + i];
+            TimeCardFlashWrite32(context, XSPI_TXD_OFFSET, value);
+        }
+
+        TimeCardFlashWrite32(context, XSPI_CR_OFFSET,
+                             control & ~XSPI_CR_TRANS_INHIBIT);
+        for (polls = 0; polls < TIMECARD_FLASH_TRANSFER_POLLS; ++polls) {
+            status = TimeCardFlashRead32(context, XSPI_SR_OFFSET);
+            if ((status & XSPI_SR_MODE_FAULT) != 0) {
+                result = STATUS_DEVICE_HARDWARE_ERROR;
+                goto Exit;
+            }
+            if ((status & XSPI_SR_TX_EMPTY) != 0)
+                break;
+            KeStallExecutionProcessor(TIMECARD_FLASH_TRANSFER_POLL_US);
+        }
+        TimeCardFlashWrite32(context, XSPI_CR_OFFSET, control);
+        if ((status & XSPI_SR_TX_EMPTY) == 0) {
+            result = STATUS_IO_TIMEOUT;
+            goto Exit;
+        }
+
+        for (i = 0; i < chunk; ++i) {
+            for (polls = 0; polls < TIMECARD_FLASH_TRANSFER_POLLS; ++polls) {
+                status = TimeCardFlashRead32(context, XSPI_SR_OFFSET);
+                if ((status & XSPI_SR_RX_EMPTY) == 0)
+                    break;
+                KeStallExecutionProcessor(TIMECARD_FLASH_TRANSFER_POLL_US);
+            }
+            if ((status & XSPI_SR_RX_EMPTY) != 0) {
+                result = STATUS_IO_TIMEOUT;
+                goto Exit;
+            }
+            status = TimeCardFlashRead32(context, XSPI_RXD_OFFSET);
+            if (receive != NULL)
+                receive[offset + i] = (UCHAR)status;
+        }
+        offset += chunk;
+    }
+
+Exit:
+    TimeCardFlashWrite32(context, XSPI_CR_OFFSET, control);
+    TimeCardFlashWrite32(context, XSPI_SSR_OFFSET, 0xffffffffu);
+    return result;
+}
+
+static NTSTATUS
+TimeCardFlashSimpleCommand(PDEVICE_CONTEXT context, UCHAR command)
+{
+    UCHAR received;
+
+    return TimeCardFlashSpiTransfer(context, &command, &received, 1u);
+}
+
+static NTSTATUS
+TimeCardFlashReadStatusRegister(PDEVICE_CONTEXT context, UCHAR *flashStatus)
+{
+    UCHAR transmit[2] = { SPI_NOR_READ_STATUS, 0 };
+    UCHAR receive[2];
+    NTSTATUS status;
+
+    status = TimeCardFlashSpiTransfer(context, transmit, receive,
+                                      RTL_NUMBER_OF(transmit));
+    if (NT_SUCCESS(status))
+        *flashStatus = receive[1];
+    return status;
+}
+
+static NTSTATUS
+TimeCardFlashWaitReady(PDEVICE_CONTEXT context, ULONG timeoutMilliseconds,
+                       UCHAR *flashStatus)
+{
+    ULONG elapsed;
+    NTSTATUS status;
+
+    for (elapsed = 0; elapsed < timeoutMilliseconds; ++elapsed) {
+        status = TimeCardFlashReadStatusRegister(context, flashStatus);
+        if (!NT_SUCCESS(status))
+            return status;
+        if ((*flashStatus & SPI_NOR_STATUS_BUSY) == 0)
+            return STATUS_SUCCESS;
+        TimeCardFlashDelayMilliseconds(1);
+    }
+    return STATUS_IO_TIMEOUT;
+}
+
+static NTSTATUS
+TimeCardFlashWriteEnable(PDEVICE_CONTEXT context, UCHAR *flashStatus)
+{
+    NTSTATUS status = TimeCardFlashSimpleCommand(context,
+                                                 SPI_NOR_WRITE_ENABLE);
+
+    if (!NT_SUCCESS(status))
+        return status;
+    status = TimeCardFlashReadStatusRegister(context, flashStatus);
+    if (!NT_SUCCESS(status))
+        return status;
+    return (*flashStatus & SPI_NOR_STATUS_WEL) != 0 ?
+           STATUS_SUCCESS : STATUS_MEDIA_WRITE_PROTECTED;
+}
+
+static NTSTATUS
+TimeCardFlashIdentify(PDEVICE_CONTEXT context)
+{
+    UCHAR transmit[4] = { SPI_NOR_READ_ID, 0, 0, 0 };
+    UCHAR receive[4];
+    ULONGLONG capacity;
+    ULONG capacityCode;
+    NTSTATUS status;
+
+    if (context->FlashJedecId != 0 && context->FlashCapacity != 0)
+        return STATUS_SUCCESS;
+
+    status = TimeCardFlashInitialize(context);
+    if (!NT_SUCCESS(status))
+        return status;
+
+    /* FPGA configuration can leave some flashes in a non-default protocol. */
+    (VOID)TimeCardFlashSimpleCommand(context, SPI_NOR_RESET_ENABLE);
+    (VOID)TimeCardFlashSimpleCommand(context, SPI_NOR_RESET);
+    KeStallExecutionProcessor(50);
+
+    status = TimeCardFlashSpiTransfer(context, transmit, receive,
+                                      RTL_NUMBER_OF(transmit));
+    if (!NT_SUCCESS(status))
+        return status;
+    context->FlashJedecId = ((ULONG)receive[1] << 16) |
+                            ((ULONG)receive[2] << 8) | receive[3];
+    if (context->FlashJedecId == 0 ||
+        context->FlashJedecId == 0x00ffffffu) {
+        context->FlashJedecId = 0;
+        return STATUS_NO_SUCH_DEVICE;
+    }
+
+    capacityCode = receive[3];
+    if (capacityCode < 20u || capacityCode > 31u) {
+        context->FlashJedecId = 0;
+        return STATUS_NOT_SUPPORTED;
+    }
+    capacity = 1ull << capacityCode;
+    if (capacity > MAXULONG || capacity <= TIMECARD_FLASH_FIRMWARE_OFFSET) {
+        context->FlashJedecId = 0;
+        return STATUS_NOT_SUPPORTED;
+    }
+    context->FlashCapacity = (ULONG)capacity;
+    return STATUS_SUCCESS;
+}
+
+static NTSTATUS
+TimeCardFlashValidateRange(PDEVICE_CONTEXT context,
+                           const TIMECARD_FLASH_RANGE *request,
+                           ULONG maximumLength, PULONG absoluteOffset)
+{
+    ULONG available;
+
+    if (request->Size < sizeof(*request) || request->Length == 0 ||
+        request->Length > maximumLength)
+        return STATUS_INVALID_PARAMETER;
+    available = context->FlashCapacity - TIMECARD_FLASH_FIRMWARE_OFFSET;
+    if (request->Offset > available || request->Length >
+        available - request->Offset)
+        return STATUS_INVALID_PARAMETER;
+    *absoluteOffset = TIMECARD_FLASH_FIRMWARE_OFFSET + request->Offset;
+    return STATUS_SUCCESS;
+}
+
+static ULONG
+TimeCardFlashBuildAddressCommand(PDEVICE_CONTEXT context, UCHAR opcode3,
+                                 UCHAR opcode4, ULONG address, UCHAR *command)
+{
+    if (context->FlashCapacity > 0x01000000u) {
+        command[0] = opcode4;
+        command[1] = (UCHAR)(address >> 24);
+        command[2] = (UCHAR)(address >> 16);
+        command[3] = (UCHAR)(address >> 8);
+        command[4] = (UCHAR)address;
+        return 5u;
+    }
+    command[0] = opcode3;
+    command[1] = (UCHAR)(address >> 16);
+    command[2] = (UCHAR)(address >> 8);
+    command[3] = (UCHAR)address;
+    return 4u;
+}
+
+NTSTATUS
+TimeCardFlashQuery(PDEVICE_CONTEXT context, TIMECARD_FLASH_STATUS *status)
+{
+    UCHAR flashStatus = 0;
+    NTSTATUS result;
+
+    RtlZeroMemory(status, sizeof(*status));
+    status->Size = sizeof(*status);
+    status->Offset = context->FlashOffset;
+    status->FirmwareOffset = TIMECARD_FLASH_FIRMWARE_OFFSET;
+    status->EraseSize = TIMECARD_FLASH_ERASE_SIZE;
+    status->PageSize = TIMECARD_FLASH_PAGE_SIZE;
+    if (!context->HardwareReady || context->Flash == NULL)
+        return STATUS_DEVICE_NOT_READY;
+    status->Flags = TIMECARD_FLASH_FLAG_PRESENT;
+
+    WdfWaitLockAcquire(context->RegisterLock, NULL);
+    result = TimeCardFlashIdentify(context);
+    if (NT_SUCCESS(result)) {
+        status->Flags |= TIMECARD_FLASH_FLAG_IDENTIFIED |
+                         TIMECARD_FLASH_FLAG_SUPPORTED;
+        if (context->FlashCapacity > 0x01000000u)
+            status->Flags |= TIMECARD_FLASH_FLAG_FOUR_BYTE;
+        status->JedecId = context->FlashJedecId;
+        status->CapacityBytes = context->FlashCapacity;
+        status->FifoDepth = context->FlashFifoDepth;
+        result = TimeCardFlashReadStatusRegister(context, &flashStatus);
+        status->FlashStatus = flashStatus;
+        status->ControllerStatus =
+            TimeCardFlashRead32(context, XSPI_SR_OFFSET);
+    }
+    WdfWaitLockRelease(context->RegisterLock);
+    return result;
+}
+
+NTSTATUS
+TimeCardFlashRead(PDEVICE_CONTEXT context,
+                  const TIMECARD_FLASH_RANGE *request,
+                  TIMECARD_FLASH_TRANSFER *transfer)
+{
+    UCHAR transmit[TIMECARD_FLASH_MAX_TRANSFER + 5u];
+    UCHAR receive[TIMECARD_FLASH_MAX_TRANSFER + 5u];
+    ULONG absoluteOffset;
+    ULONG commandLength;
+    NTSTATUS status;
+
+    if (!context->HardwareReady || context->Flash == NULL)
+        return STATUS_DEVICE_NOT_READY;
+    WdfWaitLockAcquire(context->RegisterLock, NULL);
+    status = TimeCardFlashIdentify(context);
+    if (!NT_SUCCESS(status))
+        goto Exit;
+    status = TimeCardFlashValidateRange(
+        context, request, TIMECARD_FLASH_MAX_TRANSFER, &absoluteOffset);
+    if (!NT_SUCCESS(status))
+        goto Exit;
+
+    RtlZeroMemory(transmit, sizeof(transmit));
+    commandLength = TimeCardFlashBuildAddressCommand(
+        context, SPI_NOR_READ, SPI_NOR_READ_4BYTE, absoluteOffset, transmit);
+    status = TimeCardFlashSpiTransfer(
+        context, transmit, receive, commandLength + request->Length);
+    if (NT_SUCCESS(status)) {
+        RtlZeroMemory(transfer, sizeof(*transfer));
+        transfer->Size = sizeof(*transfer);
+        transfer->Offset = request->Offset;
+        transfer->Length = request->Length;
+        RtlCopyMemory(transfer->Data, receive + commandLength,
+                      request->Length);
+    }
+
+Exit:
+    WdfWaitLockRelease(context->RegisterLock);
+    return status;
+}
+
+NTSTATUS
+TimeCardFlashErase(PDEVICE_CONTEXT context,
+                   const TIMECARD_FLASH_RANGE *request,
+                   TIMECARD_FLASH_RESULT *result)
+{
+    UCHAR command[5];
+    UCHAR receive[5];
+    UCHAR flashStatus = 0;
+    ULONG absoluteOffset;
+    ULONG commandLength;
+    NTSTATUS status;
+
+    if (!context->HardwareReady || context->Flash == NULL)
+        return STATUS_DEVICE_NOT_READY;
+    WdfWaitLockAcquire(context->RegisterLock, NULL);
+    status = TimeCardFlashIdentify(context);
+    if (!NT_SUCCESS(status))
+        goto Exit;
+    status = TimeCardFlashValidateRange(
+        context, request, TIMECARD_FLASH_ERASE_SIZE, &absoluteOffset);
+    if (!NT_SUCCESS(status))
+        goto Exit;
+    if (request->Length != TIMECARD_FLASH_ERASE_SIZE ||
+        (request->Offset % TIMECARD_FLASH_ERASE_SIZE) != 0) {
+        status = STATUS_INVALID_PARAMETER;
+        goto Exit;
+    }
+
+    status = TimeCardFlashWriteEnable(context, &flashStatus);
+    if (!NT_SUCCESS(status))
+        goto Exit;
+    commandLength = TimeCardFlashBuildAddressCommand(
+        context, SPI_NOR_ERASE_4K, SPI_NOR_ERASE_4K_4BYTE,
+        absoluteOffset, command);
+    status = TimeCardFlashSpiTransfer(context, command, receive,
+                                      commandLength);
+    if (NT_SUCCESS(status))
+        status = TimeCardFlashWaitReady(
+            context, TIMECARD_FLASH_ERASE_TIMEOUT_MS, &flashStatus);
+    if (NT_SUCCESS(status)) {
+        RtlZeroMemory(result, sizeof(*result));
+        result->Size = sizeof(*result);
+        result->Offset = request->Offset;
+        result->Length = request->Length;
+        result->Status = flashStatus;
+    }
+
+Exit:
+    WdfWaitLockRelease(context->RegisterLock);
+    return status;
+}
+
+NTSTATUS
+TimeCardFlashProgram(PDEVICE_CONTEXT context,
+                     const TIMECARD_FLASH_TRANSFER *request,
+                     TIMECARD_FLASH_RESULT *result)
+{
+    TIMECARD_FLASH_RANGE range;
+    UCHAR transmit[TIMECARD_FLASH_MAX_TRANSFER + 5u];
+    UCHAR receive[TIMECARD_FLASH_MAX_TRANSFER + 5u];
+    UCHAR flashStatus = 0;
+    ULONG absoluteOffset;
+    ULONG commandLength;
+    NTSTATUS status;
+
+    if (!context->HardwareReady || context->Flash == NULL)
+        return STATUS_DEVICE_NOT_READY;
+    RtlZeroMemory(&range, sizeof(range));
+    range.Size = sizeof(range);
+    range.Offset = request->Offset;
+    range.Length = request->Length;
+
+    WdfWaitLockAcquire(context->RegisterLock, NULL);
+    status = TimeCardFlashIdentify(context);
+    if (!NT_SUCCESS(status))
+        goto Exit;
+    status = TimeCardFlashValidateRange(
+        context, &range, TIMECARD_FLASH_MAX_TRANSFER, &absoluteOffset);
+    if (!NT_SUCCESS(status))
+        goto Exit;
+    if (request->Size < FIELD_OFFSET(TIMECARD_FLASH_TRANSFER, Data) +
+                        request->Length ||
+        (absoluteOffset & (TIMECARD_FLASH_PAGE_SIZE - 1u)) +
+            request->Length > TIMECARD_FLASH_PAGE_SIZE) {
+        status = STATUS_INVALID_PARAMETER;
+        goto Exit;
+    }
+
+    status = TimeCardFlashWriteEnable(context, &flashStatus);
+    if (!NT_SUCCESS(status))
+        goto Exit;
+    commandLength = TimeCardFlashBuildAddressCommand(
+        context, SPI_NOR_PAGE_PROGRAM, SPI_NOR_PAGE_PROGRAM_4BYTE,
+        absoluteOffset, transmit);
+    RtlCopyMemory(transmit + commandLength, request->Data, request->Length);
+    status = TimeCardFlashSpiTransfer(
+        context, transmit, receive, commandLength + request->Length);
+    if (NT_SUCCESS(status))
+        status = TimeCardFlashWaitReady(
+            context, TIMECARD_FLASH_PROGRAM_TIMEOUT_MS, &flashStatus);
+    if (NT_SUCCESS(status)) {
+        RtlZeroMemory(result, sizeof(*result));
+        result->Size = sizeof(*result);
+        result->Offset = request->Offset;
+        result->Length = request->Length;
+        result->Status = flashStatus;
+    }
+
+Exit:
+    WdfWaitLockRelease(context->RegisterLock);
+    return status;
+}

--- a/DRV/Windows/i2c.c
+++ b/DRV/Windows/i2c.c
@@ -1,5 +1,5 @@
 /* SPDX-License-Identifier: BSD-3-Clause */
-/* Bounded, read-only Xilinx AXI IIC access for the OCP Time Card. */
+/* Bounded Xilinx AXI IIC access for the OCP Time Card. */
 
 #include "timecard.h"
 
@@ -79,6 +79,15 @@ TimeCardI2cClearInterrupts(PDEVICE_CONTEXT context)
 }
 
 static VOID
+TimeCardI2cClearInterruptMask(PDEVICE_CONTEXT context, ULONG mask)
+{
+    ULONG pending = TimeCardI2cRead32(context, XIIC_IISR_OFFSET) & mask;
+
+    if (pending != 0)
+        TimeCardI2cWrite32(context, XIIC_IISR_OFFSET, pending);
+}
+
+static VOID
 TimeCardI2cArmPolling(PDEVICE_CONTEXT context)
 {
     TimeCardI2cClearInterrupts(context);
@@ -109,7 +118,7 @@ TimeCardI2cReset(PDEVICE_CONTEXT context)
         }
         (VOID)TimeCardI2cRead8(context, XIIC_DRR_OFFSET);
     }
-    return STATUS_DEVICE_DATA_ERROR;
+    return STATUS_IO_DEVICE_ERROR;
 }
 
 static NTSTATUS
@@ -157,6 +166,343 @@ TimeCardI2cKnownDeviceFlag(ULONG address)
     if (address == 0x58u)
         return TIMECARD_I2C_DEVICE_MAC_EEPROM;
     return 0;
+}
+
+static VOID
+TimeCardI2cSetReceiveWatermark(PDEVICE_CONTEXT context, ULONG remaining)
+{
+    ULONG bytes = remaining < XIIC_FIFO_DEPTH ? remaining : XIIC_FIFO_DEPTH;
+
+    if (bytes != 0)
+        TimeCardI2cWrite8(context, XIIC_RFD_OFFSET, (UCHAR)(bytes - 1u));
+}
+
+static NTSTATUS
+TimeCardI2cWaitTransmitPhase(PDEVICE_CONTEXT context, ULONG *remainingPolls,
+                             ULONG *observedInterrupts,
+                             UCHAR *controllerStatus)
+{
+    while (*remainingPolls != 0) {
+        ULONG interrupts = TimeCardI2cRead32(context, XIIC_IISR_OFFSET);
+
+        --(*remainingPolls);
+        *observedInterrupts |= interrupts;
+        *controllerStatus = TimeCardI2cRead8(context, XIIC_SR_OFFSET);
+        if ((interrupts & XIIC_INTR_ARB_LOST) != 0)
+            return STATUS_IO_DEVICE_ERROR;
+        if ((interrupts & XIIC_INTR_TX_ERROR) != 0)
+            return STATUS_NO_SUCH_DEVICE;
+        if ((interrupts & XIIC_INTR_BNB) != 0)
+            return STATUS_IO_DEVICE_ERROR;
+        if ((interrupts & XIIC_INTR_TX_EMPTY) != 0) {
+            TimeCardI2cClearInterruptMask(context, XIIC_INTR_TX_EMPTY);
+            return STATUS_SUCCESS;
+        }
+        KeStallExecutionProcessor(TIMECARD_I2C_POLL_US);
+    }
+    return STATUS_IO_TIMEOUT;
+}
+
+static VOID
+TimeCardI2cDrainReceiveFifo(PDEVICE_CONTEXT context,
+                            const TIMECARD_I2C_READ_REQUEST *request,
+                            TIMECARD_I2C_TRANSFER *transfer,
+                            ULONG *copied)
+{
+    ULONG available;
+    ULONG remaining = request->Length - *copied;
+    ULONG i;
+
+    if ((TimeCardI2cRead8(context, XIIC_SR_OFFSET) &
+         XIIC_SR_RX_EMPTY) != 0) {
+        return;
+    }
+
+    available = (ULONG)TimeCardI2cRead8(context, XIIC_RFO_OFFSET) + 1u;
+    if (available > remaining)
+        available = remaining;
+    for (i = 0; i < available; ++i)
+        transfer->Data[(*copied)++] =
+            TimeCardI2cRead8(context, XIIC_DRR_OFFSET);
+
+    remaining = request->Length - *copied;
+    if (remaining != 0)
+        TimeCardI2cSetReceiveWatermark(context, remaining);
+}
+
+static NTSTATUS
+TimeCardI2cReadAttempt(PDEVICE_CONTEXT context,
+                       const TIMECARD_I2C_READ_REQUEST *request,
+                       TIMECARD_I2C_TRANSFER *transfer, ULONG pollCount)
+{
+    ULONG copied = 0;
+    ULONG remainingPolls = pollCount;
+    ULONG observedInterrupts = 0;
+    ULONG interrupts = 0;
+    UCHAR controllerStatus = 0;
+    NTSTATUS status;
+
+    status = TimeCardI2cPrepareTransfer(context);
+    if (!NT_SUCCESS(status))
+        goto Exit;
+
+    TimeCardI2cArmPolling(context);
+
+    /*
+     * Keep the subaddress write as a separate dynamic-mode message.  Waiting
+     * for TX empty here is important: it lets an address/data NACK surface
+     * before the repeated START for the receive message is queued.
+     */
+    if (request->SubaddressLength != 0) {
+        TimeCardI2cWrite16(
+            context, XIIC_DTR_OFFSET,
+            (USHORT)(XIIC_TX_DYN_START | (request->Address << 1)));
+        if (request->SubaddressLength == 2u) {
+            TimeCardI2cWrite16(
+                context, XIIC_DTR_OFFSET,
+                (USHORT)((request->Subaddress >> 8) & 0xffu));
+        }
+        TimeCardI2cWrite16(context, XIIC_DTR_OFFSET,
+                           (USHORT)(request->Subaddress & 0xffu));
+
+        status = TimeCardI2cWaitTransmitPhase(
+            context, &remainingPolls, &observedInterrupts,
+            &controllerStatus);
+        if (!NT_SUCCESS(status))
+            goto Exit;
+    }
+
+    /*
+     * AXI IIC reports the master's expected final receive NACK through the
+     * same TX_ERROR bit used for a slave address NACK.  Program a zero-based
+     * RX watermark, only drain after RX_FULL, then clear RX_FULL and the
+     * accompanying TX_ERROR together.  This mirrors the controller's
+     * dynamic receive state machine and removes the completion race.
+    */
+    TimeCardI2cSetReceiveWatermark(context, request->Length);
+    TimeCardI2cClearInterruptMask(
+        context, XIIC_INTR_RX_FULL | XIIC_INTR_TX_ERROR);
+    TimeCardI2cWrite16(
+        context, XIIC_DTR_OFFSET,
+        (USHORT)(XIIC_TX_DYN_START | (request->Address << 1) | 1u));
+    TimeCardI2cWrite16(
+        context, XIIC_DTR_OFFSET,
+        (USHORT)(XIIC_TX_DYN_STOP | request->Length));
+
+    status = STATUS_IO_TIMEOUT;
+    while (remainingPolls != 0) {
+        --remainingPolls;
+        interrupts = TimeCardI2cRead32(context, XIIC_IISR_OFFSET);
+        observedInterrupts |= interrupts;
+        controllerStatus = TimeCardI2cRead8(context, XIIC_SR_OFFSET);
+
+        if ((interrupts & XIIC_INTR_ARB_LOST) != 0) {
+            status = STATUS_IO_DEVICE_ERROR;
+            break;
+        }
+
+        if ((interrupts & XIIC_INTR_RX_FULL) != 0) {
+            TimeCardI2cDrainReceiveFifo(context, request, transfer,
+                                        &copied);
+            TimeCardI2cClearInterruptMask(
+                context, XIIC_INTR_RX_FULL | XIIC_INTR_TX_ERROR);
+            controllerStatus = TimeCardI2cRead8(context, XIIC_SR_OFFSET);
+        }
+
+        if (copied == request->Length &&
+            ((interrupts & XIIC_INTR_BNB) != 0 ||
+             (controllerStatus & XIIC_SR_BUS_BUSY) == 0)) {
+            status = STATUS_SUCCESS;
+            break;
+        }
+
+        if ((interrupts & XIIC_INTR_TX_ERROR) != 0 &&
+            (interrupts & XIIC_INTR_RX_FULL) == 0) {
+            status = copied == 0 ? STATUS_NO_SUCH_DEVICE :
+                                   STATUS_IO_DEVICE_ERROR;
+            break;
+        }
+
+        if ((interrupts & XIIC_INTR_BNB) != 0 &&
+            copied < request->Length) {
+            status = STATUS_IO_DEVICE_ERROR;
+            break;
+        }
+        KeStallExecutionProcessor(TIMECARD_I2C_POLL_US);
+    }
+
+Exit:
+    transfer->Length = copied;
+    transfer->ControllerStatus = controllerStatus;
+    transfer->InterruptStatus = observedInterrupts;
+    (VOID)TimeCardI2cReset(context);
+    return status;
+}
+
+static NTSTATUS
+TimeCardI2cReadLocked(PDEVICE_CONTEXT context,
+                      const TIMECARD_I2C_READ_REQUEST *request,
+                      TIMECARD_I2C_TRANSFER *transfer)
+{
+    ULONG timeoutMilliseconds = request->TimeoutMilliseconds;
+    ULONG pollCount;
+    ULONG attempt;
+    NTSTATUS status = STATUS_IO_TIMEOUT;
+
+    if (timeoutMilliseconds == 0)
+        timeoutMilliseconds = TIMECARD_I2C_DEFAULT_TIMEOUT_MS;
+    if (timeoutMilliseconds > TIMECARD_I2C_MAX_TIMEOUT_MS)
+        timeoutMilliseconds = TIMECARD_I2C_MAX_TIMEOUT_MS;
+    pollCount = timeoutMilliseconds * 1000u / TIMECARD_I2C_POLL_US;
+
+    RtlZeroMemory(transfer, sizeof(*transfer));
+    transfer->Size = (ULONG)FIELD_OFFSET(TIMECARD_I2C_TRANSFER, Data) +
+                     request->Length;
+    transfer->Address = request->Address;
+
+    for (attempt = 0; attempt < 2u; ++attempt) {
+        transfer->Length = 0;
+        transfer->ControllerStatus = 0;
+        transfer->InterruptStatus = 0;
+        status = TimeCardI2cReadAttempt(context, request, transfer,
+                                        pollCount);
+        if (NT_SUCCESS(status) || status == STATUS_NO_SUCH_DEVICE)
+            break;
+    }
+    return status;
+}
+
+static NTSTATUS
+TimeCardI2cWriteAttempt(PDEVICE_CONTEXT context, ULONG address,
+                        const UCHAR *data, ULONG length, ULONG pollCount,
+                        ULONG *controllerStatus, ULONG *interruptStatus)
+{
+    ULONG remainingPolls = pollCount;
+    ULONG observedInterrupts = 0;
+    UCHAR currentStatus = 0;
+    ULONG i;
+    NTSTATUS status;
+
+    status = TimeCardI2cPrepareTransfer(context);
+    if (!NT_SUCCESS(status))
+        goto Exit;
+
+    TimeCardI2cArmPolling(context);
+    TimeCardI2cWrite16(
+        context, XIIC_DTR_OFFSET,
+        (USHORT)(XIIC_TX_DYN_START | (address << 1)));
+    for (i = 0; i < length; ++i) {
+        USHORT value = data[i];
+        if (i + 1u == length)
+            value |= XIIC_TX_DYN_STOP;
+        TimeCardI2cWrite16(context, XIIC_DTR_OFFSET, value);
+    }
+
+    status = STATUS_IO_TIMEOUT;
+    while (remainingPolls != 0) {
+        ULONG interrupts;
+
+        --remainingPolls;
+        interrupts = TimeCardI2cRead32(context, XIIC_IISR_OFFSET);
+        observedInterrupts |= interrupts;
+        currentStatus = TimeCardI2cRead8(context, XIIC_SR_OFFSET);
+        if ((interrupts & XIIC_INTR_ARB_LOST) != 0) {
+            status = STATUS_IO_DEVICE_ERROR;
+            break;
+        }
+        if ((interrupts & XIIC_INTR_TX_ERROR) != 0) {
+            status = STATUS_NO_SUCH_DEVICE;
+            break;
+        }
+        if ((interrupts & XIIC_INTR_BNB) != 0) {
+            status = STATUS_SUCCESS;
+            break;
+        }
+        KeStallExecutionProcessor(TIMECARD_I2C_POLL_US);
+    }
+
+Exit:
+    *controllerStatus = currentStatus;
+    *interruptStatus = observedInterrupts;
+    (VOID)TimeCardI2cReset(context);
+    return status;
+}
+
+static NTSTATUS
+TimeCardI2cWriteLocked(PDEVICE_CONTEXT context, ULONG address,
+                       const UCHAR *data, ULONG length,
+                       ULONG *controllerStatus, ULONG *interruptStatus)
+{
+    ULONG pollCount = TIMECARD_I2C_DEFAULT_TIMEOUT_MS * 1000u /
+                      TIMECARD_I2C_POLL_US;
+    ULONG attempt;
+    NTSTATUS status = STATUS_IO_TIMEOUT;
+
+    if (!TimeCardI2cAddressValid(address) || data == NULL ||
+        length == 0 || length >= XIIC_FIFO_DEPTH) {
+        return STATUS_INVALID_PARAMETER;
+    }
+
+    *controllerStatus = 0;
+    *interruptStatus = 0;
+    for (attempt = 0; attempt < 2u; ++attempt) {
+        status = TimeCardI2cWriteAttempt(
+            context, address, data, length, pollCount,
+            controllerStatus, interruptStatus);
+        if (NT_SUCCESS(status) || status == STATUS_NO_SUCH_DEVICE)
+            break;
+    }
+    return status;
+}
+
+static NTSTATUS
+TimeCardI2cReadBytesLocked(PDEVICE_CONTEXT context, ULONG address,
+                           ULONG subaddressLength, ULONG subaddress,
+                           UCHAR *data, ULONG length,
+                           ULONG *controllerStatus, ULONG *interruptStatus)
+{
+    TIMECARD_I2C_READ_REQUEST request;
+    TIMECARD_I2C_TRANSFER transfer;
+    NTSTATUS status;
+
+    RtlZeroMemory(&request, sizeof(request));
+    request.Size = sizeof(request);
+    request.Address = address;
+    request.SubaddressLength = subaddressLength;
+    request.Subaddress = subaddress;
+    request.Length = length;
+    request.TimeoutMilliseconds = TIMECARD_I2C_DEFAULT_TIMEOUT_MS;
+    status = TimeCardI2cReadLocked(context, &request, &transfer);
+    *controllerStatus = transfer.ControllerStatus;
+    *interruptStatus = transfer.InterruptStatus;
+    if (NT_SUCCESS(status))
+        RtlCopyMemory(data, transfer.Data, length);
+    return status;
+}
+
+static NTSTATUS
+TimeCardI2cMuxReadLocked(PDEVICE_CONTEXT context, UCHAR *channelMask,
+                         ULONG *controllerStatus, ULONG *interruptStatus)
+{
+    UCHAR value = 0;
+    NTSTATUS status = TimeCardI2cReadBytesLocked(
+        context, TIMECARD_I2C_MUX_ADDRESS, 0, 0, &value, 1,
+        controllerStatus, interruptStatus);
+
+    if (NT_SUCCESS(status))
+        *channelMask = value & TIMECARD_I2C_MUX_CHANNEL_MASK;
+    return status;
+}
+
+static NTSTATUS
+TimeCardI2cMuxWriteLocked(PDEVICE_CONTEXT context, UCHAR channelMask,
+                          ULONG *controllerStatus, ULONG *interruptStatus)
+{
+    UCHAR value = channelMask & TIMECARD_I2C_MUX_CHANNEL_MASK;
+
+    return TimeCardI2cWriteLocked(
+        context, TIMECARD_I2C_MUX_ADDRESS, &value, 1,
+        controllerStatus, interruptStatus);
 }
 
 NTSTATUS
@@ -231,7 +577,7 @@ TimeCardI2cProbe(PDEVICE_CONTEXT context, ULONG address,
         interruptStatus = TimeCardI2cRead32(context, XIIC_IISR_OFFSET);
         controllerStatus = TimeCardI2cRead8(context, XIIC_SR_OFFSET);
         if ((interruptStatus & XIIC_INTR_ARB_LOST) != 0) {
-            status = STATUS_DEVICE_DATA_ERROR;
+            status = STATUS_IO_DEVICE_ERROR;
             break;
         }
         if ((interruptStatus & XIIC_INTR_TX_ERROR) != 0) {
@@ -268,12 +614,6 @@ TimeCardI2cRead(PDEVICE_CONTEXT context,
                 const TIMECARD_I2C_READ_REQUEST *request,
                 TIMECARD_I2C_TRANSFER *transfer)
 {
-    ULONG timeoutMilliseconds;
-    ULONG pollCount;
-    ULONG copied = 0;
-    ULONG i;
-    ULONG interruptStatus = 0;
-    UCHAR controllerStatus = 0;
     NTSTATUS status;
 
     if (!context->HardwareReady || context->I2c == NULL)
@@ -285,94 +625,273 @@ TimeCardI2cRead(PDEVICE_CONTEXT context,
         return STATUS_INVALID_PARAMETER;
     }
 
-    timeoutMilliseconds = request->TimeoutMilliseconds;
-    if (timeoutMilliseconds == 0)
-        timeoutMilliseconds = TIMECARD_I2C_DEFAULT_TIMEOUT_MS;
-    if (timeoutMilliseconds > TIMECARD_I2C_MAX_TIMEOUT_MS)
-        timeoutMilliseconds = TIMECARD_I2C_MAX_TIMEOUT_MS;
-    pollCount = timeoutMilliseconds * 1000u / TIMECARD_I2C_POLL_US;
-
-    RtlZeroMemory(transfer, sizeof(*transfer));
-    transfer->Size = (ULONG)FIELD_OFFSET(TIMECARD_I2C_TRANSFER, Data) +
-                     request->Length;
-    transfer->Address = request->Address;
-
     WdfWaitLockAcquire(context->RegisterLock, NULL);
-    status = TimeCardI2cPrepareTransfer(context);
+    status = TimeCardI2cReadLocked(context, request, transfer);
+    WdfWaitLockRelease(context->RegisterLock);
+    return status;
+}
+
+NTSTATUS
+TimeCardI2cMuxQuery(PDEVICE_CONTEXT context,
+                    TIMECARD_I2C_MUX_CONTROL *control)
+{
+    UCHAR channelMask = 0;
+    ULONG controllerStatus = 0;
+    ULONG interruptStatus = 0;
+    NTSTATUS status;
+
+    if (!context->HardwareReady || context->I2c == NULL)
+        return STATUS_DEVICE_NOT_READY;
+
+    RtlZeroMemory(control, sizeof(*control));
+    control->Size = sizeof(*control);
+    WdfWaitLockAcquire(context->RegisterLock, NULL);
+    status = TimeCardI2cMuxReadLocked(
+        context, &channelMask, &controllerStatus, &interruptStatus);
+    control->ControllerStatus = controllerStatus;
+    control->InterruptStatus = interruptStatus;
+    if (NT_SUCCESS(status)) {
+        control->Present = 1;
+        control->ChannelMask = channelMask;
+    } else if (status == STATUS_NO_SUCH_DEVICE) {
+        /* Absence is a query result, not a transport failure. */
+        status = STATUS_SUCCESS;
+    }
+    WdfWaitLockRelease(context->RegisterLock);
+    return status;
+}
+
+NTSTATUS
+TimeCardI2cMuxSet(PDEVICE_CONTEXT context,
+                  const TIMECARD_I2C_MUX_CONTROL *request,
+                  TIMECARD_I2C_MUX_CONTROL *response)
+{
+    UCHAR channelMask = 0;
+    ULONG controllerStatus = 0;
+    ULONG interruptStatus = 0;
+    NTSTATUS status;
+
+    if (!context->HardwareReady || context->I2c == NULL)
+        return STATUS_DEVICE_NOT_READY;
+    if (request->Size < sizeof(*request) ||
+        (request->ChannelMask & ~TIMECARD_I2C_MUX_CHANNEL_MASK) != 0) {
+        return STATUS_INVALID_PARAMETER;
+    }
+
+    RtlZeroMemory(response, sizeof(*response));
+    response->Size = sizeof(*response);
+    WdfWaitLockAcquire(context->RegisterLock, NULL);
+    status = TimeCardI2cMuxWriteLocked(
+        context, (UCHAR)request->ChannelMask,
+        &controllerStatus, &interruptStatus);
+    if (NT_SUCCESS(status)) {
+        status = TimeCardI2cMuxReadLocked(
+            context, &channelMask, &controllerStatus, &interruptStatus);
+    }
+    response->ControllerStatus = controllerStatus;
+    response->InterruptStatus = interruptStatus;
+    if (NT_SUCCESS(status)) {
+        response->Present = 1;
+        response->ChannelMask = channelMask;
+        if (channelMask != (UCHAR)request->ChannelMask)
+            status = STATUS_DEVICE_DATA_ERROR;
+    }
+    WdfWaitLockRelease(context->RegisterLock);
+    return status;
+}
+
+static NTSTATUS
+TimeCardLedSelectLocked(PDEVICE_CONTEXT context, UCHAR *savedMask,
+                        BOOLEAN *changed, ULONG *controllerStatus,
+                        ULONG *interruptStatus)
+{
+    NTSTATUS status = TimeCardI2cMuxReadLocked(
+        context, savedMask, controllerStatus, interruptStatus);
+
+    *changed = FALSE;
+    if (!NT_SUCCESS(status))
+        return status;
+    if (*savedMask == TIMECARD_I2C_MUX_CHANNEL_SENSORS)
+        return STATUS_SUCCESS;
+
+    status = TimeCardI2cMuxWriteLocked(
+        context, TIMECARD_I2C_MUX_CHANNEL_SENSORS,
+        controllerStatus, interruptStatus);
+    if (NT_SUCCESS(status))
+        *changed = TRUE;
+    return status;
+}
+
+static NTSTATUS
+TimeCardLedRestoreLocked(PDEVICE_CONTEXT context, UCHAR savedMask,
+                         BOOLEAN changed, NTSTATUS operationStatus,
+                         ULONG *controllerStatus, ULONG *interruptStatus)
+{
+    NTSTATUS restoreStatus;
+
+    if (!changed)
+        return operationStatus;
+    restoreStatus = TimeCardI2cMuxWriteLocked(
+        context, savedMask, controllerStatus, interruptStatus);
+    return NT_SUCCESS(operationStatus) ? restoreStatus : operationStatus;
+}
+
+NTSTATUS
+TimeCardLedQuery(PDEVICE_CONTEXT context, ULONG led,
+                 TIMECARD_LED_CONTROL *control)
+{
+    UCHAR savedMask = 0;
+    BOOLEAN changed = FALSE;
+    UCHAR deviceControl = 0;
+    UCHAR globalCurrent = 0;
+    UCHAR pwm[6];
+    ULONG controllerStatus = 0;
+    ULONG interruptStatus = 0;
+    NTSTATUS status;
+
+    if (!context->HardwareReady || context->I2c == NULL)
+        return STATUS_DEVICE_NOT_READY;
+    if (led >= TIMECARD_LED_COUNT)
+        return STATUS_INVALID_PARAMETER;
+
+    RtlZeroMemory(control, sizeof(*control));
+    control->Size = sizeof(*control);
+    control->Led = led;
+    WdfWaitLockAcquire(context->RegisterLock, NULL);
+    status = TimeCardLedSelectLocked(
+        context, &savedMask, &changed,
+        &controllerStatus, &interruptStatus);
+    control->MuxChannelMask = savedMask;
     if (!NT_SUCCESS(status))
         goto Exit;
 
-    TimeCardI2cArmPolling(context);
-    TimeCardI2cWrite8(
-        context, XIIC_RFD_OFFSET,
-        (UCHAR)((request->Length < XIIC_FIFO_DEPTH ? request->Length :
-                 XIIC_FIFO_DEPTH) - 1u));
-
-    if (request->SubaddressLength != 0) {
-        TimeCardI2cWrite16(
-            context, XIIC_DTR_OFFSET,
-            (USHORT)(XIIC_TX_DYN_START | (request->Address << 1)));
-        if (request->SubaddressLength == 2u) {
-            TimeCardI2cWrite16(
-                context, XIIC_DTR_OFFSET,
-                (USHORT)((request->Subaddress >> 8) & 0xffu));
-        }
-        TimeCardI2cWrite16(context, XIIC_DTR_OFFSET,
-                           (USHORT)(request->Subaddress & 0xffu));
+    status = TimeCardI2cReadBytesLocked(
+        context, 0x6eu, 1, 0x00u, &deviceControl, 1,
+        &controllerStatus, &interruptStatus);
+    if (!NT_SUCCESS(status))
+        goto Exit;
+    status = TimeCardI2cReadBytesLocked(
+        context, 0x6eu, 1, 0x6eu, &globalCurrent, 1,
+        &controllerStatus, &interruptStatus);
+    if (!NT_SUCCESS(status))
+        goto Exit;
+    status = TimeCardI2cReadBytesLocked(
+        context, 0x6eu, 1, 0x01u + led * 6u, pwm, sizeof(pwm),
+        &controllerStatus, &interruptStatus);
+    if (NT_SUCCESS(status)) {
+        control->Flags = TIMECARD_LED_FLAG_PRESENT;
+        if ((deviceControl & 0x01u) != 0)
+            control->Flags |= TIMECARD_LED_FLAG_ENABLED;
+        control->Red = pwm[0];
+        control->Green = pwm[2];
+        control->Blue = pwm[4];
+        control->GlobalCurrent = globalCurrent;
     }
-
-    TimeCardI2cWrite16(
-        context, XIIC_DTR_OFFSET,
-        (USHORT)(XIIC_TX_DYN_START | (request->Address << 1) | 1u));
-    TimeCardI2cWrite16(
-        context, XIIC_DTR_OFFSET,
-        (USHORT)(XIIC_TX_DYN_STOP | request->Length));
-
-    status = STATUS_IO_TIMEOUT;
-    for (i = 0; i < pollCount; ++i) {
-        interruptStatus = TimeCardI2cRead32(context, XIIC_IISR_OFFSET);
-        controllerStatus = TimeCardI2cRead8(context, XIIC_SR_OFFSET);
-
-        if ((interruptStatus & XIIC_INTR_ARB_LOST) != 0) {
-            status = STATUS_DEVICE_DATA_ERROR;
-            break;
-        }
-
-        while ((controllerStatus & XIIC_SR_RX_EMPTY) == 0 &&
-               copied < request->Length) {
-            transfer->Data[copied++] =
-                TimeCardI2cRead8(context, XIIC_DRR_OFFSET);
-            controllerStatus = TimeCardI2cRead8(context, XIIC_SR_OFFSET);
-        }
-
-        if (copied == request->Length &&
-            (controllerStatus & XIIC_SR_BUS_BUSY) == 0) {
-            status = STATUS_SUCCESS;
-            break;
-        }
-
-        if ((interruptStatus & XIIC_INTR_TX_ERROR) != 0 &&
-            (interruptStatus & XIIC_INTR_RX_FULL) == 0 && copied == 0 &&
-            ((interruptStatus & XIIC_INTR_BNB) != 0 ||
-             (controllerStatus & XIIC_SR_BUS_BUSY) == 0)) {
-            status = STATUS_NO_SUCH_DEVICE;
-            break;
-        }
-
-        if ((interruptStatus & XIIC_INTR_BNB) != 0 &&
-            copied < request->Length) {
-            status = STATUS_DEVICE_DATA_ERROR;
-            break;
-        }
-        KeStallExecutionProcessor(TIMECARD_I2C_POLL_US);
-    }
-
-    transfer->Length = copied;
-    transfer->ControllerStatus = controllerStatus;
-    transfer->InterruptStatus = interruptStatus;
-    (VOID)TimeCardI2cReset(context);
 
 Exit:
+    status = TimeCardLedRestoreLocked(
+        context, savedMask, changed, status,
+        &controllerStatus, &interruptStatus);
+    control->ControllerStatus = controllerStatus;
+    control->InterruptStatus = interruptStatus;
+    WdfWaitLockRelease(context->RegisterLock);
+    return status;
+}
+
+NTSTATUS
+TimeCardLedSet(PDEVICE_CONTEXT context,
+               const TIMECARD_LED_CONTROL *request,
+               TIMECARD_LED_CONTROL *response)
+{
+    UCHAR savedMask = 0;
+    BOOLEAN changed = FALSE;
+    UCHAR writeBuffer[7];
+    ULONG controllerStatus = 0;
+    ULONG interruptStatus = 0;
+    NTSTATUS status;
+
+    if (!context->HardwareReady || context->I2c == NULL)
+        return STATUS_DEVICE_NOT_READY;
+    if (request->Size < sizeof(*request) ||
+        request->Led >= TIMECARD_LED_COUNT ||
+        request->Red > 0xffu || request->Green > 0xffu ||
+        request->Blue > 0xffu || request->GlobalCurrent == 0 ||
+        request->GlobalCurrent > TIMECARD_LED_MAX_GLOBAL_CURRENT) {
+        return STATUS_INVALID_PARAMETER;
+    }
+
+    RtlZeroMemory(response, sizeof(*response));
+    response->Size = sizeof(*response);
+    response->Led = request->Led;
+    WdfWaitLockAcquire(context->RegisterLock, NULL);
+    status = TimeCardLedSelectLocked(
+        context, &savedMask, &changed,
+        &controllerStatus, &interruptStatus);
+    response->MuxChannelMask = savedMask;
+    if (!NT_SUCCESS(status))
+        goto Exit;
+
+    /* 8-bit PWM mode, normal operation.  This yields flicker-free PWM. */
+    writeBuffer[0] = 0x00u;
+    writeBuffer[1] = 0x01u;
+    status = TimeCardI2cWriteLocked(
+        context, 0x6eu, writeBuffer, 2,
+        &controllerStatus, &interruptStatus);
+    if (!NT_SUCCESS(status))
+        goto Exit;
+
+    writeBuffer[0] = 0x6eu;
+    writeBuffer[1] = (UCHAR)request->GlobalCurrent;
+    status = TimeCardI2cWriteLocked(
+        context, 0x6eu, writeBuffer, 2,
+        &controllerStatus, &interruptStatus);
+    if (!NT_SUCCESS(status))
+        goto Exit;
+
+    /* Apply full per-channel scaling; global current remains safety-capped. */
+    writeBuffer[0] = (UCHAR)(0x4au + request->Led * 3u);
+    writeBuffer[1] = 0xffu;
+    writeBuffer[2] = 0xffu;
+    writeBuffer[3] = 0xffu;
+    status = TimeCardI2cWriteLocked(
+        context, 0x6eu, writeBuffer, 4,
+        &controllerStatus, &interruptStatus);
+    if (!NT_SUCCESS(status))
+        goto Exit;
+
+    writeBuffer[0] = (UCHAR)(0x01u + request->Led * 6u);
+    writeBuffer[1] = (UCHAR)request->Red;
+    writeBuffer[2] = 0;
+    writeBuffer[3] = (UCHAR)request->Green;
+    writeBuffer[4] = 0;
+    writeBuffer[5] = (UCHAR)request->Blue;
+    writeBuffer[6] = 0;
+    status = TimeCardI2cWriteLocked(
+        context, 0x6eu, writeBuffer, sizeof(writeBuffer),
+        &controllerStatus, &interruptStatus);
+    if (!NT_SUCCESS(status))
+        goto Exit;
+
+    writeBuffer[0] = 0x49u;
+    writeBuffer[1] = 0;
+    status = TimeCardI2cWriteLocked(
+        context, 0x6eu, writeBuffer, 2,
+        &controllerStatus, &interruptStatus);
+    if (NT_SUCCESS(status)) {
+        response->Flags = TIMECARD_LED_FLAG_PRESENT |
+                          TIMECARD_LED_FLAG_ENABLED;
+        response->Red = request->Red;
+        response->Green = request->Green;
+        response->Blue = request->Blue;
+        response->GlobalCurrent = request->GlobalCurrent;
+    }
+
+Exit:
+    status = TimeCardLedRestoreLocked(
+        context, savedMask, changed, status,
+        &controllerStatus, &interruptStatus);
+    response->ControllerStatus = controllerStatus;
+    response->InterruptStatus = interruptStatus;
     WdfWaitLockRelease(context->RegisterLock);
     return status;
 }
@@ -402,7 +921,7 @@ TimeCardGetIdentity(PDEVICE_CONTEXT context, TIMECARD_IDENTITY *identity)
     if (!NT_SUCCESS(status))
         return status;
     if (transfer.Length != TIMECARD_IDENTITY_SERIAL_LENGTH)
-        return STATUS_DEVICE_DATA_ERROR;
+        return STATUS_IO_DEVICE_ERROR;
 
     identity->Flags = TIMECARD_IDENTITY_FLAG_PRESENT;
     for (i = 0; i < TIMECARD_IDENTITY_SERIAL_LENGTH; ++i) {

--- a/DRV/Windows/include/timecard_ioctl.h
+++ b/DRV/Windows/include/timecard_ioctl.h
@@ -54,8 +54,34 @@
     TIMECARD_IOCTL(15, FILE_READ_ACCESS | FILE_WRITE_ACCESS)
 #define IOCTL_TIMECARD_GET_IDENTITY \
     TIMECARD_IOCTL(16, FILE_READ_ACCESS)
+#define IOCTL_TIMECARD_SIGNAL_QUERY \
+    TIMECARD_IOCTL(17, FILE_READ_ACCESS | FILE_WRITE_ACCESS)
+#define IOCTL_TIMECARD_SIGNAL_SET \
+    TIMECARD_IOCTL(18, FILE_READ_ACCESS | FILE_WRITE_ACCESS)
+#define IOCTL_TIMECARD_FREQUENCY_QUERY \
+    TIMECARD_IOCTL(19, FILE_READ_ACCESS | FILE_WRITE_ACCESS)
+#define IOCTL_TIMECARD_FREQUENCY_SET \
+    TIMECARD_IOCTL(20, FILE_READ_ACCESS | FILE_WRITE_ACCESS)
+#define IOCTL_TIMECARD_FLASH_QUERY \
+    TIMECARD_IOCTL(21, FILE_READ_ACCESS)
+#define IOCTL_TIMECARD_FLASH_READ \
+    TIMECARD_IOCTL(22, FILE_READ_ACCESS | FILE_WRITE_ACCESS)
+#define IOCTL_TIMECARD_FLASH_ERASE \
+    TIMECARD_IOCTL(23, FILE_READ_ACCESS | FILE_WRITE_ACCESS)
+#define IOCTL_TIMECARD_FLASH_PROGRAM \
+    TIMECARD_IOCTL(24, FILE_READ_ACCESS | FILE_WRITE_ACCESS)
+#define IOCTL_TIMECARD_UART_OBSERVE \
+    TIMECARD_IOCTL(25, FILE_READ_ACCESS | FILE_WRITE_ACCESS)
+#define IOCTL_TIMECARD_I2C_MUX_QUERY \
+    TIMECARD_IOCTL(26, FILE_READ_ACCESS)
+#define IOCTL_TIMECARD_I2C_MUX_SET \
+    TIMECARD_IOCTL(27, FILE_READ_ACCESS | FILE_WRITE_ACCESS)
+#define IOCTL_TIMECARD_LED_QUERY \
+    TIMECARD_IOCTL(28, FILE_READ_ACCESS | FILE_WRITE_ACCESS)
+#define IOCTL_TIMECARD_LED_SET \
+    TIMECARD_IOCTL(29, FILE_READ_ACCESS | FILE_WRITE_ACCESS)
 
-#define TIMECARD_ABI_VERSION 4u
+#define TIMECARD_ABI_VERSION 7u
 #define TIMECARD_LAYOUT_MSI  1u
 #define TIMECARD_LAYOUT_MSIX 2u
 #define TIMECARD_UART_COUNT  4u
@@ -90,6 +116,26 @@
 #define TIMECARD_I2C_DEVICE_BOARD_EEPROM (1u << 0)
 #define TIMECARD_I2C_DEVICE_MAC_EEPROM   (1u << 1)
 
+/* U27, PCA9546A at 0x70.  More than one downstream branch may be selected. */
+#define TIMECARD_I2C_MUX_ADDRESS         0x70u
+#define TIMECARD_I2C_MUX_CHANNEL_MAC     (1u << 0)
+#define TIMECARD_I2C_MUX_CHANNEL_SENSORS (1u << 1)
+#define TIMECARD_I2C_MUX_CHANNEL_ANADC   (1u << 2)
+#define TIMECARD_I2C_MUX_CHANNEL_DC      (1u << 3)
+#define TIMECARD_I2C_MUX_CHANNEL_MASK    0x0fu
+
+/* U6, IS32FL3207 at 0x6e on the sensor branch. */
+#define TIMECARD_LED_COUNT 6u
+#define TIMECARD_LED_GNSS1 0u
+#define TIMECARD_LED_GNSS2 1u
+#define TIMECARD_LED_IO1   2u
+#define TIMECARD_LED_IO2   3u
+#define TIMECARD_LED_IO3   4u
+#define TIMECARD_LED_IO4   5u
+#define TIMECARD_LED_FLAG_PRESENT (1u << 0)
+#define TIMECARD_LED_FLAG_ENABLED (1u << 1)
+#define TIMECARD_LED_MAX_GLOBAL_CURRENT 128u
+
 #define TIMECARD_CLOCK_SOURCE_NONE 0x00u
 #define TIMECARD_CLOCK_SOURCE_TOD  0x01u
 #define TIMECARD_CLOCK_SOURCE_IRIG 0x02u
@@ -106,6 +152,30 @@
 #define TIMECARD_IDENTITY_FLAG_PRESENT (1u << 0)
 #define TIMECARD_IDENTITY_FLAG_VALID   (1u << 1)
 #define TIMECARD_IDENTITY_SERIAL_LENGTH 6u
+
+#define TIMECARD_SIGNAL_COUNT 4u
+#define TIMECARD_SIGNAL_FLAG_PRESENT  (1u << 0)
+#define TIMECARD_SIGNAL_FLAG_ENABLED  (1u << 1)
+#define TIMECARD_SIGNAL_FLAG_INVERTED (1u << 2)
+
+#define TIMECARD_FREQUENCY_COUNT 4u
+#define TIMECARD_FREQUENCY_FLAG_PRESENT (1u << 0)
+#define TIMECARD_FREQUENCY_FLAG_ENABLED (1u << 1)
+#define TIMECARD_FREQUENCY_FLAG_VALID   (1u << 2)
+#define TIMECARD_FREQUENCY_FLAG_ERROR   (1u << 3)
+#define TIMECARD_FREQUENCY_FLAG_OVERRUN (1u << 4)
+
+#define TIMECARD_FLASH_MAX_TRANSFER 256u
+#define TIMECARD_FLASH_FIRMWARE_OFFSET 0x00400000u
+#define TIMECARD_FLASH_ERASE_SIZE 4096u
+#define TIMECARD_FLASH_PAGE_SIZE 256u
+#define TIMECARD_FLASH_FLAG_PRESENT    (1u << 0)
+#define TIMECARD_FLASH_FLAG_IDENTIFIED (1u << 1)
+#define TIMECARD_FLASH_FLAG_SUPPORTED  (1u << 2)
+#define TIMECARD_FLASH_FLAG_FOUR_BYTE  (1u << 3)
+
+#define TIMECARD_UART_OBSERVE_FLAG_PRESENT  (1u << 0)
+#define TIMECARD_UART_OBSERVE_FLAG_ACTIVITY (1u << 1)
 
 /* Function selectors match the FPGA SMA maps and the Linux ptp_ocp ABI. */
 #define TIMECARD_SMA_INPUT_10MHZ 0x0000u
@@ -255,6 +325,29 @@ typedef struct _TIMECARD_I2C_TRANSFER {
     unsigned char Data[TIMECARD_I2C_MAX_TRANSFER];
 } TIMECARD_I2C_TRANSFER;
 
+typedef struct _TIMECARD_I2C_MUX_CONTROL {
+    unsigned __int32 Size;
+    unsigned __int32 ChannelMask;
+    unsigned __int32 Present;
+    unsigned __int32 ControllerStatus;
+    unsigned __int32 InterruptStatus;
+    unsigned __int32 Reserved[3];
+} TIMECARD_I2C_MUX_CONTROL;
+
+typedef struct _TIMECARD_LED_CONTROL {
+    unsigned __int32 Size;
+    unsigned __int32 Led;
+    unsigned __int32 Flags;
+    unsigned __int32 Red;
+    unsigned __int32 Green;
+    unsigned __int32 Blue;
+    unsigned __int32 GlobalCurrent;
+    unsigned __int32 MuxChannelMask;
+    unsigned __int32 ControllerStatus;
+    unsigned __int32 InterruptStatus;
+    unsigned __int32 Reserved[2];
+} TIMECARD_LED_CONTROL;
+
 typedef struct _TIMECARD_CLOCK_SOURCE_CONTROL {
     unsigned __int32 Size;
     unsigned __int32 Source;
@@ -280,5 +373,80 @@ typedef struct _TIMECARD_IDENTITY {
     unsigned char Serial[TIMECARD_IDENTITY_SERIAL_LENGTH];
     unsigned char Reserved[2];
 } TIMECARD_IDENTITY;
+
+/* Generator numbers are 1 through 4. Times are expressed in nanoseconds. */
+typedef struct _TIMECARD_SIGNAL_CONTROL {
+    unsigned __int32 Size;
+    unsigned __int32 Generator;
+    unsigned __int32 Flags;
+    unsigned __int32 Status;
+    unsigned __int32 Version;
+    unsigned __int32 RepeatCount;
+    unsigned __int32 StartNanoseconds;
+    unsigned __int32 Reserved;
+    unsigned __int64 PeriodNanoseconds;
+    unsigned __int64 PulseNanoseconds;
+    unsigned __int64 PhaseNanoseconds;
+    unsigned __int64 StartSeconds;
+} TIMECARD_SIGNAL_CONTROL;
+
+/* Counter numbers are 1 through 4; zero integration seconds disables it. */
+typedef struct _TIMECARD_FREQUENCY_CONTROL {
+    unsigned __int32 Size;
+    unsigned __int32 Counter;
+    unsigned __int32 Flags;
+    unsigned __int32 IntegrationSeconds;
+    unsigned __int32 FrequencyHz;
+    unsigned __int32 Control;
+    unsigned __int32 Status;
+    unsigned __int32 Reserved;
+} TIMECARD_FREQUENCY_CONTROL;
+
+typedef struct _TIMECARD_FLASH_STATUS {
+    unsigned __int32 Size;
+    unsigned __int32 Flags;
+    unsigned __int32 Offset;
+    unsigned __int32 JedecId;
+    unsigned __int32 CapacityBytes;
+    unsigned __int32 FirmwareOffset;
+    unsigned __int32 EraseSize;
+    unsigned __int32 PageSize;
+    unsigned __int32 ControllerStatus;
+    unsigned __int32 FlashStatus;
+    unsigned __int32 FifoDepth;
+    unsigned __int32 Reserved[5];
+} TIMECARD_FLASH_STATUS;
+
+/* Flash offsets are relative to TIMECARD_FLASH_FIRMWARE_OFFSET. */
+typedef struct _TIMECARD_FLASH_RANGE {
+    unsigned __int32 Size;
+    unsigned __int32 Offset;
+    unsigned __int32 Length;
+    unsigned __int32 Reserved;
+} TIMECARD_FLASH_RANGE;
+
+typedef struct _TIMECARD_FLASH_TRANSFER {
+    unsigned __int32 Size;
+    unsigned __int32 Offset;
+    unsigned __int32 Length;
+    unsigned __int32 Status;
+    unsigned char Data[TIMECARD_FLASH_MAX_TRANSFER];
+} TIMECARD_FLASH_TRANSFER;
+
+typedef struct _TIMECARD_FLASH_RESULT {
+    unsigned __int32 Size;
+    unsigned __int32 Offset;
+    unsigned __int32 Length;
+    unsigned __int32 Status;
+} TIMECARD_FLASH_RESULT;
+
+typedef struct _TIMECARD_UART_OBSERVE {
+    unsigned __int32 Size;
+    unsigned __int32 Port;
+    unsigned __int32 TimeoutMilliseconds;
+    unsigned __int32 Flags;
+    unsigned __int32 LineStatus;
+    unsigned __int32 Reserved[3];
+} TIMECARD_UART_OBSERVE;
 
 #endif /* TIMECARD_IOCTL_H */

--- a/DRV/Windows/ioctl.c
+++ b/DRV/Windows/ioctl.c
@@ -283,6 +283,86 @@ TimeCardEvtIoDeviceControl(WDFQUEUE queue, WDFREQUEST request,
         break;
     }
 
+    case IOCTL_TIMECARD_I2C_MUX_QUERY:
+    {
+        TIMECARD_I2C_MUX_CONTROL *output;
+
+        status = TimeCardGetOutput(request, sizeof(*output),
+                                   (PVOID *)&output);
+        if (NT_SUCCESS(status)) {
+            status = TimeCardI2cMuxQuery(context, output);
+            if (NT_SUCCESS(status))
+                information = sizeof(*output);
+        }
+        break;
+    }
+
+    case IOCTL_TIMECARD_I2C_MUX_SET:
+    {
+        TIMECARD_I2C_MUX_CONTROL *input;
+        TIMECARD_I2C_MUX_CONTROL requestValue;
+        TIMECARD_I2C_MUX_CONTROL *output;
+
+        status = TimeCardGetInput(request, sizeof(*input),
+                                  (PVOID *)&input, NULL);
+        if (!NT_SUCCESS(status))
+            break;
+        requestValue = *input;
+
+        status = TimeCardGetOutput(request, sizeof(*output),
+                                   (PVOID *)&output);
+        if (NT_SUCCESS(status)) {
+            status = TimeCardI2cMuxSet(context, &requestValue, output);
+            if (NT_SUCCESS(status))
+                information = sizeof(*output);
+        }
+        break;
+    }
+
+    case IOCTL_TIMECARD_LED_QUERY:
+    {
+        TIMECARD_LED_CONTROL *input;
+        TIMECARD_LED_CONTROL requestValue;
+        TIMECARD_LED_CONTROL *output;
+
+        status = TimeCardGetInput(request, sizeof(*input),
+                                  (PVOID *)&input, NULL);
+        if (!NT_SUCCESS(status))
+            break;
+        requestValue = *input;
+
+        status = TimeCardGetOutput(request, sizeof(*output),
+                                   (PVOID *)&output);
+        if (NT_SUCCESS(status)) {
+            status = TimeCardLedQuery(context, requestValue.Led, output);
+            if (NT_SUCCESS(status))
+                information = sizeof(*output);
+        }
+        break;
+    }
+
+    case IOCTL_TIMECARD_LED_SET:
+    {
+        TIMECARD_LED_CONTROL *input;
+        TIMECARD_LED_CONTROL requestValue;
+        TIMECARD_LED_CONTROL *output;
+
+        status = TimeCardGetInput(request, sizeof(*input),
+                                  (PVOID *)&input, NULL);
+        if (!NT_SUCCESS(status))
+            break;
+        requestValue = *input;
+
+        status = TimeCardGetOutput(request, sizeof(*output),
+                                   (PVOID *)&output);
+        if (NT_SUCCESS(status)) {
+            status = TimeCardLedSet(context, &requestValue, output);
+            if (NT_SUCCESS(status))
+                information = sizeof(*output);
+        }
+        break;
+    }
+
     case IOCTL_TIMECARD_CLOCK_SOURCE_SET:
     {
         TIMECARD_CLOCK_SOURCE_CONTROL *input;
@@ -349,6 +429,211 @@ TimeCardEvtIoDeviceControl(WDFQUEUE queue, WDFREQUEST request,
                                    (PVOID *)&output);
         if (NT_SUCCESS(status)) {
             status = TimeCardGetIdentity(context, output);
+            if (NT_SUCCESS(status))
+                information = sizeof(*output);
+        }
+        break;
+    }
+
+    case IOCTL_TIMECARD_SIGNAL_QUERY:
+    {
+        TIMECARD_SIGNAL_CONTROL *input;
+        TIMECARD_SIGNAL_CONTROL requestValue;
+        TIMECARD_SIGNAL_CONTROL *output;
+
+        status = TimeCardGetInput(request, sizeof(*input),
+                                  (PVOID *)&input, NULL);
+        if (!NT_SUCCESS(status))
+            break;
+        requestValue = *input;
+        status = TimeCardGetOutput(request, sizeof(*output),
+                                   (PVOID *)&output);
+        if (NT_SUCCESS(status)) {
+            status = TimeCardSignalQuery(context, requestValue.Generator,
+                                         output);
+            if (NT_SUCCESS(status))
+                information = sizeof(*output);
+        }
+        break;
+    }
+
+    case IOCTL_TIMECARD_SIGNAL_SET:
+    {
+        TIMECARD_SIGNAL_CONTROL *input;
+        TIMECARD_SIGNAL_CONTROL requestValue;
+        TIMECARD_SIGNAL_CONTROL *output;
+
+        status = TimeCardGetInput(request, sizeof(*input),
+                                  (PVOID *)&input, NULL);
+        if (!NT_SUCCESS(status))
+            break;
+        requestValue = *input;
+        status = TimeCardGetOutput(request, sizeof(*output),
+                                   (PVOID *)&output);
+        if (NT_SUCCESS(status)) {
+            status = TimeCardSignalSet(context, &requestValue, output);
+            if (NT_SUCCESS(status))
+                information = sizeof(*output);
+        }
+        break;
+    }
+
+    case IOCTL_TIMECARD_FREQUENCY_QUERY:
+    {
+        TIMECARD_FREQUENCY_CONTROL *input;
+        TIMECARD_FREQUENCY_CONTROL requestValue;
+        TIMECARD_FREQUENCY_CONTROL *output;
+
+        status = TimeCardGetInput(request, sizeof(*input),
+                                  (PVOID *)&input, NULL);
+        if (!NT_SUCCESS(status))
+            break;
+        requestValue = *input;
+        status = TimeCardGetOutput(request, sizeof(*output),
+                                   (PVOID *)&output);
+        if (NT_SUCCESS(status)) {
+            status = TimeCardFrequencyQuery(context, requestValue.Counter,
+                                            output);
+            if (NT_SUCCESS(status))
+                information = sizeof(*output);
+        }
+        break;
+    }
+
+    case IOCTL_TIMECARD_FREQUENCY_SET:
+    {
+        TIMECARD_FREQUENCY_CONTROL *input;
+        TIMECARD_FREQUENCY_CONTROL requestValue;
+        TIMECARD_FREQUENCY_CONTROL *output;
+
+        status = TimeCardGetInput(request, sizeof(*input),
+                                  (PVOID *)&input, NULL);
+        if (!NT_SUCCESS(status))
+            break;
+        requestValue = *input;
+        status = TimeCardGetOutput(request, sizeof(*output),
+                                   (PVOID *)&output);
+        if (NT_SUCCESS(status)) {
+            status = TimeCardFrequencySet(context, &requestValue, output);
+            if (NT_SUCCESS(status))
+                information = sizeof(*output);
+        }
+        break;
+    }
+
+    case IOCTL_TIMECARD_FLASH_QUERY:
+    {
+        TIMECARD_FLASH_STATUS *output;
+
+        status = TimeCardGetOutput(request, sizeof(*output),
+                                   (PVOID *)&output);
+        if (NT_SUCCESS(status)) {
+            status = TimeCardFlashQuery(context, output);
+            if (NT_SUCCESS(status))
+                information = sizeof(*output);
+        }
+        break;
+    }
+
+    case IOCTL_TIMECARD_FLASH_READ:
+    {
+        TIMECARD_FLASH_RANGE *input;
+        TIMECARD_FLASH_RANGE requestValue;
+        TIMECARD_FLASH_TRANSFER *output;
+
+        status = TimeCardGetInput(request, sizeof(*input),
+                                  (PVOID *)&input, NULL);
+        if (!NT_SUCCESS(status))
+            break;
+        requestValue = *input;
+        status = TimeCardGetOutput(request, sizeof(*output),
+                                   (PVOID *)&output);
+        if (NT_SUCCESS(status)) {
+            status = TimeCardFlashRead(context, &requestValue, output);
+            if (NT_SUCCESS(status))
+                information = FIELD_OFFSET(TIMECARD_FLASH_TRANSFER, Data) +
+                              output->Length;
+        }
+        break;
+    }
+
+    case IOCTL_TIMECARD_FLASH_ERASE:
+    {
+        TIMECARD_FLASH_RANGE *input;
+        TIMECARD_FLASH_RANGE requestValue;
+        TIMECARD_FLASH_RESULT *output;
+
+        status = TimeCardGetInput(request, sizeof(*input),
+                                  (PVOID *)&input, NULL);
+        if (!NT_SUCCESS(status))
+            break;
+        requestValue = *input;
+        status = TimeCardGetOutput(request, sizeof(*output),
+                                   (PVOID *)&output);
+        if (NT_SUCCESS(status)) {
+            status = TimeCardFlashErase(context, &requestValue, output);
+            if (NT_SUCCESS(status))
+                information = sizeof(*output);
+        }
+        break;
+    }
+
+    case IOCTL_TIMECARD_FLASH_PROGRAM:
+    {
+        TIMECARD_FLASH_TRANSFER *input;
+        TIMECARD_FLASH_TRANSFER requestValue;
+        TIMECARD_FLASH_RESULT *output;
+        size_t actualInputLength = 0;
+        size_t requiredInputLength;
+
+        status = TimeCardGetInput(
+            request, FIELD_OFFSET(TIMECARD_FLASH_TRANSFER, Data),
+            (PVOID *)&input, &actualInputLength);
+        if (!NT_SUCCESS(status))
+            break;
+        if (actualInputLength > sizeof(requestValue)) {
+            status = STATUS_INVALID_BUFFER_SIZE;
+            break;
+        }
+        RtlZeroMemory(&requestValue, sizeof(requestValue));
+        RtlCopyMemory(&requestValue, input, actualInputLength);
+        if (requestValue.Length > TIMECARD_FLASH_MAX_TRANSFER) {
+            status = STATUS_INVALID_PARAMETER;
+            break;
+        }
+        requiredInputLength =
+            FIELD_OFFSET(TIMECARD_FLASH_TRANSFER, Data) +
+            requestValue.Length;
+        if (requestValue.Size < requiredInputLength ||
+            actualInputLength < requiredInputLength) {
+            status = STATUS_BUFFER_TOO_SMALL;
+            break;
+        }
+        status = TimeCardGetOutput(request, sizeof(*output),
+                                   (PVOID *)&output);
+        if (NT_SUCCESS(status)) {
+            status = TimeCardFlashProgram(context, &requestValue, output);
+            if (NT_SUCCESS(status))
+                information = sizeof(*output);
+        }
+        break;
+    }
+
+    case IOCTL_TIMECARD_UART_OBSERVE:
+    {
+        TIMECARD_UART_OBSERVE *input;
+        TIMECARD_UART_OBSERVE requestValue;
+        TIMECARD_UART_OBSERVE *output;
+
+        status = TimeCardGetInput(request, sizeof(*input),
+                                  (PVOID *)&input, NULL);
+        if (!NT_SUCCESS(status))
+            break;
+        requestValue = *input;
+        status = TimeCardGetOutput(request, sizeof(*output),
+                                   (PVOID *)&output);
+        if (NT_SUCCESS(status)) {
+            status = TimeCardUartObserve(context, &requestValue, output);
             if (NT_SUCCESS(status))
                 information = sizeof(*output);
         }

--- a/DRV/Windows/package-release.ps1
+++ b/DRV/Windows/package-release.ps1
@@ -20,7 +20,7 @@ if (-not $OutputDirectory.StartsWith(
     throw 'OutputDirectory must be a child of the Windows driver directory.'
 }
 $driverFolder = Join-Path $OutputDirectory 'TimeCard'
-$cabPath = Join-Path $OutputDirectory 'TimeCard-1.9-x64.cab'
+$cabPath = Join-Path $OutputDirectory 'TimeCard-1.13-x64.cab'
 
 function Find-MSBuild {
     $command = Get-Command msbuild.exe -ErrorAction SilentlyContinue
@@ -126,7 +126,7 @@ $ddfLines = @(
     '.Set CompressionType=MSZIP',
     '.Set Cabinet=on',
     '.Set Compress=on',
-    '.Set CabinetNameTemplate=TimeCard-1.9-x64.cab',
+    '.Set CabinetNameTemplate=TimeCard-1.13-x64.cab',
     ".Set DiskDirectoryTemplate=`"$OutputDirectory`"",
     ".Set RptFileName=`"$(Join-Path $OutputDirectory 'TimeCard.rpt')`"",
     ".Set InfFileName=`"$(Join-Path $OutputDirectory 'TimeCard-cab.inf')`"",

--- a/DRV/Windows/ptp.c
+++ b/DRV/Windows/ptp.c
@@ -122,7 +122,7 @@ TimeCardGetInfo(PDEVICE_CONTEXT context, TIMECARD_INFO *info)
 
     RtlZeroMemory(info, sizeof(*info));
     info->AbiVersion = TIMECARD_ABI_VERSION;
-    info->DriverVersion = 0x00010009u;
+    info->DriverVersion = 0x0001000cu;
     info->Layout = context->Layout;
     info->InterruptMessages = context->InterruptMessages;
     info->BarLength = context->Bar0Length;

--- a/DRV/Windows/serial.c
+++ b/DRV/Windows/serial.c
@@ -189,3 +189,44 @@ TimeCardUartWrite(PDEVICE_CONTEXT context,
     UNREFERENCED_PARAMETER(UART_LSR_TEMT);
     return STATUS_SUCCESS;
 }
+
+NTSTATUS
+TimeCardUartObserve(PDEVICE_CONTEXT context,
+                    const TIMECARD_UART_OBSERVE *request,
+                    TIMECARD_UART_OBSERVE *response)
+{
+    ULONGLONG deadline;
+    ULONG timeout;
+
+    if (request->Size < sizeof(*request) ||
+        request->Port >= TIMECARD_UART_COUNT)
+        return STATUS_INVALID_PARAMETER;
+    if (!TimeCardUartValid(context, request->Port))
+        return STATUS_INVALID_DEVICE_STATE;
+
+    timeout = TimeCardUartClampTimeout(request->TimeoutMilliseconds);
+    deadline = KeQueryInterruptTime() + (ULONGLONG)timeout * 10000u;
+    RtlZeroMemory(response, sizeof(*response));
+    response->Size = sizeof(*response);
+    response->Port = request->Port;
+    response->TimeoutMilliseconds = timeout;
+    response->Flags = TIMECARD_UART_OBSERVE_FLAG_PRESENT;
+
+    do {
+        UCHAR lsr;
+
+        WdfWaitLockAcquire(context->RegisterLock, NULL);
+        lsr = TimeCardUartReadRegister(context, request->Port, UART_LSR);
+        WdfWaitLockRelease(context->RegisterLock);
+        response->LineStatus |= lsr;
+        if ((lsr & UART_LSR_DR) != 0) {
+            response->Flags |= TIMECARD_UART_OBSERVE_FLAG_ACTIVITY;
+            break;
+        }
+        if (timeout == 0 || KeQueryInterruptTime() >= deadline)
+            break;
+        TimeCardUartPause();
+    } while (TRUE);
+
+    return STATUS_SUCCESS;
+}

--- a/DRV/Windows/timecard.h
+++ b/DRV/Windows/timecard.h
@@ -34,6 +34,13 @@ extern const GUID GUID_DEVCLASS_TIMECARD;
 
 #define TIMECARD_I2C_OFFSET_MSI         0x00150000u
 #define TIMECARD_I2C_OFFSET_MSIX        0x02150000u
+#define TIMECARD_FLASH_OFFSET_MSI       0x00310000u
+#define TIMECARD_FLASH_OFFSET_MSIX      0x02310000u
+
+#define TIMECARD_SIGNAL_BASE_MSI        0x010d0000u
+#define TIMECARD_SIGNAL_BASE_MSIX       0x030d0000u
+#define TIMECARD_FREQUENCY_BASE_MSI     0x01200000u
+#define TIMECARD_FREQUENCY_BASE_MSIX    0x03200000u
 
 #define TIMECARD_REGISTER_WINDOW_SIZE   0x00010000u
 #define TIMECARD_UART_CLOCK_HZ          50000000u
@@ -93,6 +100,31 @@ typedef struct _TIMECARD_GPIO_REG {
     ULONG Reserved1;
 } TIMECARD_GPIO_REG, *PTIMECARD_GPIO_REG;
 
+typedef struct _TIMECARD_SIGNAL_REG {
+    ULONG Enable;
+    ULONG Status;
+    ULONG Polarity;
+    ULONG Version;
+    ULONG Reserved0[4];
+    ULONG CableDelay;
+    ULONG Reserved1[3];
+    ULONG Interrupt;
+    ULONG InterruptMask;
+    ULONG Reserved2[2];
+    ULONG StartNanoseconds;
+    ULONG StartSeconds;
+    ULONG PulseNanoseconds;
+    ULONG PulseSeconds;
+    ULONG PeriodNanoseconds;
+    ULONG PeriodSeconds;
+    ULONG RepeatCount;
+} TIMECARD_SIGNAL_REG, *PTIMECARD_SIGNAL_REG;
+
+typedef struct _TIMECARD_FREQUENCY_REG {
+    ULONG Control;
+    ULONG Status;
+} TIMECARD_FREQUENCY_REG, *PTIMECARD_FREQUENCY_REG;
+
 typedef struct _DEVICE_CONTEXT {
     WDFDEVICE Device;
     volatile UCHAR *Bar0Base;
@@ -102,13 +134,20 @@ typedef struct _DEVICE_CONTEXT {
     volatile TOD_REG *NmeaOut;
     volatile TIMECARD_GPIO_REG *SmaMap1;
     volatile TIMECARD_GPIO_REG *SmaMap2;
+    volatile TIMECARD_SIGNAL_REG *Signal[TIMECARD_SIGNAL_COUNT];
+    volatile TIMECARD_FREQUENCY_REG *Frequency[TIMECARD_FREQUENCY_COUNT];
     volatile UCHAR *I2c;
+    volatile UCHAR *Flash;
     volatile UCHAR *Uart[TIMECARD_UART_COUNT];
     ULONG ClockOffset;
     ULONG TodOffset;
     ULONG NmeaOutOffset;
     ULONG I2cOffset;
     ULONG I2cKnownDeviceMask;
+    ULONG FlashOffset;
+    ULONG FlashJedecId;
+    ULONG FlashCapacity;
+    ULONG FlashFifoDepth;
     ULONG InterruptMessages;
     ULONG Layout;
     BOOLEAN HardwareReady;
@@ -177,6 +216,9 @@ NTSTATUS TimeCardUartWrite(PDEVICE_CONTEXT context,
                            const TIMECARD_UART_TRANSFER *transfer,
                            ULONG inputLength,
                            TIMECARD_UART_RESULT *result);
+NTSTATUS TimeCardUartObserve(PDEVICE_CONTEXT context,
+                             const TIMECARD_UART_OBSERVE *request,
+                             TIMECARD_UART_OBSERVE *response);
 
 NTSTATUS TimeCardSmaQuery(PDEVICE_CONTEXT context,
                           ULONG connector,
@@ -193,6 +235,17 @@ NTSTATUS TimeCardI2cProbe(PDEVICE_CONTEXT context,
 NTSTATUS TimeCardI2cRead(PDEVICE_CONTEXT context,
                          const TIMECARD_I2C_READ_REQUEST *request,
                          TIMECARD_I2C_TRANSFER *transfer);
+NTSTATUS TimeCardI2cMuxQuery(PDEVICE_CONTEXT context,
+                             TIMECARD_I2C_MUX_CONTROL *control);
+NTSTATUS TimeCardI2cMuxSet(PDEVICE_CONTEXT context,
+                           const TIMECARD_I2C_MUX_CONTROL *request,
+                           TIMECARD_I2C_MUX_CONTROL *response);
+NTSTATUS TimeCardLedQuery(PDEVICE_CONTEXT context,
+                          ULONG led,
+                          TIMECARD_LED_CONTROL *control);
+NTSTATUS TimeCardLedSet(PDEVICE_CONTEXT context,
+                        const TIMECARD_LED_CONTROL *request,
+                        TIMECARD_LED_CONTROL *response);
 NTSTATUS TimeCardGetIdentity(PDEVICE_CONTEXT context,
                              TIMECARD_IDENTITY *identity);
 
@@ -202,3 +255,26 @@ NTSTATUS TimeCardNmeaQuery(PDEVICE_CONTEXT context,
 NTSTATUS TimeCardNmeaSet(PDEVICE_CONTEXT context,
                          const TIMECARD_NMEA_CONTROL *request,
                          TIMECARD_NMEA_CONTROL *response);
+
+NTSTATUS TimeCardSignalQuery(PDEVICE_CONTEXT context, ULONG generator,
+                             TIMECARD_SIGNAL_CONTROL *control);
+NTSTATUS TimeCardSignalSet(PDEVICE_CONTEXT context,
+                           const TIMECARD_SIGNAL_CONTROL *request,
+                           TIMECARD_SIGNAL_CONTROL *response);
+NTSTATUS TimeCardFrequencyQuery(PDEVICE_CONTEXT context, ULONG counter,
+                                TIMECARD_FREQUENCY_CONTROL *control);
+NTSTATUS TimeCardFrequencySet(PDEVICE_CONTEXT context,
+                              const TIMECARD_FREQUENCY_CONTROL *request,
+                              TIMECARD_FREQUENCY_CONTROL *response);
+
+NTSTATUS TimeCardFlashQuery(PDEVICE_CONTEXT context,
+                            TIMECARD_FLASH_STATUS *status);
+NTSTATUS TimeCardFlashRead(PDEVICE_CONTEXT context,
+                           const TIMECARD_FLASH_RANGE *request,
+                           TIMECARD_FLASH_TRANSFER *transfer);
+NTSTATUS TimeCardFlashErase(PDEVICE_CONTEXT context,
+                            const TIMECARD_FLASH_RANGE *request,
+                            TIMECARD_FLASH_RESULT *result);
+NTSTATUS TimeCardFlashProgram(PDEVICE_CONTEXT context,
+                              const TIMECARD_FLASH_TRANSFER *request,
+                              TIMECARD_FLASH_RESULT *result);

--- a/DRV/Windows/timecard.inf
+++ b/DRV/Windows/timecard.inf
@@ -7,7 +7,7 @@ Class       = TimeCard
 ClassGuid   = {B5415088-5EE1-4D3A-8519-C3487370E0BF}
 Provider    = %ProviderName%
 CatalogFile = timecard.cat
-DriverVer   = 07/14/2026,1.9.0.0
+DriverVer   = 07/14/2026,1.13.0.0
 PnpLockdown = 1
 
 [ClassInstall32]

--- a/DRV/Windows/timecard.vcxproj
+++ b/DRV/Windows/timecard.vcxproj
@@ -61,12 +61,14 @@
   <ItemGroup>
     <ClCompile Include="bus.c" />
     <ClCompile Include="driver.c" />
+    <ClCompile Include="flash.c" />
     <ClCompile Include="i2c.c" />
     <ClCompile Include="ioctl.c" />
     <ClCompile Include="nmea.c" />
     <ClCompile Include="ptp.c" />
     <ClCompile Include="serial.c" />
     <ClCompile Include="sma.c" />
+    <ClCompile Include="timing.c" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="timecard.h" />

--- a/DRV/Windows/timing.c
+++ b/DRV/Windows/timing.c
@@ -1,0 +1,304 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+/* Bounded signal-generator and frequency-counter control. */
+
+#include "timecard.h"
+
+#define TIMECARD_NANOSECONDS_PER_SECOND 1000000000ull
+#define TIMECARD_SIGNAL_ENABLE_VALID    0x00000003u
+#define TIMECARD_FREQUENCY_ENABLE       0x00000001u
+#define TIMECARD_FREQUENCY_VALID        (1u << 31)
+#define TIMECARD_FREQUENCY_ERROR        (1u << 30)
+#define TIMECARD_FREQUENCY_OVERRUN      (1u << 29)
+#define TIMECARD_FREQUENCY_VALUE_MASK   ((1u << 24) - 1u)
+
+C_ASSERT(sizeof(TIMECARD_SIGNAL_CONTROL) == 64);
+C_ASSERT(sizeof(TIMECARD_FREQUENCY_CONTROL) == 32);
+C_ASSERT(FIELD_OFFSET(TIMECARD_SIGNAL_REG, StartNanoseconds) == 0x40);
+C_ASSERT(FIELD_OFFSET(TIMECARD_SIGNAL_REG, RepeatCount) == 0x58);
+
+static ULONGLONG
+TimeCardJoinTime(ULONG seconds, ULONG nanoseconds)
+{
+    return (ULONGLONG)seconds * TIMECARD_NANOSECONDS_PER_SECOND +
+           nanoseconds;
+}
+
+static NTSTATUS
+TimeCardReadClockLocked(PDEVICE_CONTEXT context, PULONGLONG nanoseconds)
+{
+    ULONG ctrl;
+    ULONG seconds;
+    ULONG subsecond;
+    ULONG i;
+
+    WRITE_REGISTER_ULONG((PULONG)&context->Regs->Ctrl,
+                         OCP_CTRL_READ_TIME_REQ | OCP_CTRL_ENABLE);
+    for (i = 0; i < 100; ++i) {
+        ctrl = READ_REGISTER_ULONG((PULONG)&context->Regs->Ctrl);
+        if ((ctrl & OCP_CTRL_READ_TIME_DONE) != 0)
+            break;
+        KeStallExecutionProcessor(1);
+    }
+    if (i == 100)
+        return STATUS_IO_TIMEOUT;
+
+    subsecond = READ_REGISTER_ULONG((PULONG)&context->Regs->TimeNs);
+    seconds = READ_REGISTER_ULONG((PULONG)&context->Regs->TimeSec);
+    if (subsecond >= TIMECARD_NANOSECONDS_PER_SECOND)
+        return STATUS_DEVICE_DATA_ERROR;
+    *nanoseconds = TimeCardJoinTime(seconds, subsecond);
+    return STATUS_SUCCESS;
+}
+
+static NTSTATUS
+TimeCardSignalQueryLocked(PDEVICE_CONTEXT context, ULONG generator,
+                          TIMECARD_SIGNAL_CONTROL *control)
+{
+    volatile TIMECARD_SIGNAL_REG *reg;
+    ULONG enable;
+    ULONG polarity;
+    ULONG periodNanoseconds;
+    ULONG pulseNanoseconds;
+    ULONG startNanoseconds;
+
+    reg = context->Signal[generator - 1];
+    if (reg == NULL)
+        return STATUS_NOT_SUPPORTED;
+
+    RtlZeroMemory(control, sizeof(*control));
+    control->Size = sizeof(*control);
+    control->Generator = generator;
+    enable = READ_REGISTER_ULONG((PULONG)&reg->Enable);
+    control->Status = READ_REGISTER_ULONG((PULONG)&reg->Status);
+    polarity = READ_REGISTER_ULONG((PULONG)&reg->Polarity);
+    control->Version = READ_REGISTER_ULONG((PULONG)&reg->Version);
+    control->RepeatCount = READ_REGISTER_ULONG((PULONG)&reg->RepeatCount);
+    startNanoseconds = READ_REGISTER_ULONG((PULONG)&reg->StartNanoseconds);
+    control->StartSeconds = READ_REGISTER_ULONG((PULONG)&reg->StartSeconds);
+    pulseNanoseconds = READ_REGISTER_ULONG((PULONG)&reg->PulseNanoseconds);
+    periodNanoseconds = READ_REGISTER_ULONG((PULONG)&reg->PeriodNanoseconds);
+
+    if (startNanoseconds >= TIMECARD_NANOSECONDS_PER_SECOND ||
+        pulseNanoseconds >= TIMECARD_NANOSECONDS_PER_SECOND ||
+        periodNanoseconds >= TIMECARD_NANOSECONDS_PER_SECOND)
+        return STATUS_DEVICE_DATA_ERROR;
+
+    control->StartNanoseconds = startNanoseconds;
+    control->PulseNanoseconds = TimeCardJoinTime(
+        READ_REGISTER_ULONG((PULONG)&reg->PulseSeconds), pulseNanoseconds);
+    control->PeriodNanoseconds = TimeCardJoinTime(
+        READ_REGISTER_ULONG((PULONG)&reg->PeriodSeconds),
+        periodNanoseconds);
+    control->Flags = TIMECARD_SIGNAL_FLAG_PRESENT;
+    if ((enable & 1u) != 0)
+        control->Flags |= TIMECARD_SIGNAL_FLAG_ENABLED;
+    if (polarity != 0)
+        control->Flags |= TIMECARD_SIGNAL_FLAG_INVERTED;
+    if (control->PeriodNanoseconds != 0) {
+        ULONGLONG start = TimeCardJoinTime(
+            (ULONG)control->StartSeconds, control->StartNanoseconds);
+        control->PhaseNanoseconds = start % control->PeriodNanoseconds;
+    }
+    return STATUS_SUCCESS;
+}
+
+NTSTATUS
+TimeCardSignalQuery(PDEVICE_CONTEXT context, ULONG generator,
+                    TIMECARD_SIGNAL_CONTROL *control)
+{
+    NTSTATUS status;
+
+    if (!context->HardwareReady || context->Regs == NULL)
+        return STATUS_DEVICE_NOT_READY;
+    if (generator == 0 || generator > TIMECARD_SIGNAL_COUNT)
+        return STATUS_INVALID_PARAMETER;
+
+    WdfWaitLockAcquire(context->RegisterLock, NULL);
+    status = TimeCardSignalQueryLocked(context, generator, control);
+    WdfWaitLockRelease(context->RegisterLock);
+    return status;
+}
+
+NTSTATUS
+TimeCardSignalSet(PDEVICE_CONTEXT context,
+                  const TIMECARD_SIGNAL_CONTROL *request,
+                  TIMECARD_SIGNAL_CONTROL *response)
+{
+    volatile TIMECARD_SIGNAL_REG *reg;
+    ULONGLONG period;
+    ULONGLONG pulse;
+    ULONGLONG phase;
+    ULONGLONG now;
+    ULONGLONG start;
+    ULONGLONG remainder;
+    ULONGLONG maximum = ~(ULONGLONG)0;
+    BOOLEAN enabled;
+    NTSTATUS status;
+
+    if (!context->HardwareReady || context->Regs == NULL)
+        return STATUS_DEVICE_NOT_READY;
+    if (request->Size < sizeof(*request) || request->Generator == 0 ||
+        request->Generator > TIMECARD_SIGNAL_COUNT)
+        return STATUS_INVALID_PARAMETER;
+    reg = context->Signal[request->Generator - 1];
+    if (reg == NULL)
+        return STATUS_NOT_SUPPORTED;
+
+    enabled = (request->Flags & TIMECARD_SIGNAL_FLAG_ENABLED) != 0;
+    period = request->PeriodNanoseconds;
+    pulse = request->PulseNanoseconds;
+    phase = request->PhaseNanoseconds;
+    if (enabled &&
+        (period < 2 || pulse == 0 || pulse >= period || phase >= period ||
+         period / TIMECARD_NANOSECONDS_PER_SECOND > MAXULONG))
+        return STATUS_INVALID_PARAMETER;
+
+    WdfWaitLockAcquire(context->RegisterLock, NULL);
+    WRITE_REGISTER_ULONG((PULONG)&reg->InterruptMask, 0);
+    WRITE_REGISTER_ULONG((PULONG)&reg->Enable, 0);
+    WRITE_REGISTER_ULONG((PULONG)&reg->Polarity,
+        (request->Flags & TIMECARD_SIGNAL_FLAG_INVERTED) != 0 ? 1u : 0u);
+
+    if (!enabled) {
+        status = TimeCardSignalQueryLocked(context, request->Generator,
+                                           response);
+        WdfWaitLockRelease(context->RegisterLock);
+        return status;
+    }
+
+    status = TimeCardReadClockLocked(context, &now);
+    if (!NT_SUCCESS(status))
+        goto done;
+    if (maximum - now < 1000000ull) {
+        status = STATUS_INTEGER_OVERFLOW;
+        goto done;
+    }
+    now += 1000000ull;
+    remainder = now % period;
+    start = now - remainder;
+    if (remainder != 0) {
+        if (maximum - start < period) {
+            status = STATUS_INTEGER_OVERFLOW;
+            goto done;
+        }
+        start += period;
+    }
+    if (maximum - start < phase) {
+        status = STATUS_INTEGER_OVERFLOW;
+        goto done;
+    }
+    start += phase;
+    if (start <= now) {
+        if (maximum - start < period) {
+            status = STATUS_INTEGER_OVERFLOW;
+            goto done;
+        }
+        start += period;
+    }
+    if (start / TIMECARD_NANOSECONDS_PER_SECOND > MAXULONG) {
+        status = STATUS_INTEGER_OVERFLOW;
+        goto done;
+    }
+
+    WRITE_REGISTER_ULONG((PULONG)&reg->StartSeconds,
+        (ULONG)(start / TIMECARD_NANOSECONDS_PER_SECOND));
+    WRITE_REGISTER_ULONG((PULONG)&reg->StartNanoseconds,
+        (ULONG)(start % TIMECARD_NANOSECONDS_PER_SECOND));
+    WRITE_REGISTER_ULONG((PULONG)&reg->PeriodSeconds,
+        (ULONG)(period / TIMECARD_NANOSECONDS_PER_SECOND));
+    WRITE_REGISTER_ULONG((PULONG)&reg->PeriodNanoseconds,
+        (ULONG)(period % TIMECARD_NANOSECONDS_PER_SECOND));
+    WRITE_REGISTER_ULONG((PULONG)&reg->PulseSeconds,
+        (ULONG)(pulse / TIMECARD_NANOSECONDS_PER_SECOND));
+    WRITE_REGISTER_ULONG((PULONG)&reg->PulseNanoseconds,
+        (ULONG)(pulse % TIMECARD_NANOSECONDS_PER_SECOND));
+    WRITE_REGISTER_ULONG((PULONG)&reg->RepeatCount, 0);
+    WRITE_REGISTER_ULONG((PULONG)&reg->Interrupt, 0);
+    WRITE_REGISTER_ULONG((PULONG)&reg->Enable,
+                         TIMECARD_SIGNAL_ENABLE_VALID);
+    status = TimeCardSignalQueryLocked(context, request->Generator, response);
+
+done:
+    WdfWaitLockRelease(context->RegisterLock);
+    return status;
+}
+
+static NTSTATUS
+TimeCardFrequencyQueryLocked(PDEVICE_CONTEXT context, ULONG counter,
+                             TIMECARD_FREQUENCY_CONTROL *control)
+{
+    volatile TIMECARD_FREQUENCY_REG *reg;
+    ULONG rawControl;
+    ULONG status;
+
+    reg = context->Frequency[counter - 1];
+    if (reg == NULL)
+        return STATUS_NOT_SUPPORTED;
+    rawControl = READ_REGISTER_ULONG((PULONG)&reg->Control);
+    status = READ_REGISTER_ULONG((PULONG)&reg->Status);
+
+    RtlZeroMemory(control, sizeof(*control));
+    control->Size = sizeof(*control);
+    control->Counter = counter;
+    control->Control = rawControl;
+    control->Status = status;
+    control->Flags = TIMECARD_FREQUENCY_FLAG_PRESENT;
+    if ((rawControl & TIMECARD_FREQUENCY_ENABLE) != 0) {
+        control->Flags |= TIMECARD_FREQUENCY_FLAG_ENABLED;
+        control->IntegrationSeconds = (rawControl >> 8) & 0xffu;
+    }
+    if ((status & TIMECARD_FREQUENCY_VALID) != 0) {
+        control->Flags |= TIMECARD_FREQUENCY_FLAG_VALID;
+        control->FrequencyHz = status & TIMECARD_FREQUENCY_VALUE_MASK;
+    }
+    if ((status & TIMECARD_FREQUENCY_ERROR) != 0)
+        control->Flags |= TIMECARD_FREQUENCY_FLAG_ERROR;
+    if ((status & TIMECARD_FREQUENCY_OVERRUN) != 0)
+        control->Flags |= TIMECARD_FREQUENCY_FLAG_OVERRUN;
+    return STATUS_SUCCESS;
+}
+
+NTSTATUS
+TimeCardFrequencyQuery(PDEVICE_CONTEXT context, ULONG counter,
+                       TIMECARD_FREQUENCY_CONTROL *control)
+{
+    NTSTATUS status;
+
+    if (!context->HardwareReady)
+        return STATUS_DEVICE_NOT_READY;
+    if (counter == 0 || counter > TIMECARD_FREQUENCY_COUNT)
+        return STATUS_INVALID_PARAMETER;
+    WdfWaitLockAcquire(context->RegisterLock, NULL);
+    status = TimeCardFrequencyQueryLocked(context, counter, control);
+    WdfWaitLockRelease(context->RegisterLock);
+    return status;
+}
+
+NTSTATUS
+TimeCardFrequencySet(PDEVICE_CONTEXT context,
+                     const TIMECARD_FREQUENCY_CONTROL *request,
+                     TIMECARD_FREQUENCY_CONTROL *response)
+{
+    volatile TIMECARD_FREQUENCY_REG *reg;
+    ULONG control;
+    NTSTATUS status;
+
+    if (!context->HardwareReady)
+        return STATUS_DEVICE_NOT_READY;
+    if (request->Size < sizeof(*request) || request->Counter == 0 ||
+        request->Counter > TIMECARD_FREQUENCY_COUNT ||
+        request->IntegrationSeconds > 0xffu)
+        return STATUS_INVALID_PARAMETER;
+    reg = context->Frequency[request->Counter - 1];
+    if (reg == NULL)
+        return STATUS_NOT_SUPPORTED;
+
+    control = request->IntegrationSeconds == 0 ? 0 :
+        (request->IntegrationSeconds << 8) | TIMECARD_FREQUENCY_ENABLE;
+    WdfWaitLockAcquire(context->RegisterLock, NULL);
+    WRITE_REGISTER_ULONG((PULONG)&reg->Control, control);
+    status = TimeCardFrequencyQueryLocked(context, request->Counter,
+                                          response);
+    WdfWaitLockRelease(context->RegisterLock);
+    return status;
+}


### PR DESCRIPTION
## Summary
- expand the Windows Time Card Control Center through v1.13 with polished splash/admin/branding UX, richer overview and subsystem workspaces, detailed clock-history charts, GNSS sky map, configurable UART views, SMA generator/frequency controls, and linked NMEA/GNSS configuration
- extend the Windows driver ABI to support timing generators, reliable UART presence, guarded FPGA SPI-flash programming, robust I2C transactions, PCA9546A branch routing, and IS32FL3207 manual/automatic subsystem LEDs
- document the schematic-derived I2C topology, release/signing workflow, and newly exposed hardware controls

## Why
The previous Windows interface exposed only a subset of the FPGA and board capabilities. I2C receives could also complete with stale/error status and surface Win32 CRC errors. This update adds explicit transfer completion/error handling and models the actual board topology so higher-level controls can safely select branches and drive status indications.

## Impact
- Windows Control Center and driver version: 1.13.0.0
- IOCTL ABI: version 7
- full hardware functionality requires the matching, signed v1.13 Windows driver
- FPGA flash operations are guarded and require explicit confirmation
- physical-card validation remains recommended for mux routing, LED mapping, timing outputs, and firmware flashing

## Validation
- Control Center Release build completed successfully
- WDK Release driver source compiled and linked with warnings treated as errors
- driver signability test and x64 INF verification completed without errors
- Git staged-diff validation completed successfully
- UI graph scaling and workspace layouts were visually reviewed during implementation