### PR TITLE
Expand Windows hardware control and sensor telemetry

### DIFF
--- a/DRV/Windows/PRODUCTION_SIGNING.md
+++ b/DRV/Windows/PRODUCTION_SIGNING.md
@@ -15,7 +15,7 @@ From PowerShell in this directory:
 This performs a clean unsigned x64 Release build and creates:
 
 - `submission\TimeCard\` - the driver folder to add to an HLK project.
-- `submission\TimeCard-1.13-x64.cab` - a CAB with the required driver,
+- `submission\TimeCard-1.15-x64.cab` - a CAB with the required driver,
   INF, catalog, subsystem icons, and PDB in a non-root `TimeCard` folder.
 
 The CAB is intentionally unsigned unless a registered code-signing
@@ -55,7 +55,7 @@ Use this route for a retail driver and for Windows Update eligibility:
 Microsoft currently limits attestation signing to supported testing
 scenarios; attestation-signed retail drivers are not published to Windows
 Update. When the Partner Center account is eligible for such a scenario,
-upload the certificate-signed `TimeCard-1.13-x64.cab`, leave both test-signing
+upload the certificate-signed `TimeCard-1.15-x64.cab`, leave both test-signing
 options disabled, and download the Microsoft-signed result.
 
 ## Verify the returned package

--- a/DRV/Windows/README.md
+++ b/DRV/Windows/README.md
@@ -17,16 +17,18 @@ Linux `/dev/ptpN`, so applications use the versioned IOCTL ABI through
   and immediate readback.
 - Bounded configuration and readback for four periodic signal generators and
   four frequency counters, including direct SMA input/output routing.
-- Read-only Xilinx AXI IIC controller access with status, address-only probes,
-  7-bit bus discovery, and bounded EEPROM/register reads. The known onboard
-  devices are the board EEPROM at `0x50` and MAC EEPROM at `0x58`.
+- Guarded Xilinx AXI IIC controller access with status, address-only probes,
+  7-bit bus discovery, bounded EEPROM/register reads, PCA9546A branch routing,
+  and dedicated IS32FL3207 LED updates. The known identity devices are the
+  board EEPROM at `0x50` and MAC EEPROM at `0x58`.
 - Guarded Xilinx SPI and SPI-NOR access for FPGA firmware query, 4 KiB erase,
   page programming, and bounded read-back. All offsets are relative to the
   FPGA image region at `0x00400000`; the configuration region is unreachable.
 - Non-destructive UART receive-activity observation for subsystem presence
   checks without removing bytes from the receiver FIFO.
-- A stable six-byte card serial number read from offset zero of the factory
-  24MAC402 identity EEPROM, matching Linux `ptp_ocp`.
+- A stable six-byte card serial number read from the factory-programmed
+  EUI-48 area at raw 24MAC402 offset `0x9a`, matching the identity Linux
+  exposes through the `24mac402` NVMEM provider to `ptp_ocp`.
 - MSI and MSI-X/LitePCIe BAR layouts matching the Linux `ptp_ocp` driver.
 - A dedicated **Time Card** Device Manager class with custom controller and
   subsystem icons.
@@ -202,12 +204,30 @@ cross a 256-byte page, and requires write-enable plus ready polling. The
 Control Center performs a complete read-back comparison after programming.
 
 Driver 1.13 / ABI 7 adds schematic-aware controls for U27, the PCA9546A at
-`0x70`, and U6, the IS32FL3207 at `0x6e` on mux channel 1. The four mux bits
+`0x70`, and U6, the IS32FL3207 on mux channel 1. The four mux bits
 route the MAC clock, sensor, analog/ADC expansion, and DC expansion branches.
 LED IOCTLs are limited to the six RGB indicators (GNSS1, GNSS2, IO1â€“IO4),
 use 8-bit PWM, cap global current at 128, and restore the caller's mux mask
 after every operation. Arbitrary I2C writes and EEPROM programming remain
 unavailable.
+
+Driver 1.14 / ABI 7 corrects the AXI IIC dynamic-mode startup handshake,
+preventing the stale bus-not-busy latch from ending a transaction before its
+START reaches the bus. It also reads the factory
+EUI-48 from raw 24MAC402 offset `0x9a` and uses U6's 7-bit address `0x37`;
+the schematic's `0x6e` label is the corresponding 8-bit write address.
+Driver 1.14.6 also reports the IS32FL3207 per-output open/short masks and
+supports a bounded electrical test. The test proves SDB state through the
+device reset behavior, forces OUT1-18 on in DC mode for five seconds, and then
+restores the prior colors. It does not expose arbitrary I2C writes.
+
+Driver 1.15.1 / ABI 8 adds a guarded sensor-telemetry query for every populated
+device on PCA9546A channel 1. It triggers a compensated BME280 environment
+sample at `0x76`, reads the +12 V, +5 V, and +3.3 V INA219 monitors at `0x40`,
+`0x41`, and `0x44` using the schematic's 2 milliohm shunts, and starts the
+BNO055 at `0x29` in NDOF fusion mode with the fitted 32.768 kHz crystal. A
+failed or absent sensor is reported independently. The driver restores the
+caller's mux mask after every sample and still exposes no arbitrary write API.
 
 The schematic's U26 TMUX1072 is not software-controlled. Its `MACSER` select
 comes only from the physical DIP switch: 0 routes MAC I2C and 1 routes the FPGA

--- a/DRV/Windows/TimeCardControlCenter/MainWindow.xaml
+++ b/DRV/Windows/TimeCardControlCenter/MainWindow.xaml
@@ -269,6 +269,8 @@
                                          Content="&#xE9CA;" ToolTip="SMA Connectors" Checked="Navigate_Checked" />
                             <RadioButton x:Name="TimingNav" GroupName="Navigation" Style="{StaticResource NavRadio}" Tag="Timing"
                                          Content="&#xE9D2;" ToolTip="Generators &amp; Freq." Checked="Navigate_Checked" />
+                            <RadioButton x:Name="SensorsNav" GroupName="Navigation" Style="{StaticResource NavRadio}" Tag="Sensors"
+                                         Content="&#xE95E;" ToolTip="Sensors &amp; IMU" Checked="Navigate_Checked" />
                             <RadioButton x:Name="I2cNav" GroupName="Navigation" Style="{StaticResource NavRadio}" Tag="I2c"
                                          Content="&#xE950;" ToolTip="I&#x00B2;C Bus" Checked="Navigate_Checked" />
                             <RadioButton x:Name="SubsystemsNav" GroupName="Navigation" Style="{StaticResource NavRadio}" Tag="Subsystems"
@@ -403,15 +405,15 @@
                                                                    FontFamily="Segoe UI Semibold" FontSize="12" />
                                                     </Grid>
                                                     <local:RollingTelemetryChart x:Name="OffsetHistoryChart" Grid.Row="1"
-                                                                                 Margin="0,11,0,8" Capacity="60"
+                                                                                 Margin="0,11,0,8" Capacity="200"
                                                                                  MinimumRange="10"
                                                                                  LineBrush="{StaticResource CyanBrush}"
                                                                                  AreaBrush="#204CC9F0"
-                                                                                 ToolTip="Rolling Time Card offset with detail-focused automatic vertical zoom" />
+                                                                                 ToolTip="Rolling 200-second Time Card offset with detail-focused automatic vertical zoom" />
                                                     <Grid Grid.Row="2">
                                                         <TextBlock x:Name="OffsetHistoryScaleText" Text="WAITING FOR SAMPLES"
                                                                    Foreground="{StaticResource MutedBrush}" FontSize="9" />
-                                                        <TextBlock Text="ROLLING &#x00B7; 60 S" HorizontalAlignment="Right"
+                                                        <TextBlock Text="ROLLING &#x00B7; 200 S" HorizontalAlignment="Right"
                                                                    Foreground="#617A90" FontSize="9" />
                                                     </Grid>
                                                 </Grid>
@@ -531,15 +533,15 @@
                                                                FontFamily="Segoe UI Semibold" FontSize="12" />
                                                 </Grid>
                                                 <local:RollingTelemetryChart x:Name="ClockOffsetHistoryChart" Grid.Row="1"
-                                                                             Margin="0,10,0,8" Capacity="60"
+                                                                             Margin="0,10,0,8" Capacity="200"
                                                                              MinimumRange="10"
                                                                              LineBrush="{StaticResource CyanBrush}"
                                                                              AreaBrush="#204CC9F0"
-                                                                             ToolTip="Rolling measured offset with detail-focused automatic vertical zoom" />
+                                                                             ToolTip="Rolling 200-second measured offset with detail-focused automatic vertical zoom" />
                                                 <Grid Grid.Row="2">
                                                     <TextBlock x:Name="ClockOffsetHistoryScaleText" Text="WAITING FOR SAMPLES"
                                                                Foreground="{StaticResource MutedBrush}" FontSize="9" />
-                                                    <TextBlock Text="ROLLING &#x00B7; 60 S" HorizontalAlignment="Right"
+                                                    <TextBlock Text="ROLLING &#x00B7; 200 S" HorizontalAlignment="Right"
                                                                Foreground="#617A90" FontSize="9" />
                                                 </Grid>
                                             </Grid>
@@ -1511,6 +1513,136 @@
                         </Grid>
                     </ScrollViewer>
 
+                    <!-- SENSORS AND IMU -->
+                    <ScrollViewer x:Name="SensorsPage" Visibility="Collapsed" VerticalScrollBarVisibility="Auto">
+                        <Grid Margin="32,28,32,34">
+                            <Grid.RowDefinitions>
+                                <RowDefinition Height="Auto" />
+                                <RowDefinition Height="Auto" />
+                                <RowDefinition Height="Auto" />
+                                <RowDefinition Height="Auto" />
+                                <RowDefinition Height="Auto" />
+                                <RowDefinition Height="Auto" />
+                            </Grid.RowDefinitions>
+                            <Grid>
+                                <Grid.ColumnDefinitions><ColumnDefinition Width="*" /><ColumnDefinition Width="Auto" /></Grid.ColumnDefinitions>
+                                <StackPanel>
+                                    <TextBlock Text="ENVIRONMENT &amp; MOTION" Style="{StaticResource Eyebrow}" />
+                                    <TextBlock Text="Board sensors &amp; inertial telemetry" Style="{StaticResource PageTitle}" Margin="0,5,0,4" />
+                                    <TextBlock Text="Live BME280 environment, INA219 power-rail, and BNO055 nine-axis readings from the sensor branch."
+                                               Foreground="{StaticResource MutedBrush}" />
+                                </StackPanel>
+                                <StackPanel Grid.Column="1" Orientation="Horizontal" VerticalAlignment="Center">
+                                    <Border Style="{StaticResource StatusChip}" Margin="0,0,10,0">
+                                        <StackPanel Orientation="Horizontal">
+                                            <Ellipse x:Name="SensorsStatusDot" Width="8" Height="8" Fill="{StaticResource MutedBrush}" VerticalAlignment="Center" Margin="0,0,8,0" />
+                                            <TextBlock x:Name="SensorsStatusText" Text="WAITING" Foreground="{StaticResource MutedBrush}" FontFamily="Segoe UI Semibold" FontSize="11" />
+                                        </StackPanel>
+                                    </Border>
+                                    <Button x:Name="SensorsRefreshButton" Content="Refresh sensors" Click="RefreshSensors_Click" />
+                                </StackPanel>
+                            </Grid>
+
+                            <Border Grid.Row="1" Background="#102638" BorderBrush="#28506C" BorderThickness="1" CornerRadius="12" Padding="16,12" Margin="0,22,0,18">
+                                <Grid><Grid.ColumnDefinitions><ColumnDefinition Width="Auto" /><ColumnDefinition Width="*" /><ColumnDefinition Width="Auto" /></Grid.ColumnDefinitions>
+                                    <TextBlock Text="&#xE95E;" FontFamily="Segoe MDL2 Assets" Foreground="{StaticResource CyanBrush}" FontSize="18" VerticalAlignment="Center" Margin="0,0,12,0" />
+                                    <TextBlock x:Name="SensorsDriverText" Grid.Column="1" Text="Connect a Time Card with driver 1.15 / ABI 8 to begin live sampling."
+                                               Foreground="#B9DCEE" TextWrapping="Wrap" VerticalAlignment="Center" />
+                                    <TextBlock x:Name="SensorsLastSampleText" Grid.Column="2" Text="NOT SAMPLED" Foreground="{StaticResource CyanBrush}" FontFamily="Segoe UI Semibold" FontSize="10" Margin="16,0,0,0" VerticalAlignment="Center" />
+                                </Grid>
+                            </Border>
+
+                            <StackPanel Grid.Row="2">
+                                <Grid Margin="0,0,0,12"><Grid.ColumnDefinitions><ColumnDefinition Width="*" /><ColumnDefinition Width="Auto" /></Grid.ColumnDefinitions>
+                                    <StackPanel><TextBlock Text="Environment" Style="{StaticResource SectionTitle}" /><TextBlock Text="Compensated BME280 measurements" Foreground="{StaticResource MutedBrush}" FontSize="11" Margin="0,4,0,0" /></StackPanel>
+                                    <TextBlock x:Name="BmeDetailText" Grid.Column="1" Text="BME280 &#x00B7; 0x76 &#x00B7; NOT SAMPLED" Foreground="{StaticResource MutedBrush}" FontFamily="Cascadia Mono, Consolas" FontSize="11" VerticalAlignment="Center" />
+                                </Grid>
+                                <UniformGrid Columns="4">
+                                    <Border Style="{StaticResource MetricCard}"><StackPanel><TextBlock Text="TEMPERATURE" Style="{StaticResource Label}" /><TextBlock x:Name="BmeTemperatureText" Text="&#x2014; &#x00B0;C" Style="{StaticResource MetricValue}" Margin="0,8,0,0" /><TextBlock Text="Ambient board sensor" Foreground="{StaticResource MutedBrush}" FontSize="10" Margin="0,5,0,0" /></StackPanel></Border>
+                                    <Border Style="{StaticResource MetricCard}"><StackPanel><TextBlock Text="RELATIVE HUMIDITY" Style="{StaticResource Label}" /><TextBlock x:Name="BmeHumidityText" Text="&#x2014; %" Style="{StaticResource MetricValue}" Margin="0,8,0,0" /><TextBlock Text="Compensated RH" Foreground="{StaticResource MutedBrush}" FontSize="10" Margin="0,5,0,0" /></StackPanel></Border>
+                                    <Border Style="{StaticResource MetricCard}"><StackPanel><TextBlock Text="PRESSURE" Style="{StaticResource Label}" /><TextBlock x:Name="BmePressureText" Text="&#x2014; hPa" Style="{StaticResource MetricValue}" Margin="0,8,0,0" /><TextBlock Text="Absolute pressure" Foreground="{StaticResource MutedBrush}" FontSize="10" Margin="0,5,0,0" /></StackPanel></Border>
+                                    <Border Style="{StaticResource MetricCard}" Margin="0"><StackPanel><TextBlock Text="DEW POINT" Style="{StaticResource Label}" /><TextBlock x:Name="BmeDewPointText" Text="&#x2014; &#x00B0;C" Style="{StaticResource MetricValue}" Margin="0,8,0,0" /><TextBlock Text="Calculated from T + RH" Foreground="{StaticResource MutedBrush}" FontSize="10" Margin="0,5,0,0" /></StackPanel></Border>
+                                </UniformGrid>
+                            </StackPanel>
+
+                            <StackPanel Grid.Row="3" Margin="0,24,0,0">
+                                <TextBlock Text="Power rails" Style="{StaticResource SectionTitle}" />
+                                <TextBlock Text="Live bus voltage, shunt current, and calculated load power from the three INA219 monitors."
+                                           Foreground="{StaticResource MutedBrush}" FontSize="11" Margin="0,4,0,12" />
+                                <UniformGrid Columns="3">
+                                    <Border Style="{StaticResource SubsystemCard}" MinHeight="156">
+                                        <StackPanel>
+                                            <Grid><Grid.ColumnDefinitions><ColumnDefinition Width="*" /><ColumnDefinition Width="Auto" /></Grid.ColumnDefinitions><TextBlock Text="+12 V input" Style="{StaticResource SectionTitle}" /><TextBlock x:Name="Rail12StatusText" Grid.Column="1" Text="0x40" Foreground="{StaticResource MutedBrush}" FontFamily="Cascadia Mono, Consolas" FontSize="10" /></Grid>
+                                            <TextBlock x:Name="Rail12VoltageText" Text="&#x2014; V" Style="{StaticResource MetricValue}" Margin="0,10,0,8" />
+                                            <Grid><Grid.ColumnDefinitions><ColumnDefinition Width="*" /><ColumnDefinition Width="*" /></Grid.ColumnDefinitions><StackPanel><TextBlock Text="CURRENT" Style="{StaticResource Label}" /><TextBlock x:Name="Rail12CurrentText" Text="&#x2014; A" FontFamily="Segoe UI Semibold" Margin="0,4,0,0" /></StackPanel><StackPanel Grid.Column="1"><TextBlock Text="POWER" Style="{StaticResource Label}" /><TextBlock x:Name="Rail12PowerText" Text="&#x2014; W" FontFamily="Segoe UI Semibold" Margin="0,4,0,0" /></StackPanel></Grid>
+                                            <TextBlock x:Name="Rail12DetailText" Text="Shunt &#x2014; mV" Foreground="{StaticResource MutedBrush}" FontSize="10" Margin="0,10,0,0" />
+                                        </StackPanel>
+                                    </Border>
+                                    <Border Style="{StaticResource SubsystemCard}" MinHeight="156">
+                                        <StackPanel>
+                                            <Grid><Grid.ColumnDefinitions><ColumnDefinition Width="*" /><ColumnDefinition Width="Auto" /></Grid.ColumnDefinitions><TextBlock Text="+5 V rail" Style="{StaticResource SectionTitle}" /><TextBlock x:Name="Rail5StatusText" Grid.Column="1" Text="0x41" Foreground="{StaticResource MutedBrush}" FontFamily="Cascadia Mono, Consolas" FontSize="10" /></Grid>
+                                            <TextBlock x:Name="Rail5VoltageText" Text="&#x2014; V" Style="{StaticResource MetricValue}" Margin="0,10,0,8" />
+                                            <Grid><Grid.ColumnDefinitions><ColumnDefinition Width="*" /><ColumnDefinition Width="*" /></Grid.ColumnDefinitions><StackPanel><TextBlock Text="CURRENT" Style="{StaticResource Label}" /><TextBlock x:Name="Rail5CurrentText" Text="&#x2014; A" FontFamily="Segoe UI Semibold" Margin="0,4,0,0" /></StackPanel><StackPanel Grid.Column="1"><TextBlock Text="POWER" Style="{StaticResource Label}" /><TextBlock x:Name="Rail5PowerText" Text="&#x2014; W" FontFamily="Segoe UI Semibold" Margin="0,4,0,0" /></StackPanel></Grid>
+                                            <TextBlock x:Name="Rail5DetailText" Text="Shunt &#x2014; mV" Foreground="{StaticResource MutedBrush}" FontSize="10" Margin="0,10,0,0" />
+                                        </StackPanel>
+                                    </Border>
+                                    <Border Style="{StaticResource SubsystemCard}" MinHeight="156" Margin="0,0,0,14">
+                                        <StackPanel>
+                                            <Grid><Grid.ColumnDefinitions><ColumnDefinition Width="*" /><ColumnDefinition Width="Auto" /></Grid.ColumnDefinitions><TextBlock Text="+3.3 V rail" Style="{StaticResource SectionTitle}" /><TextBlock x:Name="Rail3V3StatusText" Grid.Column="1" Text="0x44" Foreground="{StaticResource MutedBrush}" FontFamily="Cascadia Mono, Consolas" FontSize="10" /></Grid>
+                                            <TextBlock x:Name="Rail3V3VoltageText" Text="&#x2014; V" Style="{StaticResource MetricValue}" Margin="0,10,0,8" />
+                                            <Grid><Grid.ColumnDefinitions><ColumnDefinition Width="*" /><ColumnDefinition Width="*" /></Grid.ColumnDefinitions><StackPanel><TextBlock Text="CURRENT" Style="{StaticResource Label}" /><TextBlock x:Name="Rail3V3CurrentText" Text="&#x2014; A" FontFamily="Segoe UI Semibold" Margin="0,4,0,0" /></StackPanel><StackPanel Grid.Column="1"><TextBlock Text="POWER" Style="{StaticResource Label}" /><TextBlock x:Name="Rail3V3PowerText" Text="&#x2014; W" FontFamily="Segoe UI Semibold" Margin="0,4,0,0" /></StackPanel></Grid>
+                                            <TextBlock x:Name="Rail3V3DetailText" Text="Shunt &#x2014; mV" Foreground="{StaticResource MutedBrush}" FontSize="10" Margin="0,10,0,0" />
+                                        </StackPanel>
+                                    </Border>
+                                </UniformGrid>
+                            </StackPanel>
+
+                            <StackPanel Grid.Row="4" Margin="0,10,0,0">
+                                <Grid Margin="0,0,0,12"><Grid.ColumnDefinitions><ColumnDefinition Width="*" /><ColumnDefinition Width="Auto" /></Grid.ColumnDefinitions>
+                                    <StackPanel><TextBlock Text="Inertial measurement unit" Style="{StaticResource SectionTitle}" /><TextBlock Text="BNO055 fused orientation and raw nine-axis vectors" Foreground="{StaticResource MutedBrush}" FontSize="11" Margin="0,4,0,0" /></StackPanel>
+                                    <TextBlock x:Name="ImuDetailText" Grid.Column="1" Text="BNO055 &#x00B7; 0x29 &#x00B7; NOT SAMPLED" Foreground="{StaticResource MutedBrush}" FontFamily="Cascadia Mono, Consolas" FontSize="11" VerticalAlignment="Center" />
+                                </Grid>
+                                <Grid>
+                                    <Grid.ColumnDefinitions><ColumnDefinition Width="1.15*" /><ColumnDefinition Width="0.85*" /></Grid.ColumnDefinitions>
+                                    <Border Style="{StaticResource Panel}" Padding="18" Margin="0,0,14,0">
+                                        <StackPanel>
+                                            <TextBlock Text="FUSED ORIENTATION" Style="{StaticResource Label}" />
+                                            <UniformGrid Columns="3" Margin="0,12,0,14">
+                                                <StackPanel><TextBlock Text="HEADING" Style="{StaticResource Label}" /><TextBlock x:Name="ImuHeadingText" Text="&#x2014;&#x00B0;" Style="{StaticResource MetricValue}" Margin="0,5,0,0" /></StackPanel>
+                                                <StackPanel><TextBlock Text="ROLL" Style="{StaticResource Label}" /><TextBlock x:Name="ImuRollText" Text="&#x2014;&#x00B0;" Style="{StaticResource MetricValue}" Margin="0,5,0,0" /></StackPanel>
+                                                <StackPanel><TextBlock Text="PITCH" Style="{StaticResource Label}" /><TextBlock x:Name="ImuPitchText" Text="&#x2014;&#x00B0;" Style="{StaticResource MetricValue}" Margin="0,5,0,0" /></StackPanel>
+                                            </UniformGrid>
+                                            <TextBlock Text="QUATERNION (W, X, Y, Z)" Style="{StaticResource Label}" />
+                                            <TextBlock x:Name="ImuQuaternionText" Text="&#x2014;, &#x2014;, &#x2014;, &#x2014;" FontFamily="Cascadia Mono, Consolas" FontSize="14" Margin="0,7,0,0" />
+                                        </StackPanel>
+                                    </Border>
+                                    <Border Grid.Column="1" Style="{StaticResource Panel}" Padding="18">
+                                        <StackPanel>
+                                            <Grid><Grid.ColumnDefinitions><ColumnDefinition Width="*" /><ColumnDefinition Width="Auto" /></Grid.ColumnDefinitions><TextBlock Text="SENSOR HEALTH" Style="{StaticResource Label}" /><TextBlock x:Name="ImuStatusText" Grid.Column="1" Text="NOT SAMPLED" Foreground="{StaticResource MutedBrush}" FontFamily="Segoe UI Semibold" FontSize="10" /></Grid>
+                                            <TextBlock x:Name="ImuTemperatureText" Text="&#x2014; &#x00B0;C" Style="{StaticResource MetricValue}" Margin="0,10,0,10" />
+                                            <UniformGrid Columns="4">
+                                                <StackPanel><TextBlock Text="SYS" Style="{StaticResource Label}" /><TextBlock x:Name="ImuSystemCalibrationText" Text="&#x2014;/3" FontFamily="Segoe UI Semibold" Margin="0,4,0,0" /></StackPanel>
+                                                <StackPanel><TextBlock Text="GYR" Style="{StaticResource Label}" /><TextBlock x:Name="ImuGyroCalibrationText" Text="&#x2014;/3" FontFamily="Segoe UI Semibold" Margin="0,4,0,0" /></StackPanel>
+                                                <StackPanel><TextBlock Text="ACC" Style="{StaticResource Label}" /><TextBlock x:Name="ImuAccelCalibrationText" Text="&#x2014;/3" FontFamily="Segoe UI Semibold" Margin="0,4,0,0" /></StackPanel>
+                                                <StackPanel><TextBlock Text="MAG" Style="{StaticResource Label}" /><TextBlock x:Name="ImuMagCalibrationText" Text="&#x2014;/3" FontFamily="Segoe UI Semibold" Margin="0,4,0,0" /></StackPanel>
+                                            </UniformGrid>
+                                            <TextBlock Text="Calibration improves while the board moves through varied orientations." Foreground="{StaticResource MutedBrush}" FontSize="10" TextWrapping="Wrap" Margin="0,12,0,0" />
+                                        </StackPanel>
+                                    </Border>
+                                </Grid>
+                            </StackPanel>
+
+                            <UniformGrid Grid.Row="5" Columns="3" Margin="0,14,0,0">
+                                <Border Style="{StaticResource SubsystemCard}" MinHeight="112"><StackPanel><TextBlock Text="ACCELERATION &#x00B7; M/S&#x00B2;" Style="{StaticResource Label}" /><TextBlock x:Name="ImuAccelerationText" Text="X &#x2014;   Y &#x2014;   Z &#x2014;" FontFamily="Cascadia Mono, Consolas" FontSize="13" Margin="0,9,0,0" /><TextBlock Text="Includes gravity" Foreground="{StaticResource MutedBrush}" FontSize="10" Margin="0,7,0,0" /></StackPanel></Border>
+                                <Border Style="{StaticResource SubsystemCard}" MinHeight="112"><StackPanel><TextBlock Text="GYROSCOPE &#x00B7; &#x00B0;/S" Style="{StaticResource Label}" /><TextBlock x:Name="ImuGyroscopeText" Text="X &#x2014;   Y &#x2014;   Z &#x2014;" FontFamily="Cascadia Mono, Consolas" FontSize="13" Margin="0,9,0,0" /><TextBlock Text="Angular velocity" Foreground="{StaticResource MutedBrush}" FontSize="10" Margin="0,7,0,0" /></StackPanel></Border>
+                                <Border Style="{StaticResource SubsystemCard}" MinHeight="112" Margin="0,0,0,14"><StackPanel><TextBlock Text="MAGNETIC FIELD &#x00B7; &#x03BC;T" Style="{StaticResource Label}" /><TextBlock x:Name="ImuMagneticText" Text="X &#x2014;   Y &#x2014;   Z &#x2014;" FontFamily="Cascadia Mono, Consolas" FontSize="13" Margin="0,9,0,0" /><TextBlock Text="Three-axis magnetometer" Foreground="{StaticResource MutedBrush}" FontSize="10" Margin="0,7,0,0" /></StackPanel></Border>
+                                <Border Style="{StaticResource SubsystemCard}" MinHeight="112"><StackPanel><TextBlock Text="LINEAR ACCELERATION &#x00B7; M/S&#x00B2;" Style="{StaticResource Label}" /><TextBlock x:Name="ImuLinearAccelerationText" Text="X &#x2014;   Y &#x2014;   Z &#x2014;" FontFamily="Cascadia Mono, Consolas" FontSize="13" Margin="0,9,0,0" /><TextBlock Text="Gravity removed" Foreground="{StaticResource MutedBrush}" FontSize="10" Margin="0,7,0,0" /></StackPanel></Border>
+                                <Border Style="{StaticResource SubsystemCard}" MinHeight="112"><StackPanel><TextBlock Text="GRAVITY VECTOR &#x00B7; M/S&#x00B2;" Style="{StaticResource Label}" /><TextBlock x:Name="ImuGravityText" Text="X &#x2014;   Y &#x2014;   Z &#x2014;" FontFamily="Cascadia Mono, Consolas" FontSize="13" Margin="0,9,0,0" /><TextBlock Text="Fused gravity estimate" Foreground="{StaticResource MutedBrush}" FontSize="10" Margin="0,7,0,0" /></StackPanel></Border>
+                                <Border Style="{StaticResource SubsystemCard}" MinHeight="112" Margin="0,0,0,14"><StackPanel><TextBlock Text="DEVICE STATUS" Style="{StaticResource Label}" /><TextBlock x:Name="ImuRawStatusText" Text="Mode &#x2014; &#x00B7; Status &#x2014;" FontFamily="Cascadia Mono, Consolas" FontSize="13" Margin="0,9,0,0" /><TextBlock x:Name="ImuClockText" Text="Clock source not sampled" Foreground="{StaticResource MutedBrush}" FontSize="10" Margin="0,7,0,0" /></StackPanel></Border>
+                            </UniformGrid>
+                        </Grid>
+                    </ScrollViewer>
+
                     <!-- I2C BUS -->
                     <ScrollViewer x:Name="I2cPage" Visibility="Collapsed" VerticalScrollBarVisibility="Auto">
                         <Grid Margin="32,28,32,34">
@@ -1559,7 +1691,7 @@
                                         </WrapPanel>
                                         <UniformGrid Columns="2">
                                             <Border Background="#0B1926" BorderBrush="{StaticResource BorderBrush}" BorderThickness="1" CornerRadius="9" Padding="12" Margin="0,0,8,8"><StackPanel><TextBlock Text="CH0  MAC CLOCK" FontFamily="Segoe UI Semibold" /><TextBlock Text="Atomic-clock connector I&#x00B2;C; also requires MACSER DIP = I&#x00B2;C." Foreground="{StaticResource MutedBrush}" FontSize="11" TextWrapping="Wrap" Margin="0,4,0,0" /></StackPanel></Border>
-                                            <Border Background="#0B1926" BorderBrush="{StaticResource BorderBrush}" BorderThickness="1" CornerRadius="9" Padding="12" Margin="8,0,0,8"><StackPanel><TextBlock Text="CH1  SENSORS + LEDS" FontFamily="Segoe UI Semibold" /><TextBlock Text="0x29 BNO055 &#x00B7; 0x40/41/44 INA219 &#x00B7; 0x6E IS32FL3207 &#x00B7; 0x76 BME280" Foreground="{StaticResource MutedBrush}" FontSize="11" TextWrapping="Wrap" Margin="0,4,0,0" /></StackPanel></Border>
+                                            <Border Background="#0B1926" BorderBrush="{StaticResource BorderBrush}" BorderThickness="1" CornerRadius="9" Padding="12" Margin="8,0,0,8"><StackPanel><TextBlock Text="CH1  SENSORS + LEDS" FontFamily="Segoe UI Semibold" /><TextBlock Text="0x29 BNO055 &#x00B7; 0x40/41/44 INA219 &#x00B7; 0x37 IS32FL3207 &#x00B7; 0x76 BME280" Foreground="{StaticResource MutedBrush}" FontSize="11" TextWrapping="Wrap" Margin="0,4,0,0" /></StackPanel></Border>
                                             <Border Background="#0B1926" BorderBrush="{StaticResource BorderBrush}" BorderThickness="1" CornerRadius="9" Padding="12" Margin="0,8,8,0"><StackPanel><TextBlock Text="CH2  AN / ADC" FontFamily="Segoe UI Semibold" /><TextBlock Text="Analog/ADC expansion I&#x00B2;C branch exposed by the card headers." Foreground="{StaticResource MutedBrush}" FontSize="11" TextWrapping="Wrap" Margin="0,4,0,0" /></StackPanel></Border>
                                             <Border Background="#0B1926" BorderBrush="{StaticResource BorderBrush}" BorderThickness="1" CornerRadius="9" Padding="12" Margin="8,8,0,0"><StackPanel><TextBlock Text="CH3  DC" FontFamily="Segoe UI Semibold" /><TextBlock Text="DC expansion I&#x00B2;C branch exposed by the card headers." Foreground="{StaticResource MutedBrush}" FontSize="11" TextWrapping="Wrap" Margin="0,4,0,0" /></StackPanel></Border>
                                         </UniformGrid>
@@ -1577,7 +1709,7 @@
 
                             <Border Grid.Row="4" Style="{StaticResource Panel}" Margin="0,0,0,18">
                                 <StackPanel>
-                                    <Grid><Grid.ColumnDefinitions><ColumnDefinition Width="*" /><ColumnDefinition Width="Auto" /></Grid.ColumnDefinitions><StackPanel><TextBlock Text="Subsystem RGB status indicators" Style="{StaticResource SectionTitle}" /><TextBlock Text="IS32FL3207 at 0x6E on sensor channel 1 &#x00B7; GNSS 1/2 and IO 1&#x2013;4" Foreground="{StaticResource MutedBrush}" FontSize="11" Margin="0,3,0,0" /></StackPanel><CheckBox x:Name="I2cLedAutoCheckBox" Grid.Column="1" Content="Automatic status mapping" IsChecked="True" Click="I2cLedAuto_Click" VerticalAlignment="Center" /></Grid>
+                                    <Grid><Grid.ColumnDefinitions><ColumnDefinition Width="*" /><ColumnDefinition Width="Auto" /></Grid.ColumnDefinitions><StackPanel><TextBlock Text="Subsystem RGB status indicators" Style="{StaticResource SectionTitle}" /><TextBlock Text="IS32FL3207 at 7-bit 0x37 on sensor channel 1 &#x00B7; GNSS 1/2 and IO 1&#x2013;4" Foreground="{StaticResource MutedBrush}" FontSize="11" Margin="0,3,0,0" /></StackPanel><StackPanel Grid.Column="1" Orientation="Horizontal" VerticalAlignment="Center"><Button x:Name="I2cLedTestButton" Content="Electrical test" Click="TestI2cLeds_Click" Style="{StaticResource SecondaryButton}" Padding="12,6" Margin="0,0,14,0" /><CheckBox x:Name="I2cLedAutoCheckBox" Content="Automatic status mapping" IsChecked="True" Click="I2cLedAuto_Click" VerticalAlignment="Center" /></StackPanel></Grid>
                                     <Grid Margin="0,18,0,0"><Grid.ColumnDefinitions><ColumnDefinition Width="1.05*" /><ColumnDefinition Width="0.95*" /></Grid.ColumnDefinitions>
                                         <UniformGrid Columns="3" Margin="0,0,18,0">
                                             <Border Background="#0B1926" BorderBrush="{StaticResource BorderBrush}" BorderThickness="1" CornerRadius="9" Padding="12" Margin="0,0,8,8"><StackPanel HorizontalAlignment="Center"><Border x:Name="I2cLedGnss1Swatch" Width="34" Height="34" CornerRadius="17" Background="#263342" BorderBrush="#53677C" BorderThickness="1" /><TextBlock Text="GNSS 1" FontFamily="Segoe UI Semibold" Margin="0,8,0,2" HorizontalAlignment="Center" /><TextBlock x:Name="I2cLedGnss1StatusText" Text="WAITING" Foreground="{StaticResource MutedBrush}" FontSize="9" HorizontalAlignment="Center" /></StackPanel></Border>
@@ -1618,7 +1750,7 @@
                                             <Border Background="#0B1926" BorderBrush="{StaticResource BorderBrush}" BorderThickness="1" CornerRadius="10" Padding="14">
                                                 <Grid><Grid.ColumnDefinitions><ColumnDefinition Width="Auto" /><ColumnDefinition Width="*" /><ColumnDefinition Width="Auto" /></Grid.ColumnDefinitions>
                                                     <Image Source="Assets/timecard-i2c.png" Width="38" Height="38" />
-                                                    <StackPanel Grid.Column="1" Margin="12,0"><TextBlock Text="MAC identity EEPROM" FontFamily="Segoe UI Semibold" /><TextBlock Text="24MAC402 &#x00B7; address 0x58" Foreground="{StaticResource MutedBrush}" FontSize="11" /><TextBlock x:Name="I2cSerialNumberText" Text="Card serial not read" Foreground="{StaticResource CyanBrush}" FontFamily="Cascadia Mono, Consolas" FontSize="12" Margin="0,5,0,0" /></StackPanel>
+                                                    <StackPanel Grid.Column="1" Margin="12,0"><TextBlock Text="MAC identity EEPROM" FontFamily="Segoe UI Semibold" /><TextBlock Text="24MAC402 &#x00B7; address 0x58 &#x00B7; EUI-48 offset 0x9A" Foreground="{StaticResource MutedBrush}" FontSize="11" /><TextBlock x:Name="I2cSerialNumberText" Text="Card serial not read" Foreground="{StaticResource CyanBrush}" FontFamily="Cascadia Mono, Consolas" FontSize="12" Margin="0,5,0,0" /></StackPanel>
                                                     <StackPanel Grid.Column="2" HorizontalAlignment="Right"><TextBlock x:Name="I2cMacStatusText" Text="NOT PROBED" Foreground="{StaticResource MutedBrush}" FontSize="10" HorizontalAlignment="Right" /><Button x:Name="I2cMacReadButton" Content="Read identity" Click="ReadMacEeprom_Click" Style="{StaticResource SecondaryButton}" Padding="10,5" Margin="0,7,0,0" /></StackPanel>
                                                 </Grid>
                                             </Border>

--- a/DRV/Windows/TimeCardControlCenter/MainWindow.xaml.cs
+++ b/DRV/Windows/TimeCardControlCenter/MainWindow.xaml.cs
@@ -33,6 +33,7 @@ namespace TimeCardControlCenter
         private bool connecting;
         private bool smaUpdatingUi;
         private bool timingRefreshing;
+        private bool sensorsRefreshing;
         private bool i2cRefreshing;
         private bool ledAutomationUpdating;
         private bool ledControlsUpdating;
@@ -48,6 +49,8 @@ namespace TimeCardControlCenter
         private uint lastI2cSubaddressLength;
         private readonly SmaConnectorState[] lastSmaLedStates = new SmaConnectorState[4];
         private readonly BoardLedColor[] lastAppliedLedColors = new BoardLedColor[6];
+        private readonly bool[] boardLedHardwareFaults = new bool[6];
+        private string boardLedHardwareWarning;
         private bool? secondaryGnssPresent;
         private DateTime lastSmaLedRefreshUtc = DateTime.MinValue;
         private DateTime lastSecondaryLedObservationUtc = DateTime.MinValue;
@@ -122,6 +125,13 @@ namespace TimeCardControlCenter
                 return other != null && Red == other.Red &&
                     Green == other.Green && Blue == other.Blue;
             }
+        }
+
+        private sealed class BoardLedElectricalTestResult
+        {
+            public BoardLedState[] Saved { get; set; }
+            public BoardLedState Reset { get; set; }
+            public BoardLedState Output { get; set; }
         }
 
         private sealed class SmaFunctionChoice
@@ -229,6 +239,7 @@ namespace TimeCardControlCenter
                 page.Equals("Uart", StringComparison.OrdinalIgnoreCase) ? UartNav :
                 page.Equals("Sma", StringComparison.OrdinalIgnoreCase) ? SmaNav :
                 page.Equals("Timing", StringComparison.OrdinalIgnoreCase) ? TimingNav :
+                page.Equals("Sensors", StringComparison.OrdinalIgnoreCase) ? SensorsNav :
                 page.Equals("I2c", StringComparison.OrdinalIgnoreCase) ? I2cNav :
                 page.Equals("Subsystems", StringComparison.OrdinalIgnoreCase) ? SubsystemsNav :
                 page.Equals("Diagnostics", StringComparison.OrdinalIgnoreCase) ? DiagnosticsNav :
@@ -322,6 +333,8 @@ namespace TimeCardControlCenter
                 return;
             }
             await RefreshSnapshotAsync(false);
+            if (SensorsPage.Visibility == Visibility.Visible)
+                await RefreshSensorsAsync(false);
         }
 
         private async Task ConnectAsync()
@@ -399,6 +412,7 @@ namespace TimeCardControlCenter
             SidebarDriverText.Text = "Driver " + snapshot.DriverVersion + " · ABI " + snapshot.AbiVersion;
             LastRefreshText.Text = "Sampled " + DateTime.Now.ToString("HH:mm:ss", CultureInfo.InvariantCulture);
             UpdateI2cDriverCompatibility(snapshot);
+            UpdateSensorsCompatibility(snapshot);
 
             SyncStatusText.Text = snapshot.IsClockSynchronized ? "IN SYNC" : "NOT LOCKED";
             SyncStatusText.Foreground = snapshot.IsClockSynchronized ? healthyBrush : warningBrush;
@@ -3044,15 +3058,15 @@ namespace TimeCardControlCenter
                 result.MacEeprom != null &&
                 result.MacEeprom.IsPresent;
             if (!readsSupported)
-                I2cReadStatusText.Text = "Install Time Card driver 1.13 to enable reliable I\u00B2C reads.";
+                I2cReadStatusText.Text = "Install Time Card driver 1.14 to enable reliable I\u00B2C reads.";
         }
 
         private void UpdateI2cDriverCompatibility(TimeCardSnapshot snapshot)
         {
             bool abiSupported = snapshot.AbiVersion >= 3;
             bool reliableReads = abiSupported &&
-                DriverVersionAtLeast(snapshot.DriverVersion, 1, 11);
-            bool boardControls = snapshot.AbiVersion >= 7;
+                DriverVersionAtLeast(snapshot.DriverVersion, 1, 14);
+            bool boardControls = snapshot.AbiVersion >= 7 && reliableReads;
             Brush stateBrush = (Brush)FindResource(
                 boardControls ? "AccentBrush" : "GoldBrush");
 
@@ -3074,7 +3088,7 @@ namespace TimeCardControlCenter
                 I2cDriverBadgeText.Text = "READS ONLY · UPDATE";
                 I2cSafetyBannerText.Text = string.Format(
                     CultureInfo.InvariantCulture,
-                    "Driver {0} supports reliable reads. Install driver 1.13 / ABI 7 to control the PCA9546A mux and subsystem LEDs.",
+                    "Driver {0} supports legacy reads. Install driver 1.14 / ABI 7 for corrected PCA9546A, identity, and subsystem LED control.",
                     snapshot.DriverVersion);
                 return;
             }
@@ -3082,9 +3096,9 @@ namespace TimeCardControlCenter
             I2cDriverBadgeText.Text = "UPDATE REQUIRED";
             I2cSafetyBannerText.Text = abiSupported ? string.Format(
                 CultureInfo.InvariantCulture,
-                "Driver {0} uses the legacy AXI IIC receive sequence that Windows can report as a CRC data error. Install driver 1.13 before reading.",
+                "Driver {0} uses the legacy AXI IIC sequence that Windows can report as a CRC data error. Install driver 1.14 before reading.",
                 snapshot.DriverVersion) :
-                "This driver predates I\u00B2C control support. Install Time Card driver 1.13 before using the bus workspace.";
+                "This driver predates corrected I\u00B2C control support. Install Time Card driver 1.14 before using the bus workspace.";
             I2cReadButton.IsEnabled = false;
             I2cPreviousButton.IsEnabled = false;
             I2cNextButton.IsEnabled = false;
@@ -3097,13 +3111,14 @@ namespace TimeCardControlCenter
         {
             return client != null && lastSnapshot != null &&
                 lastSnapshot.AbiVersion >= 3 &&
-                DriverVersionAtLeast(lastSnapshot.DriverVersion, 1, 11);
+                DriverVersionAtLeast(lastSnapshot.DriverVersion, 1, 14);
         }
 
         private bool SupportsI2cBoardControls()
         {
             return client != null && lastSnapshot != null &&
-                lastSnapshot.AbiVersion >= 7;
+                lastSnapshot.AbiVersion >= 7 &&
+                DriverVersionAtLeast(lastSnapshot.DriverVersion, 1, 14);
         }
 
         private static bool DriverVersionAtLeast(string value, int major,
@@ -3120,7 +3135,7 @@ namespace TimeCardControlCenter
             Brush warningBrush = (Brush)FindResource("GoldBrush");
             if (state == null)
             {
-                I2cMuxStatusText.Text = "DRIVER 1.13 / ABI 7 REQUIRED";
+                I2cMuxStatusText.Text = "DRIVER 1.14 / ABI 7 REQUIRED";
                 I2cMuxStatusText.Foreground = warningBrush;
                 return;
             }
@@ -3163,7 +3178,7 @@ namespace TimeCardControlCenter
             if (!SupportsI2cBoardControls())
             {
                 MessageBox.Show(this,
-                    "Install Time Card driver 1.13 / ABI 7 to control the PCA9546A.",
+                    "Install Time Card driver 1.14 / ABI 7 to control the PCA9546A.",
                     "Driver update required", MessageBoxButton.OK,
                     MessageBoxImage.Information);
                 return;
@@ -3202,7 +3217,7 @@ namespace TimeCardControlCenter
             if (!SupportsI2cBoardControls())
             {
                 I2cLedOperationText.Text =
-                    "Automatic LED mapping requires Time Card driver 1.13 / ABI 7.";
+                    "Automatic LED mapping requires Time Card driver 1.14 / ABI 7.";
                 return;
             }
 
@@ -3273,28 +3288,58 @@ namespace TimeCardControlCenter
                 }
                 if (changed.Count == 0)
                 {
-                    I2cLedOperationText.Text =
+                    I2cLedOperationText.Text = boardLedHardwareWarning ??
                         "Automatic mapping is active · hardware colors are current.";
                     return;
                 }
 
-                await Task.Run(() =>
+                BoardLedState[] applied = await Task.Run(() =>
                 {
-                    foreach (int index in changed)
+                    BoardLedState[] states = new BoardLedState[changed.Count];
+                    for (int resultIndex = 0;
+                         resultIndex < changed.Count; resultIndex++)
                     {
+                        int index = changed[resultIndex];
                         BoardLedColor color = desired[index];
-                        activeClient.SetBoardLed((uint)index, color.Red,
+                        states[resultIndex] = activeClient.SetBoardLed(
+                            (uint)index, color.Red,
                             color.Green, color.Blue, 96);
                     }
+                    return states;
                 });
                 if (client != activeClient)
                     return;
                 foreach (int index in changed)
                     lastAppliedLedColors[index] = desired[index];
-                I2cLedOperationText.Text = string.Format(
-                    CultureInfo.InvariantCulture,
-                    "Automatic mapping updated {0} indicator{1}; mux route restored after each update.",
-                    changed.Count, changed.Count == 1 ? string.Empty : "s");
+                List<uint> faulted = new List<uint>();
+                foreach (BoardLedState state in applied)
+                {
+                    bool hasFault = HasBoardLedFault(state);
+                    boardLedHardwareFaults[state.Led] = hasFault;
+                    if (!hasFault)
+                        continue;
+                    faulted.Add(state.Led + 1);
+                    TextBlock status = GetBoardLedStatusText((int)state.Led);
+                    status.Text = "HARDWARE FAULT";
+                    status.Foreground = (Brush)FindResource("GoldBrush");
+                }
+                if (faulted.Count != 0)
+                {
+                    boardLedHardwareWarning = string.Format(
+                        CultureInfo.InvariantCulture,
+                        "IS32FL3207 accepted the colors, but LED {0} report electrical open/short faults. Check the +3.3 V common-anode rail and D13-D18 assembly.",
+                        string.Join(", ", faulted));
+                    I2cLedOperationText.Text = boardLedHardwareWarning;
+                }
+                else
+                {
+                    boardLedHardwareWarning = null;
+                    I2cLedOperationText.Text = string.Format(
+                        CultureInfo.InvariantCulture,
+                        "Automatic mapping updated {0} indicator{1}; mux route restored after each update.",
+                        changed.Count,
+                        changed.Count == 1 ? string.Empty : "s");
+                }
             }
             catch (Exception ex)
             {
@@ -3348,6 +3393,11 @@ namespace TimeCardControlCenter
                 color.Red, color.Green, color.Blue));
             status.Text = color.Status;
             status.Foreground = (Brush)FindResource("MutedBrush");
+            if (boardLedHardwareFaults[led])
+            {
+                status.Text = "HARDWARE FAULT";
+                status.Foreground = (Brush)FindResource("GoldBrush");
+            }
         }
 
         private Border GetBoardLedSwatch(int led)
@@ -3430,9 +3480,9 @@ namespace TimeCardControlCenter
                 ApplyManualBoardLedState(state);
                 I2cLedOperationText.Text = string.Format(
                     CultureInfo.InvariantCulture,
-                    "LED {0} read · RGB {1}/{2}/{3} · global current {4}.",
+                    "LED {0} read · RGB {1}/{2}/{3} · global current {4} · {5}.",
                     led + 1, state.Red, state.Green, state.Blue,
-                    state.GlobalCurrent);
+                    state.GlobalCurrent, DescribeBoardLedFaults(state));
             }
             catch (Exception ex)
             {
@@ -3448,6 +3498,101 @@ namespace TimeCardControlCenter
         private async void TurnOffI2cLed_Click(object sender, RoutedEventArgs e)
         {
             await SetManualBoardLedAsync(true);
+        }
+
+        private async void TestI2cLeds_Click(object sender, RoutedEventArgs e)
+        {
+            if (!SupportsI2cBoardControls() || ledAutomationUpdating)
+                return;
+
+            TimeCardClient activeClient = client;
+            BoardLedElectricalTestResult test = null;
+            string resultText = null;
+            ledAutomationUpdating = true;
+            SetI2cLedButtonsEnabled(false);
+            I2cLedTestButton.IsEnabled = false;
+            I2cLedOperationText.Text =
+                "Preparing the guarded IS32FL3207 electrical test…";
+            try
+            {
+                test = await Task.Run(() =>
+                {
+                    BoardLedElectricalTestResult value =
+                        new BoardLedElectricalTestResult
+                        {
+                            Saved = new BoardLedState[6]
+                        };
+                    for (uint led = 0; led < 6; led++)
+                        value.Saved[led] = activeClient.GetBoardLed(led);
+
+                    value.Reset = activeClient.SetBoardLed(
+                        0, 255, 255, 255, 128, false, true);
+                    for (uint led = 1; led < 6; led++)
+                        activeClient.SetBoardLed(
+                            led, 255, 255, 255, 128);
+                    value.Output = activeClient.SetBoardLed(
+                        0, 255, 255, 255, 128, true);
+                    return value;
+                });
+                if (client == activeClient)
+                    I2cLedOperationText.Text =
+                        "Electrical test active · all 18 outputs forced on for five seconds.";
+                await Task.Delay(TimeSpan.FromSeconds(5));
+
+                if (!test.Reset.IsSdbHigh)
+                    resultText =
+                        "Electrical test failed: the IS32FL3207 SDB pin is low. Check R109 and the U6 shutdown net.";
+                else if (HasAnyBoardLedFault(test.Output))
+                    resultText = string.Format(
+                        CultureInfo.InvariantCulture,
+                        "Electrical test: SDB is high and DC mode was accepted, but U6 reports open 0x{0:X5} / short 0x{1:X5}. Inspect the +3.3 V common-anode rail and D13-D18 orientation/soldering.",
+                        test.Output.OpenOutputMask,
+                        test.Output.ShortOutputMask);
+                else
+                    resultText =
+                        "Electrical test passed: SDB is high and all 18 LED outputs are electrically connected.";
+            }
+            catch (Exception ex)
+            {
+                resultText = "LED electrical test failed: " + ex.Message;
+            }
+            finally
+            {
+                if (test != null && test.Saved != null)
+                {
+                    try
+                    {
+                        await Task.Run(() =>
+                        {
+                            for (uint led = 0; led < test.Saved.Length; led++)
+                            {
+                                BoardLedState saved = test.Saved[led];
+                                byte current = (byte)Math.Max(
+                                    1, (int)saved.GlobalCurrent);
+                                activeClient.SetBoardLed(
+                                    led, saved.Red, saved.Green,
+                                    saved.Blue, current);
+                            }
+                        });
+                    }
+                    catch (Exception ex)
+                    {
+                        resultText = (resultText ?? "LED test completed.") +
+                            " Restore failed: " + ex.Message;
+                    }
+                }
+                Array.Clear(lastAppliedLedColors, 0,
+                    lastAppliedLedColors.Length);
+                boardLedHardwareWarning = resultText;
+                ledAutomationUpdating = false;
+                if (client == activeClient)
+                {
+                    SetI2cLedButtonsEnabled(true);
+                    I2cLedTestButton.IsEnabled = true;
+                    I2cLedOperationText.Text = resultText ??
+                        "LED electrical test completed.";
+                }
+            }
         }
 
         private async Task SetManualBoardLedAsync(bool turnOff)
@@ -3475,8 +3620,9 @@ namespace TimeCardControlCenter
                 ApplyManualBoardLedState(state);
                 I2cLedOperationText.Text = string.Format(
                     CultureInfo.InvariantCulture,
-                    "LED {0} updated · RGB {1}/{2}/{3}; previous PCA9546A route restored.",
-                    led + 1, state.Red, state.Green, state.Blue);
+                    "LED {0} updated · RGB {1}/{2}/{3} · {4}; previous PCA9546A route restored.",
+                    led + 1, state.Red, state.Green, state.Blue,
+                    DescribeBoardLedFaults(state));
                 Log(string.Format(CultureInfo.InvariantCulture,
                     "Subsystem LED {0} set to RGB {1}/{2}/{3}.",
                     led + 1, state.Red, state.Green, state.Blue));
@@ -3500,6 +3646,41 @@ namespace TimeCardControlCenter
                 out led) ? led : 0u;
         }
 
+        private static string DescribeBoardLedFaults(BoardLedState state)
+        {
+            if (!state.HasFaultDiagnostics)
+                return "hardware fault diagnostics unavailable";
+
+            uint channelMask = 7u << ((int)state.Led * 3);
+            uint open = state.OpenOutputMask & channelMask;
+            uint shorted = state.ShortOutputMask & channelMask;
+            if (open == 0 && shorted == 0)
+                return "LED outputs electrically connected";
+            if (open != 0 && shorted != 0)
+                return string.Format(CultureInfo.InvariantCulture,
+                    "open 0x{0:X5}, short 0x{1:X5}",
+                    state.OpenOutputMask, state.ShortOutputMask);
+            return open != 0 ? string.Format(CultureInfo.InvariantCulture,
+                "open-output mask 0x{0:X5}", state.OpenOutputMask) :
+                string.Format(CultureInfo.InvariantCulture,
+                    "short-output mask 0x{0:X5}", state.ShortOutputMask);
+        }
+
+        private static bool HasBoardLedFault(BoardLedState state)
+        {
+            if (!state.HasFaultDiagnostics)
+                return false;
+            uint channelMask = 7u << ((int)state.Led * 3);
+            return ((state.OpenOutputMask | state.ShortOutputMask) &
+                    channelMask) != 0;
+        }
+
+        private static bool HasAnyBoardLedFault(BoardLedState state)
+        {
+            return state.HasFaultDiagnostics &&
+                (state.OpenOutputMask | state.ShortOutputMask) != 0;
+        }
+
         private void ApplyManualBoardLedState(BoardLedState state)
         {
             ledControlsUpdating = true;
@@ -3520,6 +3701,13 @@ namespace TimeCardControlCenter
                 new BoardLedColor(state.Red, state.Green, state.Blue,
                     state.Red == 0 && state.Green == 0 && state.Blue == 0 ?
                     "OFF" : "MANUAL"));
+            boardLedHardwareFaults[state.Led] = HasBoardLedFault(state);
+            if (HasBoardLedFault(state))
+            {
+                TextBlock status = GetBoardLedStatusText((int)state.Led);
+                status.Text = "HARDWARE FAULT";
+                status.Foreground = (Brush)FindResource("GoldBrush");
+            }
         }
 
         private void SetI2cLedButtonsEnabled(bool enabled)
@@ -3527,6 +3715,7 @@ namespace TimeCardControlCenter
             I2cLedReadButton.IsEnabled = enabled;
             I2cLedOffButton.IsEnabled = enabled;
             I2cLedApplyButton.IsEnabled = enabled;
+            I2cLedTestButton.IsEnabled = enabled;
         }
 
         private void SetI2cUnavailable(string state, string detail)
@@ -3573,7 +3762,7 @@ namespace TimeCardControlCenter
                 string name = address == 0x50 ? "board EEPROM" :
                     address == 0x58 ? "MAC identity" :
                     address == 0x70 ? "PCA9546A mux" :
-                    address == 0x6e ? "IS32FL3207 status LEDs (CH1)" :
+                    address == 0x37 ? "IS32FL3207 status LEDs (CH1)" :
                     address == 0x29 ? "BNO055 IMU (CH1)" :
                     address == 0x40 ? "INA219 12 V monitor (CH1)" :
                     address == 0x41 ? "INA219 5 V monitor (CH1)" :
@@ -3592,13 +3781,20 @@ namespace TimeCardControlCenter
             return string.Format(CultureInfo.InvariantCulture,
                 "CR  0x{0:X2}  {1}\r\nSR  0x{2:X2}  {3}\r\n" +
                 "ISR 0x{4:X8}  {5}\r\nIER 0x{6:X8}\r\n" +
-                "TX FIFO {7}  RX FIFO {8}\r\n{9}",
+                "TX FIFO {7}  RX FIFO {8}\r\n" +
+                "Last START CR 0x{9:X2}->0x{10:X2}  SR 0x{11:X2}->0x{12:X2}\r\n" +
+                "Last START events 0x{13:X4}  TX FIFO {14}->{15}\r\n{16}",
                 status.Control, DecodeI2cControl(status.Control),
                 status.Status, DecodeI2cStatus(status.Status),
                 status.InterruptStatus,
                 DecodeI2cInterrupts(status.InterruptStatus),
                 status.InterruptEnable, status.TxFifoOccupancy,
-                status.RxFifoOccupancy, operation);
+                status.RxFifoOccupancy,
+                status.LastStartInitialControl, status.LastStartFinalControl,
+                status.LastStartInitialStatus, status.LastStartFinalStatus,
+                status.LastStartInterruptStatus,
+                status.LastStartInitialTxFifoOccupancy,
+                status.LastStartFinalTxFifoOccupancy, operation);
         }
 
         private static string FormatI2cTransactionDiagnostics(
@@ -3686,7 +3882,7 @@ namespace TimeCardControlCenter
             else if (preset == "identity")
             {
                 I2cAddressTextBox.Text = "58";
-                I2cSubaddressTextBox.Text = "00";
+                I2cSubaddressTextBox.Text = "9A";
                 I2cSubaddressLengthCombo.SelectedIndex = 1;
                 I2cLengthTextBox.Text = "6";
             }
@@ -3713,7 +3909,7 @@ namespace TimeCardControlCenter
             }
             else if (preset == "leddriver")
             {
-                I2cAddressTextBox.Text = "6E";
+                I2cAddressTextBox.Text = "37";
                 I2cSubaddressTextBox.Text = "00";
                 I2cSubaddressLengthCombo.SelectedIndex = 1;
                 I2cLengthTextBox.Text = "8";
@@ -3813,7 +4009,7 @@ namespace TimeCardControlCenter
         {
             I2cPresetCombo.SelectedIndex = 2;
             I2cAddressTextBox.Text = "58";
-            I2cSubaddressTextBox.Text = "00";
+            I2cSubaddressTextBox.Text = "9A";
             I2cSubaddressLengthCombo.SelectedIndex = 1;
             I2cLengthTextBox.Text = "6";
             await ExecuteI2cReadAsync();
@@ -3825,9 +4021,9 @@ namespace TimeCardControlCenter
             if (client == null || lastSnapshot == null ||
                 !SupportsReliableI2cReads())
             {
-                SidebarSerialText.Text = "Driver 1.12 required";
+                SidebarSerialText.Text = "Driver 1.14 required";
                 I2cSerialNumberText.Text =
-                    "Update to driver 1.12 to read the card identity";
+                    "Update to driver 1.14 to read the card identity";
                 return;
             }
 
@@ -3844,7 +4040,7 @@ namespace TimeCardControlCenter
                 else
                 {
                     I2cReadResult result = await Task.Run(() =>
-                        client.ReadI2c(0x58, 0, 1, 6, 100));
+                        client.ReadI2c(0x58, 0x9a, 1, 6, 100));
                     serial = BitConverter.ToString(result.Data).Replace('-', ':');
                     valid = result.Data.Length == 6 &&
                         result.Data.Any(value => value != 0) &&
@@ -3874,11 +4070,11 @@ namespace TimeCardControlCenter
             if (!SupportsReliableI2cReads())
             {
                 MessageBox.Show(this,
-                    "Reliable I2C reads require Time Card driver 1.11 or later. " +
+                    "Corrected I2C reads require Time Card driver 1.14 or later. " +
                     "This computer is running driver " +
                     (lastSnapshot == null ? "an unknown version" :
                      lastSnapshot.DriverVersion) + ".\n\n" +
-                     "Install the current driver 1.13 package, then restart the Control Center.",
+                     "Install the current driver 1.14 package, then restart the Control Center.",
                     "Driver update required", MessageBoxButton.OK,
                     MessageBoxImage.Information);
                 return;
@@ -3973,7 +4169,7 @@ namespace TimeCardControlCenter
             {
                 return "The installed driver returned its legacy I2C short-transfer status. " +
                     "Windows labels that status as a CRC data error, but this transaction does not use a CRC. " +
-                    "Install Time Card driver 1.13 and retry the read.";
+                    "Install Time Card driver 1.14 and retry the read.";
             }
             return error.Message;
         }
@@ -4713,6 +4909,249 @@ namespace TimeCardControlCenter
             return crc;
         }
 
+        private void UpdateSensorsCompatibility(TimeCardSnapshot snapshot)
+        {
+            bool supported = snapshot != null && snapshot.AbiVersion >= 8;
+            SensorsRefreshButton.IsEnabled = supported && client != null &&
+                !sensorsRefreshing;
+            if (supported)
+            {
+                SensorsDriverText.Text =
+                    "Sensor branch ready · PCA9546A channel 1 is selected only for each guarded sample, then restored.";
+                return;
+            }
+
+            SensorsDriverText.Text = snapshot == null
+                ? "Connect a Time Card with driver 1.15 / ABI 8 to begin live sampling."
+                : string.Format(CultureInfo.InvariantCulture,
+                    "Driver {0} / ABI {1} does not expose sensor telemetry. Install Time Card driver 1.15 / ABI 8.",
+                    snapshot.DriverVersion, snapshot.AbiVersion);
+            SensorsStatusText.Text = "DRIVER UPDATE REQUIRED";
+            SensorsStatusText.Foreground = (Brush)FindResource("GoldBrush");
+            SensorsStatusDot.Fill = (Brush)FindResource("GoldBrush");
+        }
+
+        private async void RefreshSensors_Click(object sender, RoutedEventArgs e)
+        {
+            await RefreshSensorsAsync(true);
+        }
+
+        private async Task RefreshSensorsAsync(bool logSuccess)
+        {
+            if (sensorsRefreshing || client == null)
+                return;
+            if (lastSnapshot == null || lastSnapshot.AbiVersion < 8)
+            {
+                UpdateSensorsCompatibility(lastSnapshot);
+                return;
+            }
+
+            sensorsRefreshing = true;
+            SensorsRefreshButton.IsEnabled = false;
+            SensorsStatusText.Text = "SAMPLING";
+            SensorsStatusText.Foreground = (Brush)FindResource("CyanBrush");
+            SensorsStatusDot.Fill = (Brush)FindResource("CyanBrush");
+            try
+            {
+                SensorTelemetrySnapshot telemetry = await Task.Run(
+                    () => client.GetSensorTelemetry());
+                ApplySensorTelemetry(telemetry);
+                if (logSuccess)
+                    Log("Environment, power-rail, and IMU telemetry refreshed.");
+            }
+            catch (Exception ex)
+            {
+                SensorsStatusText.Text = "SAMPLE FAILED";
+                SensorsStatusText.Foreground = (Brush)FindResource("DangerBrush");
+                SensorsStatusDot.Fill = (Brush)FindResource("DangerBrush");
+                SensorsLastSampleText.Text = "ERROR";
+                SensorsDriverText.Text = "Sensor read failed: " + ex.Message;
+                Log("Sensor telemetry failed: " + ex.Message);
+            }
+            finally
+            {
+                sensorsRefreshing = false;
+                SensorsRefreshButton.IsEnabled = client != null &&
+                    lastSnapshot != null && lastSnapshot.AbiVersion >= 8;
+            }
+        }
+
+        private void ApplySensorTelemetry(SensorTelemetrySnapshot telemetry)
+        {
+            Brush healthy = (Brush)FindResource("AccentBrush");
+            Brush warning = (Brush)FindResource("GoldBrush");
+            bool anyValid = telemetry.Environment.IsValid ||
+                telemetry.Rail12V.IsValid || telemetry.Rail5V.IsValid ||
+                telemetry.Rail3V3.IsValid || telemetry.Imu.IsValid;
+
+            SensorsStatusText.Text = anyValid ? "LIVE · 1 HZ" : "NO SENSOR DATA";
+            SensorsStatusText.Foreground = anyValid ? healthy : warning;
+            SensorsStatusDot.Fill = anyValid ? healthy : warning;
+            SensorsLastSampleText.Text = DateTime.Now.ToString(
+                "HH:mm:ss", CultureInfo.InvariantCulture);
+            SensorsDriverText.Text = string.Format(CultureInfo.InvariantCulture,
+                "Guarded sensor branch sample · prior mux mask 0x{0:X2} · controller 0x{1:X2} · events 0x{2:X8}",
+                telemetry.MuxChannelMask, telemetry.ControllerStatus,
+                telemetry.InterruptStatus);
+
+            EnvironmentSensorReading environment = telemetry.Environment;
+            if (environment.IsValid)
+            {
+                BmeTemperatureText.Text = environment.TemperatureCelsius.ToString(
+                    "F1", CultureInfo.InvariantCulture) + " °C";
+                BmeHumidityText.Text = environment.HumidityPercent.ToString(
+                    "F1", CultureInfo.InvariantCulture) + " %";
+                BmePressureText.Text = environment.PressureHectopascals.ToString(
+                    "F1", CultureInfo.InvariantCulture) + " hPa";
+                BmeDewPointText.Text = environment.DewPointCelsius.ToString(
+                    "F1", CultureInfo.InvariantCulture) + " °C";
+                BmeDetailText.Text = string.Format(CultureInfo.InvariantCulture,
+                    "BME280 · 0x76 · ID 0x{0:X2} · {1}", environment.ChipId,
+                    environment.IsConversionReady ? "READY" : "CONVERTING");
+                BmeDetailText.Foreground = healthy;
+            }
+            else
+            {
+                SetEnvironmentUnavailable(environment.IsPresent ?
+                    "BME280 · 0x76 · INVALID SAMPLE" :
+                    "BME280 · 0x76 · NOT PRESENT");
+            }
+
+            ApplyPowerRail(telemetry.Rail12V, Rail12VoltageText,
+                Rail12CurrentText, Rail12PowerText, Rail12DetailText,
+                Rail12StatusText);
+            ApplyPowerRail(telemetry.Rail5V, Rail5VoltageText,
+                Rail5CurrentText, Rail5PowerText, Rail5DetailText,
+                Rail5StatusText);
+            ApplyPowerRail(telemetry.Rail3V3, Rail3V3VoltageText,
+                Rail3V3CurrentText, Rail3V3PowerText, Rail3V3DetailText,
+                Rail3V3StatusText);
+            ApplyImu(telemetry.Imu);
+        }
+
+        private void SetEnvironmentUnavailable(string detail)
+        {
+            BmeTemperatureText.Text = "— °C";
+            BmeHumidityText.Text = "— %";
+            BmePressureText.Text = "— hPa";
+            BmeDewPointText.Text = "— °C";
+            BmeDetailText.Text = detail;
+            BmeDetailText.Foreground = (Brush)FindResource("GoldBrush");
+        }
+
+        private void ApplyPowerRail(PowerRailReading rail, TextBlock voltage,
+                                    TextBlock current, TextBlock power,
+                                    TextBlock detail, TextBlock status)
+        {
+            Brush healthy = (Brush)FindResource("AccentBrush");
+            Brush warning = (Brush)FindResource("GoldBrush");
+            if (!rail.IsValid)
+            {
+                voltage.Text = "— V";
+                current.Text = "— A";
+                power.Text = "— W";
+                detail.Text = rail.IsPresent ? "Sample unavailable" :
+                    "INA219 not present";
+                status.Text = string.Format(CultureInfo.InvariantCulture,
+                    "0x{0:X2} · {1}", rail.Address,
+                    rail.IsPresent ? "INVALID" : "NOT PRESENT");
+                status.Foreground = warning;
+                return;
+            }
+
+            voltage.Text = rail.VoltageVolts.ToString("F3",
+                CultureInfo.InvariantCulture) + " V";
+            current.Text = rail.CurrentAmps.ToString("F3",
+                CultureInfo.InvariantCulture) + " A";
+            power.Text = rail.PowerWatts.ToString("F3",
+                CultureInfo.InvariantCulture) + " W";
+            detail.Text = string.Format(CultureInfo.InvariantCulture,
+                "Shunt {0:F3} mV · config 0x{1:X4}",
+                rail.ShuntMillivolts, rail.Configuration);
+            status.Text = string.Format(CultureInfo.InvariantCulture,
+                "0x{0:X2} · {1}", rail.Address,
+                rail.HasOverflow ? "OVERFLOW" :
+                rail.IsConversionReady ? "READY" : "LIVE");
+            status.Foreground = rail.HasOverflow ? warning : healthy;
+        }
+
+        private void ApplyImu(ImuSensorReading imu)
+        {
+            Brush healthy = (Brush)FindResource("AccentBrush");
+            Brush warning = (Brush)FindResource("GoldBrush");
+            if (!imu.IsValid)
+            {
+                ImuHeadingText.Text = "—°";
+                ImuRollText.Text = "—°";
+                ImuPitchText.Text = "—°";
+                ImuQuaternionText.Text = "—, —, —, —";
+                ImuTemperatureText.Text = "— °C";
+                ImuSystemCalibrationText.Text = "—/3";
+                ImuGyroCalibrationText.Text = "—/3";
+                ImuAccelCalibrationText.Text = "—/3";
+                ImuMagCalibrationText.Text = "—/3";
+                ImuAccelerationText.Text = "X —   Y —   Z —";
+                ImuGyroscopeText.Text = "X —   Y —   Z —";
+                ImuMagneticText.Text = "X —   Y —   Z —";
+                ImuLinearAccelerationText.Text = "X —   Y —   Z —";
+                ImuGravityText.Text = "X —   Y —   Z —";
+                ImuStatusText.Text = imu.IsPresent ? "INITIALIZING" :
+                    "NOT PRESENT";
+                ImuStatusText.Foreground = warning;
+                ImuDetailText.Text = imu.IsPresent ?
+                    "BNO055 · 0x29 · INITIALIZING" :
+                    "BNO055 · 0x29 · NOT PRESENT";
+                ImuDetailText.Foreground = warning;
+                ImuRawStatusText.Text = string.Format(CultureInfo.InvariantCulture,
+                    "Mode 0x{0:X2} · Status 0x{1:X2}",
+                    imu.OperationMode, imu.SystemStatus);
+                ImuClockText.Text = "Clock source not available";
+                return;
+            }
+
+            ImuHeadingText.Text = imu.HeadingDegrees.ToString("F1",
+                CultureInfo.InvariantCulture) + "°";
+            ImuRollText.Text = imu.RollDegrees.ToString("F1",
+                CultureInfo.InvariantCulture) + "°";
+            ImuPitchText.Text = imu.PitchDegrees.ToString("F1",
+                CultureInfo.InvariantCulture) + "°";
+            ImuQuaternionText.Text = string.Format(CultureInfo.InvariantCulture,
+                "{0:F4}, {1:F4}, {2:F4}, {3:F4}", imu.QuaternionW,
+                imu.QuaternionX, imu.QuaternionY, imu.QuaternionZ);
+            ImuTemperatureText.Text = imu.TemperatureCelsius.ToString("F1",
+                CultureInfo.InvariantCulture) + " °C";
+            ImuSystemCalibrationText.Text = imu.SystemCalibration + "/3";
+            ImuGyroCalibrationText.Text = imu.GyroscopeCalibration + "/3";
+            ImuAccelCalibrationText.Text = imu.AccelerometerCalibration + "/3";
+            ImuMagCalibrationText.Text = imu.MagnetometerCalibration + "/3";
+            ImuAccelerationText.Text = FormatSensorVector(imu.Acceleration);
+            ImuGyroscopeText.Text = FormatSensorVector(imu.Gyroscope);
+            ImuMagneticText.Text = FormatSensorVector(imu.MagneticField);
+            ImuLinearAccelerationText.Text =
+                FormatSensorVector(imu.LinearAcceleration);
+            ImuGravityText.Text = FormatSensorVector(imu.Gravity);
+            ImuStatusText.Text = imu.SystemError == 0 ? "FUSION LIVE" :
+                "SYSTEM ERROR";
+            ImuStatusText.Foreground = imu.SystemError == 0 ? healthy : warning;
+            ImuDetailText.Text = string.Format(CultureInfo.InvariantCulture,
+                "BNO055 · 0x29 · ID 0x{0:X2} · NDOF", imu.ChipId);
+            ImuDetailText.Foreground = healthy;
+            ImuRawStatusText.Text = string.Format(CultureInfo.InvariantCulture,
+                "Mode 0x{0:X2} · Status 0x{1:X2} · Error 0x{2:X2}",
+                imu.OperationMode, imu.SystemStatus, imu.SystemError);
+            ImuClockText.Text = imu.UsesExternalClock ?
+                "External 32.768 kHz crystal active" :
+                "Internal clock active";
+        }
+
+        private static string FormatSensorVector(SensorVector3 vector)
+        {
+            return vector == null ? "X —   Y —   Z —" :
+                string.Format(CultureInfo.InvariantCulture,
+                    "X {0,7:F3}   Y {1,7:F3}   Z {2,7:F3}",
+                    vector.X, vector.Y, vector.Z);
+        }
+
         private async void Navigate_Checked(object sender, RoutedEventArgs e)
         {
             RadioButton button = sender as RadioButton;
@@ -4730,6 +5169,8 @@ namespace TimeCardControlCenter
                 await RefreshSmaAsync();
             else if (page == "Timing")
                 await RefreshTimingAsync();
+            else if (page == "Sensors")
+                await RefreshSensorsAsync(false);
             else if (page == "I2c")
                 await RefreshI2cAsync(false);
             else if (page == "Subsystems")
@@ -4747,6 +5188,7 @@ namespace TimeCardControlCenter
             UartPage.Visibility = name == "Uart" ? Visibility.Visible : Visibility.Collapsed;
             SmaPage.Visibility = name == "Sma" ? Visibility.Visible : Visibility.Collapsed;
             TimingPage.Visibility = name == "Timing" ? Visibility.Visible : Visibility.Collapsed;
+            SensorsPage.Visibility = name == "Sensors" ? Visibility.Visible : Visibility.Collapsed;
             I2cPage.Visibility = name == "I2c" ? Visibility.Visible : Visibility.Collapsed;
             FlashPage.Visibility = name == "Flash" ? Visibility.Visible : Visibility.Collapsed;
             SubsystemsPage.Visibility = name == "Subsystems" ? Visibility.Visible : Visibility.Collapsed;
@@ -4756,6 +5198,7 @@ namespace TimeCardControlCenter
                 name == "Uart" ? "UART Console" :
                 name == "Sma" ? "SMA Connectors" :
                 name == "Timing" ? "Generators & Frequency" :
+                name == "Sensors" ? "Sensors & IMU" :
                 name == "Flash" ? "FPGA SPI Flash" :
                 name == "I2c" ? "I²C Bus" : name;
             TopPageTitle.Text = title;

--- a/DRV/Windows/TimeCardControlCenter/Models.cs
+++ b/DRV/Windows/TimeCardControlCenter/Models.cs
@@ -150,8 +150,106 @@ namespace TimeCardControlCenter
         public uint MuxChannelMask;
         public uint ControllerStatus;
         public uint InterruptStatus;
-        public uint Reserved0;
-        public uint Reserved1;
+        public uint OpenOutputMask;
+        public uint ShortOutputMask;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    internal struct TimeCardBme280ReadingRaw
+    {
+        public uint Size;
+        public uint Flags;
+        public uint ChipId;
+        public uint Status;
+        public int RawTemperature;
+        public uint RawPressure;
+        public uint RawHumidity;
+        public uint DigT1;
+        public int DigT2;
+        public int DigT3;
+        public uint DigP1;
+        public int DigP2;
+        public int DigP3;
+        public int DigP4;
+        public int DigP5;
+        public int DigP6;
+        public int DigP7;
+        public int DigP8;
+        public int DigP9;
+        public uint DigH1;
+        public int DigH2;
+        public uint DigH3;
+        public int DigH4;
+        public int DigH5;
+        public int DigH6;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    internal struct TimeCardIna219ReadingRaw
+    {
+        public uint Size;
+        public uint Flags;
+        public uint Address;
+        public uint BusMillivolts;
+        public int ShuntMicrovolts;
+        public int CurrentMilliamps;
+        public int PowerMilliwatts;
+        public uint Configuration;
+        public uint RawBus;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    internal struct TimeCardBno055ReadingRaw
+    {
+        public uint Size;
+        public uint Flags;
+        public uint ChipId;
+        public uint OperationMode;
+        public uint PowerMode;
+        public uint UnitSelection;
+        public uint SystemStatus;
+        public uint SystemError;
+        public uint Calibration;
+        public uint SelfTest;
+        public uint SystemClockStatus;
+        public int Temperature;
+        public int AccelerationX;
+        public int AccelerationY;
+        public int AccelerationZ;
+        public int MagneticX;
+        public int MagneticY;
+        public int MagneticZ;
+        public int GyroscopeX;
+        public int GyroscopeY;
+        public int GyroscopeZ;
+        public int Heading;
+        public int Roll;
+        public int Pitch;
+        public int QuaternionW;
+        public int QuaternionX;
+        public int QuaternionY;
+        public int QuaternionZ;
+        public int LinearAccelerationX;
+        public int LinearAccelerationY;
+        public int LinearAccelerationZ;
+        public int GravityX;
+        public int GravityY;
+        public int GravityZ;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    internal struct TimeCardSensorTelemetryRaw
+    {
+        public uint Size;
+        public uint Flags;
+        public uint MuxChannelMask;
+        public uint ControllerStatus;
+        public uint InterruptStatus;
+        public TimeCardBme280ReadingRaw Environment;
+        public TimeCardIna219ReadingRaw Rail12V;
+        public TimeCardIna219ReadingRaw Rail5V;
+        public TimeCardIna219ReadingRaw Rail3V3;
+        public TimeCardBno055ReadingRaw Imu;
     }
 
     [StructLayout(LayoutKind.Sequential)]
@@ -320,6 +418,15 @@ namespace TimeCardControlCenter
             TxFifoOccupancy = value.TxFifoOccupancy;
             RxFifoOccupancy = value.RxFifoOccupancy;
             KnownDeviceMask = value.KnownDeviceMask;
+            LastStartInitialControl = value.Reserved0 & 0xffu;
+            LastStartInitialStatus = (value.Reserved0 >> 8) & 0xffu;
+            LastStartFinalControl = (value.Reserved0 >> 16) & 0xffu;
+            LastStartFinalStatus = (value.Reserved0 >> 24) & 0xffu;
+            LastStartInterruptStatus = value.Reserved1 & 0xffffu;
+            LastStartInitialTxFifoOccupancy =
+                (value.Reserved1 >> 16) & 0xffu;
+            LastStartFinalTxFifoOccupancy =
+                (value.Reserved1 >> 24) & 0xffu;
         }
 
         public bool IsPresent { get; private set; }
@@ -335,6 +442,13 @@ namespace TimeCardControlCenter
         public uint TxFifoOccupancy { get; private set; }
         public uint RxFifoOccupancy { get; private set; }
         public uint KnownDeviceMask { get; private set; }
+        public uint LastStartInitialControl { get; private set; }
+        public uint LastStartInitialStatus { get; private set; }
+        public uint LastStartFinalControl { get; private set; }
+        public uint LastStartFinalStatus { get; private set; }
+        public uint LastStartInterruptStatus { get; private set; }
+        public uint LastStartInitialTxFifoOccupancy { get; private set; }
+        public uint LastStartFinalTxFifoOccupancy { get; private set; }
     }
 
     public sealed class I2cProbeResult
@@ -393,6 +507,10 @@ namespace TimeCardControlCenter
             Led = value.Led;
             IsPresent = (value.Flags & 1u) != 0;
             IsEnabled = (value.Flags & 2u) != 0;
+            HasFaultDiagnostics = (value.Flags & 4u) != 0;
+            IsDcTestActive = (value.Flags & 8u) != 0;
+            WasResetTested = (value.Flags & 16u) != 0;
+            IsSdbHigh = (value.Flags & 32u) != 0;
             Red = (byte)value.Red;
             Green = (byte)value.Green;
             Blue = (byte)value.Blue;
@@ -400,11 +518,17 @@ namespace TimeCardControlCenter
             MuxChannelMask = value.MuxChannelMask;
             ControllerStatus = value.ControllerStatus;
             InterruptStatus = value.InterruptStatus;
+            OpenOutputMask = value.OpenOutputMask;
+            ShortOutputMask = value.ShortOutputMask;
         }
 
         public uint Led { get; private set; }
         public bool IsPresent { get; private set; }
         public bool IsEnabled { get; private set; }
+        public bool HasFaultDiagnostics { get; private set; }
+        public bool IsDcTestActive { get; private set; }
+        public bool WasResetTested { get; private set; }
+        public bool IsSdbHigh { get; private set; }
         public byte Red { get; private set; }
         public byte Green { get; private set; }
         public byte Blue { get; private set; }
@@ -412,6 +536,238 @@ namespace TimeCardControlCenter
         public uint MuxChannelMask { get; private set; }
         public uint ControllerStatus { get; private set; }
         public uint InterruptStatus { get; private set; }
+        public uint OpenOutputMask { get; private set; }
+        public uint ShortOutputMask { get; private set; }
+    }
+
+    public sealed class SensorTelemetrySnapshot
+    {
+        internal SensorTelemetrySnapshot(TimeCardSensorTelemetryRaw value)
+        {
+            IsAvailable = (value.Flags & 1u) != 0;
+            IsValid = (value.Flags & 2u) != 0;
+            MuxChannelMask = value.MuxChannelMask;
+            ControllerStatus = value.ControllerStatus;
+            InterruptStatus = value.InterruptStatus;
+            Environment = new EnvironmentSensorReading(value.Environment);
+            Rail12V = new PowerRailReading("+12 V", value.Rail12V);
+            Rail5V = new PowerRailReading("+5 V", value.Rail5V);
+            Rail3V3 = new PowerRailReading("+3.3 V", value.Rail3V3);
+            Imu = new ImuSensorReading(value.Imu);
+        }
+
+        public bool IsAvailable { get; private set; }
+        public bool IsValid { get; private set; }
+        public uint MuxChannelMask { get; private set; }
+        public uint ControllerStatus { get; private set; }
+        public uint InterruptStatus { get; private set; }
+        public EnvironmentSensorReading Environment { get; private set; }
+        public PowerRailReading Rail12V { get; private set; }
+        public PowerRailReading Rail5V { get; private set; }
+        public PowerRailReading Rail3V3 { get; private set; }
+        public ImuSensorReading Imu { get; private set; }
+    }
+
+    public sealed class EnvironmentSensorReading
+    {
+        internal EnvironmentSensorReading(TimeCardBme280ReadingRaw value)
+        {
+            IsPresent = (value.Flags & 1u) != 0;
+            IsValid = (value.Flags & 2u) != 0;
+            IsConfigured = (value.Flags & 4u) != 0;
+            IsConversionReady = (value.Flags & 8u) != 0;
+            ChipId = value.ChipId;
+            Status = value.Status;
+            if (!IsValid || value.DigT1 == 0 || value.DigP1 == 0)
+                return;
+
+            double var1 = (value.RawTemperature / 16384.0 -
+                value.DigT1 / 1024.0) * value.DigT2;
+            double var2 = value.RawTemperature / 131072.0 -
+                value.DigT1 / 8192.0;
+            var2 = var2 * var2 * value.DigT3;
+            double tFine = var1 + var2;
+            TemperatureCelsius = Math.Max(-40.0,
+                Math.Min(85.0, tFine / 5120.0));
+
+            var1 = tFine / 2.0 - 64000.0;
+            var2 = var1 * var1 * value.DigP6 / 32768.0;
+            var2 += var1 * value.DigP5 * 2.0;
+            var2 = var2 / 4.0 + value.DigP4 * 65536.0;
+            double var3 = value.DigP3 * var1 * var1 / 524288.0;
+            var1 = (var3 + value.DigP2 * var1) / 524288.0;
+            var1 = (1.0 + var1 / 32768.0) * value.DigP1;
+            if (var1 > 0.0)
+            {
+                double pressure = 1048576.0 - value.RawPressure;
+                pressure = (pressure - var2 / 4096.0) * 6250.0 / var1;
+                var1 = value.DigP9 * pressure * pressure / 2147483648.0;
+                var2 = pressure * value.DigP8 / 32768.0;
+                pressure += (var1 + var2 + value.DigP7) / 16.0;
+                PressureHectopascals = Math.Max(30000.0,
+                    Math.Min(110000.0, pressure)) / 100.0;
+            }
+
+            var1 = tFine - 76800.0;
+            var2 = value.DigH4 * 64.0 + value.DigH5 / 16384.0 * var1;
+            var3 = value.RawHumidity - var2;
+            double var4 = value.DigH2 / 65536.0;
+            double var5 = 1.0 + value.DigH3 / 67108864.0 * var1;
+            double var6 = 1.0 + value.DigH6 / 67108864.0 * var1 * var5;
+            var6 = var3 * var4 * (var5 * var6);
+            HumidityPercent = Math.Max(0.0, Math.Min(100.0,
+                var6 * (1.0 - value.DigH1 * var6 / 524288.0)));
+            if (HumidityPercent > 0.0)
+            {
+                double gamma = Math.Log(HumidityPercent / 100.0) +
+                    17.62 * TemperatureCelsius /
+                    (243.12 + TemperatureCelsius);
+                DewPointCelsius = 243.12 * gamma / (17.62 - gamma);
+            }
+        }
+
+        public bool IsPresent { get; private set; }
+        public bool IsValid { get; private set; }
+        public bool IsConfigured { get; private set; }
+        public bool IsConversionReady { get; private set; }
+        public uint ChipId { get; private set; }
+        public uint Status { get; private set; }
+        public double TemperatureCelsius { get; private set; }
+        public double HumidityPercent { get; private set; }
+        public double PressureHectopascals { get; private set; }
+        public double DewPointCelsius { get; private set; }
+    }
+
+    public sealed class PowerRailReading
+    {
+        internal PowerRailReading(string name, TimeCardIna219ReadingRaw value)
+        {
+            Name = name;
+            IsPresent = (value.Flags & 1u) != 0;
+            IsValid = (value.Flags & 2u) != 0;
+            IsConversionReady = (value.Flags & 8u) != 0;
+            HasOverflow = (value.Flags & 16u) != 0;
+            Address = value.Address;
+            VoltageVolts = value.BusMillivolts / 1000.0;
+            CurrentAmps = value.CurrentMilliamps / 1000.0;
+            PowerWatts = value.PowerMilliwatts / 1000.0;
+            ShuntMillivolts = value.ShuntMicrovolts / 1000.0;
+            Configuration = value.Configuration;
+        }
+
+        public string Name { get; private set; }
+        public bool IsPresent { get; private set; }
+        public bool IsValid { get; private set; }
+        public bool IsConversionReady { get; private set; }
+        public bool HasOverflow { get; private set; }
+        public uint Address { get; private set; }
+        public double VoltageVolts { get; private set; }
+        public double CurrentAmps { get; private set; }
+        public double PowerWatts { get; private set; }
+        public double ShuntMillivolts { get; private set; }
+        public uint Configuration { get; private set; }
+    }
+
+    public sealed class SensorVector3
+    {
+        internal SensorVector3(double x, double y, double z)
+        {
+            X = x;
+            Y = y;
+            Z = z;
+        }
+
+        public double X { get; private set; }
+        public double Y { get; private set; }
+        public double Z { get; private set; }
+    }
+
+    public sealed class ImuSensorReading
+    {
+        internal ImuSensorReading(TimeCardBno055ReadingRaw value)
+        {
+            IsPresent = (value.Flags & 1u) != 0;
+            IsValid = (value.Flags & 2u) != 0;
+            IsConfigured = (value.Flags & 4u) != 0;
+            UsesExternalClock = (value.Flags & 32u) != 0;
+            ChipId = value.ChipId;
+            OperationMode = value.OperationMode;
+            PowerMode = value.PowerMode;
+            UnitSelection = value.UnitSelection;
+            SystemStatus = value.SystemStatus;
+            SystemError = value.SystemError;
+            SelfTest = value.SelfTest;
+            SystemClockStatus = value.SystemClockStatus;
+            SystemCalibration = (int)((value.Calibration >> 6) & 3u);
+            GyroscopeCalibration = (int)((value.Calibration >> 4) & 3u);
+            AccelerometerCalibration = (int)((value.Calibration >> 2) & 3u);
+            MagnetometerCalibration = (int)(value.Calibration & 3u);
+
+            double accelerationScale = (value.UnitSelection & 0x02u) != 0
+                ? 9.80665 / 1000.0 : 1.0 / 100.0;
+            double gyroScale = (value.UnitSelection & 0x04u) != 0
+                ? 180.0 / (Math.PI * 900.0) : 1.0 / 16.0;
+            double eulerScale = (value.UnitSelection & 0x08u) != 0
+                ? 180.0 / (Math.PI * 900.0) : 1.0 / 16.0;
+            TemperatureCelsius = (value.UnitSelection & 0x20u) != 0
+                ? (value.Temperature * 2.0 - 32.0) * 5.0 / 9.0
+                : value.Temperature;
+            Acceleration = new SensorVector3(
+                value.AccelerationX * accelerationScale,
+                value.AccelerationY * accelerationScale,
+                value.AccelerationZ * accelerationScale);
+            MagneticField = new SensorVector3(
+                value.MagneticX / 16.0, value.MagneticY / 16.0,
+                value.MagneticZ / 16.0);
+            Gyroscope = new SensorVector3(
+                value.GyroscopeX * gyroScale, value.GyroscopeY * gyroScale,
+                value.GyroscopeZ * gyroScale);
+            HeadingDegrees = value.Heading * eulerScale;
+            RollDegrees = value.Roll * eulerScale;
+            PitchDegrees = value.Pitch * eulerScale;
+            QuaternionW = value.QuaternionW / 16384.0;
+            QuaternionX = value.QuaternionX / 16384.0;
+            QuaternionY = value.QuaternionY / 16384.0;
+            QuaternionZ = value.QuaternionZ / 16384.0;
+            LinearAcceleration = new SensorVector3(
+                value.LinearAccelerationX * accelerationScale,
+                value.LinearAccelerationY * accelerationScale,
+                value.LinearAccelerationZ * accelerationScale);
+            Gravity = new SensorVector3(
+                value.GravityX * accelerationScale,
+                value.GravityY * accelerationScale,
+                value.GravityZ * accelerationScale);
+        }
+
+        public bool IsPresent { get; private set; }
+        public bool IsValid { get; private set; }
+        public bool IsConfigured { get; private set; }
+        public bool UsesExternalClock { get; private set; }
+        public uint ChipId { get; private set; }
+        public uint OperationMode { get; private set; }
+        public uint PowerMode { get; private set; }
+        public uint UnitSelection { get; private set; }
+        public uint SystemStatus { get; private set; }
+        public uint SystemError { get; private set; }
+        public uint SelfTest { get; private set; }
+        public uint SystemClockStatus { get; private set; }
+        public int SystemCalibration { get; private set; }
+        public int GyroscopeCalibration { get; private set; }
+        public int AccelerometerCalibration { get; private set; }
+        public int MagnetometerCalibration { get; private set; }
+        public double TemperatureCelsius { get; private set; }
+        public SensorVector3 Acceleration { get; private set; }
+        public SensorVector3 MagneticField { get; private set; }
+        public SensorVector3 Gyroscope { get; private set; }
+        public double HeadingDegrees { get; private set; }
+        public double RollDegrees { get; private set; }
+        public double PitchDegrees { get; private set; }
+        public double QuaternionW { get; private set; }
+        public double QuaternionX { get; private set; }
+        public double QuaternionY { get; private set; }
+        public double QuaternionZ { get; private set; }
+        public SensorVector3 LinearAcceleration { get; private set; }
+        public SensorVector3 Gravity { get; private set; }
     }
 
     public sealed class NmeaOutputState

--- a/DRV/Windows/TimeCardControlCenter/Properties/AssemblyInfo.cs
+++ b/DRV/Windows/TimeCardControlCenter/Properties/AssemblyInfo.cs
@@ -9,5 +9,5 @@ using System.Windows;
 [assembly: AssemblyCopyright("Copyright © Open Compute Project contributors")]
 [assembly: ComVisible(false)]
 [assembly: ThemeInfo(ResourceDictionaryLocation.None, ResourceDictionaryLocation.SourceAssembly)]
-[assembly: AssemblyVersion("1.13.0.0")]
-[assembly: AssemblyFileVersion("1.13.0.0")]
+[assembly: AssemblyVersion("1.15.1.0")]
+[assembly: AssemblyFileVersion("1.15.1.0")]

--- a/DRV/Windows/TimeCardControlCenter/README.md
+++ b/DRV/Windows/TimeCardControlCenter/README.md
@@ -250,21 +250,22 @@ the 24MAC402 identity EEPROM at `0x58`, can scan all normal 7-bit addresses,
 and displays reads as hex plus ASCII, hex, ASCII, decimal, or binary. Presets,
 previous/next page navigation, a 50/100/250 ms timeout selector, copy, an ACK
 map, and decoded control/status/interrupt flags support bus diagnosis. The six
-bytes at MAC EEPROM offset zero are formatted as the card's unique serial
-number, the same mapping used by Linux `ptp_ocp` and its `serialnum` attribute.
+bytes in the factory EUI-48 area at raw offset `0x9a` are formatted as the
+card's unique serial number. Linux exposes the same identity bytes at NVMEM
+offset zero through the `24mac402` provider to `ptp_ocp`'s `serialnum`
+attribute.
 
 Reads support no subaddress or a one- or two-byte subaddress followed by a
 repeated start. Transfers are limited to 255 bytes and a bounded timeout.
-Driver 1.11 fixes the repeated-start receive race by separating the subaddress
-and receive phases, servicing the AXI IIC receive watermark before interpreting
-its shared `TX_ERROR`/final-NACK bit, advancing the watermark across FIFO-sized
-chunks, and retrying once after controller reset for transient failures. Native
-Win32 error text and a post-failure controller snapshot are shown if a read
-still fails. The Control Center requires driver 1.11 or newer for reads and
-identifies older drivers before they can surface the misleading Windows CRC
-error; the current supported package is driver 1.13.
+Driver 1.14 corrects the dynamic-mode startup handshake by queuing the complete
+command before clearing the stale bus-not-busy latch, matching Linux
+`i2c-xiic`. Receive data is drained whenever available,
+the expected final receive NACK is handled separately from an address NACK,
+and a failed transient transaction is reset and retried once. Native Win32
+error text and a post-failure controller snapshot are shown if a read still
+fails. The Control Center requires driver 1.14 or newer for I2C operations.
 
-Driver 1.13 / ABI 7 adds dedicated controls for the schematic's U27 PCA9546A
+Driver 1.14 / ABI 7 provides dedicated controls for the schematic's U27 PCA9546A
 at `0x70`. Channel 0 is the MAC-clock branch, channel 1 contains the onboard
 sensors and RGB LED driver, channel 2 is the analog/ADC expansion branch, and
 channel 3 is the DC expansion branch. The workspace shows the selected mask,
@@ -277,7 +278,8 @@ U26, the TMUX1072 near the MAC connector, is controlled by the physical
 therefore explains that channel 0 also requires `MACSER=0` instead of exposing
 a non-functional software toggle.
 
-The IS32FL3207 at `0x6e` drives six common-anode RGB indicators: GNSS1 uses
+The IS32FL3207 uses 7-bit address `0x37`; the schematic's `0x6e` label is its
+8-bit write address. It drives six common-anode RGB indicators: GNSS1 uses
 OUT1â€“3, GNSS2 OUT4â€“6, and IO1 through IO4 use OUT7â€“18 in groups of three.
 Manual RGB/current controls and automatic status mapping are available.
 Automatic mode uses green for a GNSS fix or configured SMA output, blue for an
@@ -285,6 +287,27 @@ SMA input, amber for searching/unknown/disabled states, and red for missing or
 failed status. LED transactions temporarily select sensor channel 1 and then
 restore the user's PCA9546A mask. The driver caps global current at 128 and
 does not expose a general data-write or EEPROM-programming IOCTL.
+
+The Electrical test button saves the six colors, verifies that the hardware
+SDB pin permits a device reset, bypasses PWM, and forces all 18 current sinks
+on for five seconds before restoring the saved state. Open/short results are
+shown in the workspace, and automatic mapping marks affected packages as
+`HARDWARE FAULT` instead of reporting a successful visible update.
+
+## Sensors and IMU
+
+Driver 1.15.1 / ABI 8 and the dedicated Sensors & IMU workspace read every
+populated monitor on the schematic's sensor branch. The BME280 cards show
+factory-compensated temperature, relative humidity, pressure, and calculated
+dew point. The three INA219 cards show bus voltage, shunt current, and load
+power for +12 V, +5 V, and +3.3 V using the board's 2 milliohm shunts.
+
+The BNO055 is placed in NDOF fusion mode and uses the V9 schematic's external
+32.768 kHz crystal. The workspace reports heading, roll, pitch, quaternion,
+temperature, calibration levels, acceleration, linear acceleration, gravity,
+angular velocity, and magnetic field. Sampling is live at one hertz while the
+workspace is visible. Each query temporarily selects PCA9546A channel 1,
+reports missing devices separately, and restores the previous mux selection.
 
 ## FPGA SPI flash
 

--- a/DRV/Windows/TimeCardControlCenter/TimeCardClient.cs
+++ b/DRV/Windows/TimeCardControlCenter/TimeCardClient.cs
@@ -56,6 +56,7 @@ namespace TimeCardControlCenter
         private static readonly uint IoctlI2cMuxSet = ControlCode(27, FileReadAccess | FileWriteAccess);
         private static readonly uint IoctlLedQuery = ControlCode(28, FileReadAccess | FileWriteAccess);
         private static readonly uint IoctlLedSet = ControlCode(29, FileReadAccess | FileWriteAccess);
+        private static readonly uint IoctlSensorQuery = ControlCode(30, FileReadAccess | FileWriteAccess);
 
         private readonly object gate = new object();
         private SafeFileHandle handle;
@@ -771,6 +772,21 @@ namespace TimeCardControlCenter
         public BoardLedState SetBoardLed(uint led, byte red, byte green,
                                          byte blue, byte globalCurrent)
         {
+            return SetBoardLed(led, red, green, blue, globalCurrent, false);
+        }
+
+        public BoardLedState SetBoardLed(uint led, byte red, byte green,
+                                         byte blue, byte globalCurrent,
+                                         bool dcTest)
+        {
+            return SetBoardLed(led, red, green, blue, globalCurrent,
+                dcTest, false);
+        }
+
+        public BoardLedState SetBoardLed(uint led, byte red, byte green,
+                                         byte blue, byte globalCurrent,
+                                         bool dcTest, bool resetTest)
+        {
             if (led >= 6)
                 throw new ArgumentOutOfRangeException("led");
             if (globalCurrent == 0 || globalCurrent > 128)
@@ -782,11 +798,18 @@ namespace TimeCardControlCenter
                 Red = red,
                 Green = green,
                 Blue = blue,
-                GlobalCurrent = globalCurrent
+                GlobalCurrent = globalCurrent,
+                Flags = (dcTest ? 8u : 0u) | (resetTest ? 16u : 0u)
             };
             byte[] output = Call(IoctlLedSet, StructToBytes(request),
                 Marshal.SizeOf(typeof(TimeCardLedControlRaw)));
             return new BoardLedState(BytesToStruct<TimeCardLedControlRaw>(output));
+        }
+
+        public SensorTelemetrySnapshot GetSensorTelemetry()
+        {
+            return new SensorTelemetrySnapshot(
+                GetOutput<TimeCardSensorTelemetryRaw>(IoctlSensorQuery));
         }
 
         private TimeCardHierarchyRaw SetHierarchyRaw(uint action, bool persist)

--- a/DRV/Windows/driver.c
+++ b/DRV/Windows/driver.c
@@ -104,6 +104,8 @@ TimeCardSelectLayout(PDEVICE_CONTEXT context)
     context->NmeaOut = NULL;
     context->I2c = NULL;
     context->I2cKnownDeviceMask = 0;
+    context->I2cLastStartTrace = 0;
+    context->I2cLastStartEvents = 0;
     context->Flash = NULL;
     context->FlashJedecId = 0;
     context->FlashCapacity = 0;

--- a/DRV/Windows/i2c.c
+++ b/DRV/Windows/i2c.c
@@ -42,6 +42,11 @@
 static UCHAR
 TimeCardI2cRead8(PDEVICE_CONTEXT context, ULONG offset)
 {
+    /*
+     * Match Linux i2c-xiic's native register widths.  The control, status,
+     * FIFO occupancy, and receive-data registers are byte-wide; the dynamic
+     * transmit register is 16-bit so its START/STOP flags reach bits 8/9.
+     */
     return READ_REGISTER_UCHAR((volatile UCHAR *)(context->I2c + offset));
 }
 
@@ -135,6 +140,45 @@ TimeCardI2cWaitNotBusy(PDEVICE_CONTEXT context)
     return STATUS_DEVICE_BUSY;
 }
 
+static VOID
+TimeCardI2cQueueDynamicStart(PDEVICE_CONTEXT context, USHORT addressWord)
+{
+    /*
+     * Queue the complete dynamic command before clearing BNB.  This matches
+     * Linux i2c-xiic: some AXI IIC revisions do not launch START from an
+     * address-only FIFO and instead wait for data or a dynamic receive length.
+     * BNB is level-derived while idle, so the caller clears it only after the
+     * complete command has been queued.
+     */
+    TimeCardI2cClearInterruptMask(
+        context, XIIC_INTR_ARB_LOST | XIIC_INTR_TX_ERROR |
+                 XIIC_INTR_TX_EMPTY | XIIC_INTR_RX_FULL);
+    TimeCardI2cWrite16(
+        context, XIIC_DTR_OFFSET,
+        (USHORT)(XIIC_TX_DYN_START | addressWord));
+}
+
+static VOID
+TimeCardI2cCaptureStartTrace(PDEVICE_CONTEXT context)
+{
+    context->I2cLastStartTrace =
+        (ULONG)TimeCardI2cRead8(context, XIIC_CR_OFFSET) |
+        ((ULONG)TimeCardI2cRead8(context, XIIC_SR_OFFSET) << 8);
+    context->I2cLastStartEvents =
+        (ULONG)TimeCardI2cRead8(context, XIIC_TFO_OFFSET) << 16;
+}
+
+static VOID
+TimeCardI2cFinishStartTrace(PDEVICE_CONTEXT context, ULONG observedInterrupts)
+{
+    context->I2cLastStartTrace |=
+        ((ULONG)TimeCardI2cRead8(context, XIIC_CR_OFFSET) << 16) |
+        ((ULONG)TimeCardI2cRead8(context, XIIC_SR_OFFSET) << 24);
+    context->I2cLastStartEvents |=
+        (observedInterrupts & 0xffffu) |
+        ((ULONG)TimeCardI2cRead8(context, XIIC_TFO_OFFSET) << 24);
+}
+
 static NTSTATUS
 TimeCardI2cPrepareTransfer(PDEVICE_CONTEXT context)
 {
@@ -161,9 +205,9 @@ TimeCardI2cAddressValid(ULONG address)
 static ULONG
 TimeCardI2cKnownDeviceFlag(ULONG address)
 {
-    if (address == 0x50u)
+    if (address == TIMECARD_BOARD_EEPROM_ADDRESS)
         return TIMECARD_I2C_DEVICE_BOARD_EEPROM;
-    if (address == 0x58u)
+    if (address == TIMECARD_IDENTITY_ADDRESS)
         return TIMECARD_I2C_DEVICE_MAC_EEPROM;
     return 0;
 }
@@ -242,6 +286,8 @@ TimeCardI2cReadAttempt(PDEVICE_CONTEXT context,
     UCHAR controllerStatus = 0;
     NTSTATUS status;
 
+    context->I2cLastStartTrace = 0;
+    context->I2cLastStartEvents = 0;
     status = TimeCardI2cPrepareTransfer(context);
     if (!NT_SUCCESS(status))
         goto Exit;
@@ -252,11 +298,10 @@ TimeCardI2cReadAttempt(PDEVICE_CONTEXT context,
      * Keep the subaddress write as a separate dynamic-mode message.  Waiting
      * for TX empty here is important: it lets an address/data NACK surface
      * before the repeated START for the receive message is queued.
-     */
+    */
     if (request->SubaddressLength != 0) {
-        TimeCardI2cWrite16(
-            context, XIIC_DTR_OFFSET,
-            (USHORT)(XIIC_TX_DYN_START | (request->Address << 1)));
+        TimeCardI2cQueueDynamicStart(
+            context, (USHORT)(request->Address << 1));
         if (request->SubaddressLength == 2u) {
             TimeCardI2cWrite16(
                 context, XIIC_DTR_OFFSET,
@@ -264,6 +309,10 @@ TimeCardI2cReadAttempt(PDEVICE_CONTEXT context,
         }
         TimeCardI2cWrite16(context, XIIC_DTR_OFFSET,
                            (USHORT)(request->Subaddress & 0xffu));
+        TimeCardI2cCaptureStartTrace(context);
+        TimeCardI2cClearInterruptMask(
+            context, XIIC_INTR_TX_EMPTY | XIIC_INTR_TX_ERROR |
+                     XIIC_INTR_BNB);
 
         status = TimeCardI2cWaitTransmitPhase(
             context, &remainingPolls, &observedInterrupts,
@@ -275,19 +324,18 @@ TimeCardI2cReadAttempt(PDEVICE_CONTEXT context,
     /*
      * AXI IIC reports the master's expected final receive NACK through the
      * same TX_ERROR bit used for a slave address NACK.  Program a zero-based
-     * RX watermark, only drain after RX_FULL, then clear RX_FULL and the
-     * accompanying TX_ERROR together.  This mirrors the controller's
+     * RX watermark, drain whenever data is available, then clear RX_FULL and
+     * the accompanying TX_ERROR together.  This mirrors the controller's
      * dynamic receive state machine and removes the completion race.
     */
     TimeCardI2cSetReceiveWatermark(context, request->Length);
-    TimeCardI2cClearInterruptMask(
-        context, XIIC_INTR_RX_FULL | XIIC_INTR_TX_ERROR);
-    TimeCardI2cWrite16(
-        context, XIIC_DTR_OFFSET,
-        (USHORT)(XIIC_TX_DYN_START | (request->Address << 1) | 1u));
+    TimeCardI2cQueueDynamicStart(
+        context, (USHORT)((request->Address << 1) | 1u));
     TimeCardI2cWrite16(
         context, XIIC_DTR_OFFSET,
         (USHORT)(XIIC_TX_DYN_STOP | request->Length));
+    TimeCardI2cCaptureStartTrace(context);
+    TimeCardI2cClearInterruptMask(context, XIIC_INTR_BNB);
 
     status = STATUS_IO_TIMEOUT;
     while (remainingPolls != 0) {
@@ -301,19 +349,25 @@ TimeCardI2cReadAttempt(PDEVICE_CONTEXT context,
             break;
         }
 
-        if ((interrupts & XIIC_INTR_RX_FULL) != 0) {
+        if ((controllerStatus & XIIC_SR_RX_EMPTY) == 0) {
             TimeCardI2cDrainReceiveFifo(context, request, transfer,
                                         &copied);
-            TimeCardI2cClearInterruptMask(
-                context, XIIC_INTR_RX_FULL | XIIC_INTR_TX_ERROR);
+            if ((interrupts & XIIC_INTR_RX_FULL) != 0) {
+                TimeCardI2cClearInterruptMask(
+                    context, XIIC_INTR_RX_FULL | XIIC_INTR_TX_ERROR);
+            }
             controllerStatus = TimeCardI2cRead8(context, XIIC_SR_OFFSET);
         }
 
-        if (copied == request->Length &&
-            ((interrupts & XIIC_INTR_BNB) != 0 ||
-             (controllerStatus & XIIC_SR_BUS_BUSY) == 0)) {
-            status = STATUS_SUCCESS;
-            break;
+        if (copied == request->Length) {
+            TimeCardI2cClearInterruptMask(context, XIIC_INTR_TX_ERROR);
+            if ((interrupts & XIIC_INTR_BNB) != 0 ||
+                (controllerStatus & XIIC_SR_BUS_BUSY) == 0) {
+                status = STATUS_SUCCESS;
+                break;
+            }
+            KeStallExecutionProcessor(TIMECARD_I2C_POLL_US);
+            continue;
         }
 
         if ((interrupts & XIIC_INTR_TX_ERROR) != 0 &&
@@ -332,6 +386,7 @@ TimeCardI2cReadAttempt(PDEVICE_CONTEXT context,
     }
 
 Exit:
+    TimeCardI2cFinishStartTrace(context, observedInterrupts);
     transfer->Length = copied;
     transfer->ControllerStatus = controllerStatus;
     transfer->InterruptStatus = observedInterrupts;
@@ -383,20 +438,23 @@ TimeCardI2cWriteAttempt(PDEVICE_CONTEXT context, ULONG address,
     ULONG i;
     NTSTATUS status;
 
+    context->I2cLastStartTrace = 0;
+    context->I2cLastStartEvents = 0;
     status = TimeCardI2cPrepareTransfer(context);
     if (!NT_SUCCESS(status))
         goto Exit;
 
     TimeCardI2cArmPolling(context);
-    TimeCardI2cWrite16(
-        context, XIIC_DTR_OFFSET,
-        (USHORT)(XIIC_TX_DYN_START | (address << 1)));
+    TimeCardI2cQueueDynamicStart(context, (USHORT)(address << 1));
     for (i = 0; i < length; ++i) {
         USHORT value = data[i];
         if (i + 1u == length)
             value |= XIIC_TX_DYN_STOP;
         TimeCardI2cWrite16(context, XIIC_DTR_OFFSET, value);
     }
+    TimeCardI2cCaptureStartTrace(context);
+    TimeCardI2cClearInterruptMask(
+        context, XIIC_INTR_TX_EMPTY | XIIC_INTR_TX_ERROR | XIIC_INTR_BNB);
 
     status = STATUS_IO_TIMEOUT;
     while (remainingPolls != 0) {
@@ -422,6 +480,7 @@ TimeCardI2cWriteAttempt(PDEVICE_CONTEXT context, ULONG address,
     }
 
 Exit:
+    TimeCardI2cFinishStartTrace(context, observedInterrupts);
     *controllerStatus = currentStatus;
     *interruptStatus = observedInterrupts;
     (VOID)TimeCardI2cReset(context);
@@ -538,6 +597,8 @@ TimeCardI2cGetStatus(PDEVICE_CONTEXT context, TIMECARD_I2C_STATUS *status)
     status->TxFifoOccupancy = TimeCardI2cRead8(context, XIIC_TFO_OFFSET);
     status->RxFifoOccupancy = TimeCardI2cRead8(context, XIIC_RFO_OFFSET);
     status->KnownDeviceMask = context->I2cKnownDeviceMask;
+    status->Reserved[0] = context->I2cLastStartTrace;
+    status->Reserved[1] = context->I2cLastStartEvents;
     WdfWaitLockRelease(context->RegisterLock);
     return STATUS_SUCCESS;
 }
@@ -546,7 +607,8 @@ NTSTATUS
 TimeCardI2cProbe(PDEVICE_CONTEXT context, ULONG address,
                  TIMECARD_I2C_PROBE *probe)
 {
-    ULONG i;
+    ULONG remainingPolls = TIMECARD_I2C_DEFAULT_TIMEOUT_MS * 1000u /
+                           TIMECARD_I2C_POLL_US;
     ULONG interruptStatus = 0;
     ULONG flag;
     UCHAR controllerStatus = 0;
@@ -562,30 +624,36 @@ TimeCardI2cProbe(PDEVICE_CONTEXT context, ULONG address,
     probe->Address = address;
 
     WdfWaitLockAcquire(context->RegisterLock, NULL);
+    context->I2cLastStartTrace = 0;
+    context->I2cLastStartEvents = 0;
     status = TimeCardI2cPrepareTransfer(context);
     if (!NT_SUCCESS(status))
         goto Exit;
 
     TimeCardI2cArmPolling(context);
-    TimeCardI2cWrite16(
-        context, XIIC_DTR_OFFSET,
-        (USHORT)(XIIC_TX_DYN_START | XIIC_TX_DYN_STOP | (address << 1)));
+    TimeCardI2cQueueDynamicStart(
+        context, (USHORT)(XIIC_TX_DYN_STOP | (address << 1)));
+    TimeCardI2cCaptureStartTrace(context);
+    TimeCardI2cClearInterruptMask(
+        context, XIIC_INTR_TX_EMPTY | XIIC_INTR_TX_ERROR | XIIC_INTR_BNB);
 
     status = STATUS_IO_TIMEOUT;
-    for (i = 0; i < (TIMECARD_I2C_DEFAULT_TIMEOUT_MS * 1000u /
-                     TIMECARD_I2C_POLL_US); ++i) {
-        interruptStatus = TimeCardI2cRead32(context, XIIC_IISR_OFFSET);
+    while (remainingPolls != 0) {
+        ULONG interrupts = TimeCardI2cRead32(context, XIIC_IISR_OFFSET);
+
+        --remainingPolls;
+        interruptStatus |= interrupts;
         controllerStatus = TimeCardI2cRead8(context, XIIC_SR_OFFSET);
-        if ((interruptStatus & XIIC_INTR_ARB_LOST) != 0) {
+        if ((interrupts & XIIC_INTR_ARB_LOST) != 0) {
             status = STATUS_IO_DEVICE_ERROR;
             break;
         }
-        if ((interruptStatus & XIIC_INTR_TX_ERROR) != 0) {
+        if ((interrupts & XIIC_INTR_TX_ERROR) != 0) {
             probe->Present = 0;
             status = STATUS_SUCCESS;
             break;
         }
-        if ((interruptStatus & XIIC_INTR_BNB) != 0) {
+        if ((interrupts & XIIC_INTR_BNB) != 0) {
             probe->Present = 1;
             status = STATUS_SUCCESS;
             break;
@@ -593,6 +661,7 @@ TimeCardI2cProbe(PDEVICE_CONTEXT context, ULONG address,
         KeStallExecutionProcessor(TIMECARD_I2C_POLL_US);
     }
 
+    TimeCardI2cFinishStartTrace(context, interruptStatus);
     probe->ControllerStatus = controllerStatus;
     probe->InterruptStatus = interruptStatus;
     if (NT_SUCCESS(status)) {
@@ -701,9 +770,9 @@ TimeCardI2cMuxSet(PDEVICE_CONTEXT context,
 }
 
 static NTSTATUS
-TimeCardLedSelectLocked(PDEVICE_CONTEXT context, UCHAR *savedMask,
-                        BOOLEAN *changed, ULONG *controllerStatus,
-                        ULONG *interruptStatus)
+TimeCardSensorBranchSelectLocked(PDEVICE_CONTEXT context, UCHAR *savedMask,
+                                 BOOLEAN *changed, ULONG *controllerStatus,
+                                 ULONG *interruptStatus)
 {
     NTSTATUS status = TimeCardI2cMuxReadLocked(
         context, savedMask, controllerStatus, interruptStatus);
@@ -723,9 +792,10 @@ TimeCardLedSelectLocked(PDEVICE_CONTEXT context, UCHAR *savedMask,
 }
 
 static NTSTATUS
-TimeCardLedRestoreLocked(PDEVICE_CONTEXT context, UCHAR savedMask,
-                         BOOLEAN changed, NTSTATUS operationStatus,
-                         ULONG *controllerStatus, ULONG *interruptStatus)
+TimeCardSensorBranchRestoreLocked(PDEVICE_CONTEXT context, UCHAR savedMask,
+                                  BOOLEAN changed, NTSTATUS operationStatus,
+                                  ULONG *controllerStatus,
+                                  ULONG *interruptStatus)
 {
     NTSTATUS restoreStatus;
 
@@ -736,6 +806,63 @@ TimeCardLedRestoreLocked(PDEVICE_CONTEXT context, UCHAR savedMask,
     return NT_SUCCESS(operationStatus) ? restoreStatus : operationStatus;
 }
 
+static ULONG
+TimeCardLedFaultMask(const UCHAR *data)
+{
+    return ((ULONG)data[0] | ((ULONG)data[1] << 8) |
+            ((ULONG)(data[2] & 0x03u) << 16)) &
+           TIMECARD_LED_OUTPUT_MASK;
+}
+
+static NTSTATUS
+TimeCardLedDetectFaultsLocked(PDEVICE_CONTEXT context, ULONG *openMask,
+                              ULONG *shortMask, ULONG *controllerStatus,
+                              ULONG *interruptStatus)
+{
+    UCHAR writeBuffer[2];
+    UCHAR result[3];
+    NTSTATUS disableStatus;
+    NTSTATUS status;
+
+    *openMask = 0;
+    *shortMask = 0;
+
+    /* OSDE=11 selects open detection; results appear immediately. */
+    writeBuffer[0] = 0x71u;
+    writeBuffer[1] = 0x03u;
+    status = TimeCardI2cWriteLocked(
+        context, TIMECARD_LED_ADDRESS, writeBuffer, sizeof(writeBuffer),
+        controllerStatus, interruptStatus);
+    if (!NT_SUCCESS(status))
+        goto Disable;
+    status = TimeCardI2cReadBytesLocked(
+        context, TIMECARD_LED_ADDRESS, 1, 0x72u, result, sizeof(result),
+        controllerStatus, interruptStatus);
+    if (!NT_SUCCESS(status))
+        goto Disable;
+    *openMask = TimeCardLedFaultMask(result);
+
+    /* OSDE=10 selects short detection and replaces the result registers. */
+    writeBuffer[1] = 0x02u;
+    status = TimeCardI2cWriteLocked(
+        context, TIMECARD_LED_ADDRESS, writeBuffer, sizeof(writeBuffer),
+        controllerStatus, interruptStatus);
+    if (!NT_SUCCESS(status))
+        goto Disable;
+    status = TimeCardI2cReadBytesLocked(
+        context, TIMECARD_LED_ADDRESS, 1, 0x72u, result, sizeof(result),
+        controllerStatus, interruptStatus);
+    if (NT_SUCCESS(status))
+        *shortMask = TimeCardLedFaultMask(result);
+
+Disable:
+    writeBuffer[1] = 0x00u;
+    disableStatus = TimeCardI2cWriteLocked(
+        context, TIMECARD_LED_ADDRESS, writeBuffer, sizeof(writeBuffer),
+        controllerStatus, interruptStatus);
+    return NT_SUCCESS(status) ? disableStatus : status;
+}
+
 NTSTATUS
 TimeCardLedQuery(PDEVICE_CONTEXT context, ULONG led,
                  TIMECARD_LED_CONTROL *control)
@@ -744,10 +871,14 @@ TimeCardLedQuery(PDEVICE_CONTEXT context, ULONG led,
     BOOLEAN changed = FALSE;
     UCHAR deviceControl = 0;
     UCHAR globalCurrent = 0;
+    UCHAR spreadSpectrum = 0;
     UCHAR pwm[6];
     ULONG controllerStatus = 0;
     ULONG interruptStatus = 0;
+    ULONG openMask = 0;
+    ULONG shortMask = 0;
     NTSTATUS status;
+    NTSTATUS faultStatus;
 
     if (!context->HardwareReady || context->I2c == NULL)
         return STATUS_DEVICE_NOT_READY;
@@ -758,7 +889,7 @@ TimeCardLedQuery(PDEVICE_CONTEXT context, ULONG led,
     control->Size = sizeof(*control);
     control->Led = led;
     WdfWaitLockAcquire(context->RegisterLock, NULL);
-    status = TimeCardLedSelectLocked(
+    status = TimeCardSensorBranchSelectLocked(
         context, &savedMask, &changed,
         &controllerStatus, &interruptStatus);
     control->MuxChannelMask = savedMask;
@@ -766,30 +897,46 @@ TimeCardLedQuery(PDEVICE_CONTEXT context, ULONG led,
         goto Exit;
 
     status = TimeCardI2cReadBytesLocked(
-        context, 0x6eu, 1, 0x00u, &deviceControl, 1,
+        context, TIMECARD_LED_ADDRESS, 1, 0x00u, &deviceControl, 1,
         &controllerStatus, &interruptStatus);
     if (!NT_SUCCESS(status))
         goto Exit;
     status = TimeCardI2cReadBytesLocked(
-        context, 0x6eu, 1, 0x6eu, &globalCurrent, 1,
+        context, TIMECARD_LED_ADDRESS, 1, 0x6eu, &globalCurrent, 1,
         &controllerStatus, &interruptStatus);
     if (!NT_SUCCESS(status))
         goto Exit;
     status = TimeCardI2cReadBytesLocked(
-        context, 0x6eu, 1, 0x01u + led * 6u, pwm, sizeof(pwm),
+        context, TIMECARD_LED_ADDRESS, 1, 0x78u, &spreadSpectrum, 1,
+        &controllerStatus, &interruptStatus);
+    if (!NT_SUCCESS(status))
+        goto Exit;
+    status = TimeCardI2cReadBytesLocked(
+        context, TIMECARD_LED_ADDRESS, 1, 0x01u + led * 6u, pwm,
+        sizeof(pwm),
         &controllerStatus, &interruptStatus);
     if (NT_SUCCESS(status)) {
         control->Flags = TIMECARD_LED_FLAG_PRESENT;
         if ((deviceControl & 0x01u) != 0)
             control->Flags |= TIMECARD_LED_FLAG_ENABLED;
+        if ((spreadSpectrum & 0x60u) == 0x60u)
+            control->Flags |= TIMECARD_LED_FLAG_DC_TEST;
         control->Red = pwm[0];
         control->Green = pwm[2];
         control->Blue = pwm[4];
         control->GlobalCurrent = globalCurrent;
+        faultStatus = TimeCardLedDetectFaultsLocked(
+            context, &openMask, &shortMask,
+            &controllerStatus, &interruptStatus);
+        if (NT_SUCCESS(faultStatus)) {
+            control->Flags |= TIMECARD_LED_FLAG_FAULT_VALID;
+            control->OpenOutputMask = openMask;
+            control->ShortOutputMask = shortMask;
+        }
     }
 
 Exit:
-    status = TimeCardLedRestoreLocked(
+    status = TimeCardSensorBranchRestoreLocked(
         context, savedMask, changed, status,
         &controllerStatus, &interruptStatus);
     control->ControllerStatus = controllerStatus;
@@ -806,9 +953,14 @@ TimeCardLedSet(PDEVICE_CONTEXT context,
     UCHAR savedMask = 0;
     BOOLEAN changed = FALSE;
     UCHAR writeBuffer[7];
+    UCHAR resetProbe = 0;
+    BOOLEAN sdbHigh = FALSE;
     ULONG controllerStatus = 0;
     ULONG interruptStatus = 0;
+    ULONG openMask = 0;
+    ULONG shortMask = 0;
     NTSTATUS status;
+    NTSTATUS faultStatus;
 
     if (!context->HardwareReady || context->I2c == NULL)
         return STATUS_DEVICE_NOT_READY;
@@ -816,7 +968,9 @@ TimeCardLedSet(PDEVICE_CONTEXT context,
         request->Led >= TIMECARD_LED_COUNT ||
         request->Red > 0xffu || request->Green > 0xffu ||
         request->Blue > 0xffu || request->GlobalCurrent == 0 ||
-        request->GlobalCurrent > TIMECARD_LED_MAX_GLOBAL_CURRENT) {
+        request->GlobalCurrent > TIMECARD_LED_MAX_GLOBAL_CURRENT ||
+        (request->Flags & ~(TIMECARD_LED_FLAG_DC_TEST |
+                            TIMECARD_LED_FLAG_RESET_TEST)) != 0) {
         return STATUS_INVALID_PARAMETER;
     }
 
@@ -824,18 +978,62 @@ TimeCardLedSet(PDEVICE_CONTEXT context,
     response->Size = sizeof(*response);
     response->Led = request->Led;
     WdfWaitLockAcquire(context->RegisterLock, NULL);
-    status = TimeCardLedSelectLocked(
+    status = TimeCardSensorBranchSelectLocked(
         context, &savedMask, &changed,
         &controllerStatus, &interruptStatus);
     response->MuxChannelMask = savedMask;
     if (!NT_SUCCESS(status))
         goto Exit;
 
+    if ((request->Flags & TIMECARD_LED_FLAG_RESET_TEST) != 0) {
+        /*
+         * The reset command is honored only while SDB is physically high
+         * and SSD is set.  Use a benign non-default phase value as a probe,
+         * then restore normal operation before applying the requested LED.
+         */
+        writeBuffer[0] = 0x00u;
+        writeBuffer[1] = 0x01u;
+        status = TimeCardI2cWriteLocked(
+            context, TIMECARD_LED_ADDRESS, writeBuffer, 2,
+            &controllerStatus, &interruptStatus);
+        if (!NT_SUCCESS(status))
+            goto Exit;
+        writeBuffer[0] = 0x70u;
+        writeBuffer[1] = 0x05u;
+        status = TimeCardI2cWriteLocked(
+            context, TIMECARD_LED_ADDRESS, writeBuffer, 2,
+            &controllerStatus, &interruptStatus);
+        if (!NT_SUCCESS(status))
+            goto Exit;
+        status = TimeCardI2cReadBytesLocked(
+            context, TIMECARD_LED_ADDRESS, 1, 0x70u, &resetProbe, 1,
+            &controllerStatus, &interruptStatus);
+        if (!NT_SUCCESS(status) || resetProbe != 0x05u) {
+            if (NT_SUCCESS(status))
+                status = STATUS_DEVICE_DATA_ERROR;
+            goto Exit;
+        }
+        writeBuffer[0] = 0x7fu;
+        writeBuffer[1] = 0x00u;
+        status = TimeCardI2cWriteLocked(
+            context, TIMECARD_LED_ADDRESS, writeBuffer, 2,
+            &controllerStatus, &interruptStatus);
+        if (!NT_SUCCESS(status))
+            goto Exit;
+        status = TimeCardI2cReadBytesLocked(
+            context, TIMECARD_LED_ADDRESS, 1, 0x70u, &resetProbe, 1,
+            &controllerStatus, &interruptStatus);
+        if (!NT_SUCCESS(status))
+            goto Exit;
+        sdbHigh = resetProbe == 0x00u;
+
+    }
+
     /* 8-bit PWM mode, normal operation.  This yields flicker-free PWM. */
     writeBuffer[0] = 0x00u;
     writeBuffer[1] = 0x01u;
     status = TimeCardI2cWriteLocked(
-        context, 0x6eu, writeBuffer, 2,
+        context, TIMECARD_LED_ADDRESS, writeBuffer, 2,
         &controllerStatus, &interruptStatus);
     if (!NT_SUCCESS(status))
         goto Exit;
@@ -843,7 +1041,7 @@ TimeCardLedSet(PDEVICE_CONTEXT context,
     writeBuffer[0] = 0x6eu;
     writeBuffer[1] = (UCHAR)request->GlobalCurrent;
     status = TimeCardI2cWriteLocked(
-        context, 0x6eu, writeBuffer, 2,
+        context, TIMECARD_LED_ADDRESS, writeBuffer, 2,
         &controllerStatus, &interruptStatus);
     if (!NT_SUCCESS(status))
         goto Exit;
@@ -854,7 +1052,7 @@ TimeCardLedSet(PDEVICE_CONTEXT context,
     writeBuffer[2] = 0xffu;
     writeBuffer[3] = 0xffu;
     status = TimeCardI2cWriteLocked(
-        context, 0x6eu, writeBuffer, 4,
+        context, TIMECARD_LED_ADDRESS, writeBuffer, 4,
         &controllerStatus, &interruptStatus);
     if (!NT_SUCCESS(status))
         goto Exit;
@@ -867,7 +1065,7 @@ TimeCardLedSet(PDEVICE_CONTEXT context,
     writeBuffer[5] = (UCHAR)request->Blue;
     writeBuffer[6] = 0;
     status = TimeCardI2cWriteLocked(
-        context, 0x6eu, writeBuffer, sizeof(writeBuffer),
+        context, TIMECARD_LED_ADDRESS, writeBuffer, sizeof(writeBuffer),
         &controllerStatus, &interruptStatus);
     if (!NT_SUCCESS(status))
         goto Exit;
@@ -875,23 +1073,466 @@ TimeCardLedSet(PDEVICE_CONTEXT context,
     writeBuffer[0] = 0x49u;
     writeBuffer[1] = 0;
     status = TimeCardI2cWriteLocked(
-        context, 0x6eu, writeBuffer, 2,
+        context, TIMECARD_LED_ADDRESS, writeBuffer, 2,
+        &controllerStatus, &interruptStatus);
+    if (!NT_SUCCESS(status))
+        goto Exit;
+
+    /*
+     * DCPWM is a guarded electrical diagnostic.  0x60 forces OUT1-18 on
+     * independently of the PWM/update path; normal requests explicitly
+     * return the device to PWM mode.
+     */
+    writeBuffer[0] = 0x78u;
+    writeBuffer[1] =
+        (request->Flags & TIMECARD_LED_FLAG_DC_TEST) != 0 ? 0x60u : 0x00u;
+    status = TimeCardI2cWriteLocked(
+        context, TIMECARD_LED_ADDRESS, writeBuffer, 2,
         &controllerStatus, &interruptStatus);
     if (NT_SUCCESS(status)) {
         response->Flags = TIMECARD_LED_FLAG_PRESENT |
                           TIMECARD_LED_FLAG_ENABLED;
+        if ((request->Flags & TIMECARD_LED_FLAG_DC_TEST) != 0)
+            response->Flags |= TIMECARD_LED_FLAG_DC_TEST;
+        if ((request->Flags & TIMECARD_LED_FLAG_RESET_TEST) != 0)
+            response->Flags |= TIMECARD_LED_FLAG_RESET_TEST;
+        if (sdbHigh)
+            response->Flags |= TIMECARD_LED_FLAG_SDB_HIGH;
         response->Red = request->Red;
         response->Green = request->Green;
         response->Blue = request->Blue;
         response->GlobalCurrent = request->GlobalCurrent;
+        faultStatus = TimeCardLedDetectFaultsLocked(
+            context, &openMask, &shortMask,
+            &controllerStatus, &interruptStatus);
+        if (NT_SUCCESS(faultStatus)) {
+            response->Flags |= TIMECARD_LED_FLAG_FAULT_VALID;
+            response->OpenOutputMask = openMask;
+            response->ShortOutputMask = shortMask;
+        }
     }
 
 Exit:
-    status = TimeCardLedRestoreLocked(
+    status = TimeCardSensorBranchRestoreLocked(
         context, savedMask, changed, status,
         &controllerStatus, &interruptStatus);
     response->ControllerStatus = controllerStatus;
     response->InterruptStatus = interruptStatus;
+    WdfWaitLockRelease(context->RegisterLock);
+    return status;
+}
+
+static VOID
+TimeCardSensorDelayMilliseconds(ULONG milliseconds)
+{
+    LARGE_INTEGER interval;
+
+    interval.QuadPart = -((LONGLONG)milliseconds * 10000ll);
+    (VOID)KeDelayExecutionThread(KernelMode, FALSE, &interval);
+}
+
+static USHORT
+TimeCardSensorReadLe16(const UCHAR *data)
+{
+    return (USHORT)((USHORT)data[0] | ((USHORT)data[1] << 8));
+}
+
+static LONG
+TimeCardSensorReadLeSigned16(const UCHAR *data)
+{
+    return (LONG)(SHORT)TimeCardSensorReadLe16(data);
+}
+
+static USHORT
+TimeCardSensorReadBe16(const UCHAR *data)
+{
+    return (USHORT)(((USHORT)data[0] << 8) | (USHORT)data[1]);
+}
+
+static LONG
+TimeCardSensorReadBeSigned16(const UCHAR *data)
+{
+    return (LONG)(SHORT)TimeCardSensorReadBe16(data);
+}
+
+static VOID
+TimeCardBme280ReadLocked(PDEVICE_CONTEXT context,
+                         TIMECARD_BME280_READING *reading,
+                         ULONG *controllerStatus, ULONG *interruptStatus)
+{
+    UCHAR chipId = 0;
+    UCHAR statusByte = 0;
+    UCHAR calibration1[26];
+    UCHAR calibration2[7];
+    UCHAR data[8];
+    UCHAR writeBuffer[2];
+    ULONG index;
+    NTSTATUS status;
+
+    reading->Size = sizeof(*reading);
+    status = TimeCardI2cReadBytesLocked(
+        context, TIMECARD_SENSOR_BME280_ADDRESS, 1, 0xd0u,
+        &chipId, 1, controllerStatus, interruptStatus);
+    if (!NT_SUCCESS(status) || chipId != 0x60u)
+        return;
+    reading->ChipId = chipId;
+    reading->Flags = TIMECARD_SENSOR_FLAG_PRESENT;
+
+    status = TimeCardI2cReadBytesLocked(
+        context, TIMECARD_SENSOR_BME280_ADDRESS, 1, 0x88u,
+        calibration1, sizeof(calibration1),
+        controllerStatus, interruptStatus);
+    if (!NT_SUCCESS(status))
+        return;
+    status = TimeCardI2cReadBytesLocked(
+        context, TIMECARD_SENSOR_BME280_ADDRESS, 1, 0xe1u,
+        calibration2, sizeof(calibration2),
+        controllerStatus, interruptStatus);
+    if (!NT_SUCCESS(status))
+        return;
+
+    reading->DigT1 = TimeCardSensorReadLe16(&calibration1[0]);
+    reading->DigT2 = TimeCardSensorReadLeSigned16(&calibration1[2]);
+    reading->DigT3 = TimeCardSensorReadLeSigned16(&calibration1[4]);
+    reading->DigP1 = TimeCardSensorReadLe16(&calibration1[6]);
+    reading->DigP2 = TimeCardSensorReadLeSigned16(&calibration1[8]);
+    reading->DigP3 = TimeCardSensorReadLeSigned16(&calibration1[10]);
+    reading->DigP4 = TimeCardSensorReadLeSigned16(&calibration1[12]);
+    reading->DigP5 = TimeCardSensorReadLeSigned16(&calibration1[14]);
+    reading->DigP6 = TimeCardSensorReadLeSigned16(&calibration1[16]);
+    reading->DigP7 = TimeCardSensorReadLeSigned16(&calibration1[18]);
+    reading->DigP8 = TimeCardSensorReadLeSigned16(&calibration1[20]);
+    reading->DigP9 = TimeCardSensorReadLeSigned16(&calibration1[22]);
+    reading->DigH1 = calibration1[25];
+    reading->DigH2 = TimeCardSensorReadLeSigned16(&calibration2[0]);
+    reading->DigH3 = calibration2[2];
+    reading->DigH4 = (LONG)(CHAR)calibration2[3] * 16L +
+                     (LONG)(calibration2[4] & 0x0fu);
+    reading->DigH5 = (LONG)(CHAR)calibration2[5] * 16L +
+                     (LONG)(calibration2[4] >> 4);
+    reading->DigH6 = (LONG)(CHAR)calibration2[6];
+
+    /* Humidity x1, temperature x2, pressure x4, one forced sample. */
+    writeBuffer[0] = 0xf2u;
+    writeBuffer[1] = 0x01u;
+    status = TimeCardI2cWriteLocked(
+        context, TIMECARD_SENSOR_BME280_ADDRESS, writeBuffer, 2,
+        controllerStatus, interruptStatus);
+    if (!NT_SUCCESS(status))
+        return;
+    writeBuffer[0] = 0xf4u;
+    writeBuffer[1] = 0x4du;
+    status = TimeCardI2cWriteLocked(
+        context, TIMECARD_SENSOR_BME280_ADDRESS, writeBuffer, 2,
+        controllerStatus, interruptStatus);
+    if (!NT_SUCCESS(status))
+        return;
+    reading->Flags |= TIMECARD_SENSOR_FLAG_CONFIGURED;
+
+    for (index = 0; index < 20u; ++index) {
+        TimeCardSensorDelayMilliseconds(5u);
+        status = TimeCardI2cReadBytesLocked(
+            context, TIMECARD_SENSOR_BME280_ADDRESS, 1, 0xf3u,
+            &statusByte, 1, controllerStatus, interruptStatus);
+        if (!NT_SUCCESS(status))
+            return;
+        if ((statusByte & 0x08u) == 0)
+            break;
+    }
+    reading->Status = statusByte;
+    if ((statusByte & 0x08u) == 0)
+        reading->Flags |= TIMECARD_SENSOR_FLAG_CONVERSION_READY;
+
+    status = TimeCardI2cReadBytesLocked(
+        context, TIMECARD_SENSOR_BME280_ADDRESS, 1, 0xf7u,
+        data, sizeof(data), controllerStatus, interruptStatus);
+    if (!NT_SUCCESS(status))
+        return;
+    reading->RawPressure = ((ULONG)data[0] << 12) |
+                           ((ULONG)data[1] << 4) |
+                           ((ULONG)data[2] >> 4);
+    reading->RawTemperature = (LONG)(((ULONG)data[3] << 12) |
+                                    ((ULONG)data[4] << 4) |
+                                    ((ULONG)data[5] >> 4));
+    reading->RawHumidity = ((ULONG)data[6] << 8) | data[7];
+    if ((ULONG)reading->RawTemperature != 0x80000u &&
+        reading->RawPressure != 0x80000u) {
+        reading->Flags |= TIMECARD_SENSOR_FLAG_VALID;
+    }
+}
+
+static VOID
+TimeCardIna219ReadLocked(PDEVICE_CONTEXT context, ULONG address,
+                         TIMECARD_INA219_READING *reading,
+                         ULONG *controllerStatus, ULONG *interruptStatus)
+{
+    UCHAR data[2];
+    USHORT busRaw;
+    LONG shuntRaw;
+    LONGLONG power;
+    NTSTATUS status;
+
+    reading->Size = sizeof(*reading);
+    reading->Address = address;
+    status = TimeCardI2cReadBytesLocked(
+        context, address, 1, 0x00u, data, 2,
+        controllerStatus, interruptStatus);
+    if (!NT_SUCCESS(status))
+        return;
+    reading->Flags = TIMECARD_SENSOR_FLAG_PRESENT;
+    reading->Configuration = TimeCardSensorReadBe16(data);
+    status = TimeCardI2cReadBytesLocked(
+        context, address, 1, 0x01u, data, 2,
+        controllerStatus, interruptStatus);
+    if (!NT_SUCCESS(status))
+        return;
+    shuntRaw = TimeCardSensorReadBeSigned16(data);
+    status = TimeCardI2cReadBytesLocked(
+        context, address, 1, 0x02u, data, 2,
+        controllerStatus, interruptStatus);
+    if (!NT_SUCCESS(status))
+        return;
+    busRaw = TimeCardSensorReadBe16(data);
+
+    reading->RawBus = busRaw;
+    reading->BusMillivolts = ((ULONG)busRaw >> 3) * 4u;
+    reading->ShuntMicrovolts = shuntRaw * 10L;
+    /* Each shunt is 2 milliohms on Time Card V9: 10 uV/LSB = 5 mA/LSB. */
+    reading->CurrentMilliamps = shuntRaw * 5L;
+    power = ((LONGLONG)reading->BusMillivolts *
+             (LONGLONG)reading->CurrentMilliamps) / 1000ll;
+    if (power > 2147483647ll)
+        power = 2147483647ll;
+    else if (power < (-2147483647ll - 1ll))
+        power = (-2147483647ll - 1ll);
+    reading->PowerMilliwatts = (LONG)power;
+    reading->Flags |= TIMECARD_SENSOR_FLAG_VALID |
+                      TIMECARD_SENSOR_FLAG_CONFIGURED;
+    if ((busRaw & 0x0002u) != 0)
+        reading->Flags |= TIMECARD_SENSOR_FLAG_CONVERSION_READY;
+    if ((busRaw & 0x0001u) != 0)
+        reading->Flags |= TIMECARD_SENSOR_FLAG_OVERFLOW;
+}
+
+static VOID
+TimeCardBno055ReadLocked(PDEVICE_CONTEXT context,
+                         TIMECARD_BNO055_READING *reading,
+                         ULONG *controllerStatus, ULONG *interruptStatus)
+{
+    UCHAR chipId = 0;
+    UCHAR operationMode = 0;
+    UCHAR powerMode = 0;
+    UCHAR calibration = 0;
+    UCHAR selfTest = 0;
+    UCHAR clockStatus = 0;
+    UCHAR systemStatus = 0;
+    UCHAR systemError = 0;
+    UCHAR unitSelection = 0;
+    UCHAR systemTrigger = 0;
+    UCHAR data[45];
+    UCHAR writeBuffer[2];
+    NTSTATUS status;
+
+    reading->Size = sizeof(*reading);
+    status = TimeCardI2cReadBytesLocked(
+        context, TIMECARD_SENSOR_BNO055_ADDRESS, 1, 0x00u,
+        &chipId, 1, controllerStatus, interruptStatus);
+    if (!NT_SUCCESS(status) || chipId != 0xa0u)
+        return;
+    reading->ChipId = chipId;
+    reading->Flags = TIMECARD_SENSOR_FLAG_PRESENT;
+    status = TimeCardI2cReadBytesLocked(
+        context, TIMECARD_SENSOR_BNO055_ADDRESS, 1, 0x3du,
+        &operationMode, 1, controllerStatus, interruptStatus);
+    if (!NT_SUCCESS(status))
+        return;
+    operationMode &= 0x0fu;
+
+    if (operationMode != 0x0cu) {
+        if (operationMode != 0) {
+            writeBuffer[0] = 0x3du;
+            writeBuffer[1] = 0x00u;
+            status = TimeCardI2cWriteLocked(
+                context, TIMECARD_SENSOR_BNO055_ADDRESS,
+                writeBuffer, 2, controllerStatus, interruptStatus);
+            if (!NT_SUCCESS(status))
+                return;
+            TimeCardSensorDelayMilliseconds(20u);
+        }
+        /* Celsius, degrees, dps, m/s2, and Android orientation convention. */
+        writeBuffer[0] = 0x3bu;
+        writeBuffer[1] = 0x80u;
+        status = TimeCardI2cWriteLocked(
+            context, TIMECARD_SENSOR_BNO055_ADDRESS,
+            writeBuffer, 2, controllerStatus, interruptStatus);
+        if (!NT_SUCCESS(status))
+            return;
+        /* V9 fits Y1, so select the external 32.768 kHz timebase. */
+        writeBuffer[0] = 0x3fu;
+        writeBuffer[1] = 0x80u;
+        status = TimeCardI2cWriteLocked(
+            context, TIMECARD_SENSOR_BNO055_ADDRESS,
+            writeBuffer, 2, controllerStatus, interruptStatus);
+        if (!NT_SUCCESS(status))
+            return;
+        TimeCardSensorDelayMilliseconds(650u);
+        writeBuffer[0] = 0x3du;
+        writeBuffer[1] = 0x0cu;
+        status = TimeCardI2cWriteLocked(
+            context, TIMECARD_SENSOR_BNO055_ADDRESS,
+            writeBuffer, 2, controllerStatus, interruptStatus);
+        if (!NT_SUCCESS(status))
+            return;
+        TimeCardSensorDelayMilliseconds(10u);
+        operationMode = 0x0cu;
+    }
+
+    status = TimeCardI2cReadBytesLocked(
+        context, TIMECARD_SENSOR_BNO055_ADDRESS, 1, 0x08u,
+        data, sizeof(data), controllerStatus, interruptStatus);
+    if (!NT_SUCCESS(status))
+        return;
+    status = TimeCardI2cReadBytesLocked(
+        context, TIMECARD_SENSOR_BNO055_ADDRESS, 1, 0x35u,
+        &calibration, 1, controllerStatus, interruptStatus);
+    if (!NT_SUCCESS(status))
+        return;
+    status = TimeCardI2cReadBytesLocked(
+        context, TIMECARD_SENSOR_BNO055_ADDRESS, 1, 0x36u,
+        &selfTest, 1, controllerStatus, interruptStatus);
+    if (!NT_SUCCESS(status))
+        return;
+    status = TimeCardI2cReadBytesLocked(
+        context, TIMECARD_SENSOR_BNO055_ADDRESS, 1, 0x38u,
+        &clockStatus, 1, controllerStatus, interruptStatus);
+    if (!NT_SUCCESS(status))
+        return;
+    status = TimeCardI2cReadBytesLocked(
+        context, TIMECARD_SENSOR_BNO055_ADDRESS, 1, 0x39u,
+        &systemStatus, 1, controllerStatus, interruptStatus);
+    if (!NT_SUCCESS(status))
+        return;
+    status = TimeCardI2cReadBytesLocked(
+        context, TIMECARD_SENSOR_BNO055_ADDRESS, 1, 0x3au,
+        &systemError, 1, controllerStatus, interruptStatus);
+    if (!NT_SUCCESS(status))
+        return;
+    status = TimeCardI2cReadBytesLocked(
+        context, TIMECARD_SENSOR_BNO055_ADDRESS, 1, 0x3bu,
+        &unitSelection, 1, controllerStatus, interruptStatus);
+    if (!NT_SUCCESS(status))
+        return;
+    status = TimeCardI2cReadBytesLocked(
+        context, TIMECARD_SENSOR_BNO055_ADDRESS, 1, 0x3eu,
+        &powerMode, 1, controllerStatus, interruptStatus);
+    if (!NT_SUCCESS(status))
+        return;
+    status = TimeCardI2cReadBytesLocked(
+        context, TIMECARD_SENSOR_BNO055_ADDRESS, 1, 0x3fu,
+        &systemTrigger, 1, controllerStatus, interruptStatus);
+    if (!NT_SUCCESS(status))
+        return;
+
+    reading->Calibration = calibration;
+    reading->SelfTest = selfTest;
+    reading->SystemClockStatus = clockStatus;
+    reading->SystemStatus = systemStatus;
+    reading->SystemError = systemError;
+    reading->UnitSelection = unitSelection;
+    reading->OperationMode = operationMode;
+    reading->PowerMode = powerMode & 0x03u;
+    reading->AccelerationX = TimeCardSensorReadLeSigned16(&data[0]);
+    reading->AccelerationY = TimeCardSensorReadLeSigned16(&data[2]);
+    reading->AccelerationZ = TimeCardSensorReadLeSigned16(&data[4]);
+    reading->MagneticX = TimeCardSensorReadLeSigned16(&data[6]);
+    reading->MagneticY = TimeCardSensorReadLeSigned16(&data[8]);
+    reading->MagneticZ = TimeCardSensorReadLeSigned16(&data[10]);
+    reading->GyroscopeX = TimeCardSensorReadLeSigned16(&data[12]);
+    reading->GyroscopeY = TimeCardSensorReadLeSigned16(&data[14]);
+    reading->GyroscopeZ = TimeCardSensorReadLeSigned16(&data[16]);
+    reading->Heading = TimeCardSensorReadLeSigned16(&data[18]);
+    reading->Roll = TimeCardSensorReadLeSigned16(&data[20]);
+    reading->Pitch = TimeCardSensorReadLeSigned16(&data[22]);
+    reading->QuaternionW = TimeCardSensorReadLeSigned16(&data[24]);
+    reading->QuaternionX = TimeCardSensorReadLeSigned16(&data[26]);
+    reading->QuaternionY = TimeCardSensorReadLeSigned16(&data[28]);
+    reading->QuaternionZ = TimeCardSensorReadLeSigned16(&data[30]);
+    reading->LinearAccelerationX =
+        TimeCardSensorReadLeSigned16(&data[32]);
+    reading->LinearAccelerationY =
+        TimeCardSensorReadLeSigned16(&data[34]);
+    reading->LinearAccelerationZ =
+        TimeCardSensorReadLeSigned16(&data[36]);
+    reading->GravityX = TimeCardSensorReadLeSigned16(&data[38]);
+    reading->GravityY = TimeCardSensorReadLeSigned16(&data[40]);
+    reading->GravityZ = TimeCardSensorReadLeSigned16(&data[42]);
+    reading->Temperature = (LONG)(CHAR)data[44];
+    reading->Flags |= TIMECARD_SENSOR_FLAG_VALID |
+                      TIMECARD_SENSOR_FLAG_CONVERSION_READY;
+    if (reading->OperationMode == 0x0cu)
+        reading->Flags |= TIMECARD_SENSOR_FLAG_CONFIGURED;
+    if ((systemTrigger & 0x80u) != 0 &&
+        (reading->SystemClockStatus & 0x01u) == 0) {
+        reading->Flags |= TIMECARD_SENSOR_FLAG_EXTERNAL_CLOCK;
+    }
+}
+
+NTSTATUS
+TimeCardSensorQuery(PDEVICE_CONTEXT context,
+                    TIMECARD_SENSOR_TELEMETRY *telemetry)
+{
+    UCHAR savedMask = 0;
+    BOOLEAN changed = FALSE;
+    ULONG controllerStatus = 0;
+    ULONG interruptStatus = 0;
+    NTSTATUS status;
+
+    if (!context->HardwareReady || context->I2c == NULL)
+        return STATUS_DEVICE_NOT_READY;
+
+    RtlZeroMemory(telemetry, sizeof(*telemetry));
+    telemetry->Size = sizeof(*telemetry);
+    telemetry->Environment.Size = sizeof(telemetry->Environment);
+    telemetry->Rail12V.Size = sizeof(telemetry->Rail12V);
+    telemetry->Rail12V.Address = TIMECARD_SENSOR_INA219_12V_ADDRESS;
+    telemetry->Rail5V.Size = sizeof(telemetry->Rail5V);
+    telemetry->Rail5V.Address = TIMECARD_SENSOR_INA219_5V_ADDRESS;
+    telemetry->Rail3V3.Size = sizeof(telemetry->Rail3V3);
+    telemetry->Rail3V3.Address = TIMECARD_SENSOR_INA219_3V3_ADDRESS;
+    telemetry->Imu.Size = sizeof(telemetry->Imu);
+
+    WdfWaitLockAcquire(context->RegisterLock, NULL);
+    status = TimeCardSensorBranchSelectLocked(
+        context, &savedMask, &changed,
+        &controllerStatus, &interruptStatus);
+    telemetry->MuxChannelMask = savedMask;
+    if (!NT_SUCCESS(status))
+        goto Exit;
+    telemetry->Flags = TIMECARD_SENSOR_FLAG_PRESENT;
+
+    TimeCardBme280ReadLocked(
+        context, &telemetry->Environment,
+        &controllerStatus, &interruptStatus);
+    TimeCardIna219ReadLocked(
+        context, TIMECARD_SENSOR_INA219_12V_ADDRESS,
+        &telemetry->Rail12V, &controllerStatus, &interruptStatus);
+    TimeCardIna219ReadLocked(
+        context, TIMECARD_SENSOR_INA219_5V_ADDRESS,
+        &telemetry->Rail5V, &controllerStatus, &interruptStatus);
+    TimeCardIna219ReadLocked(
+        context, TIMECARD_SENSOR_INA219_3V3_ADDRESS,
+        &telemetry->Rail3V3, &controllerStatus, &interruptStatus);
+    TimeCardBno055ReadLocked(
+        context, &telemetry->Imu,
+        &controllerStatus, &interruptStatus);
+    telemetry->Flags |= TIMECARD_SENSOR_FLAG_VALID;
+
+Exit:
+    status = TimeCardSensorBranchRestoreLocked(
+        context, savedMask, changed, status,
+        &controllerStatus, &interruptStatus);
+    telemetry->ControllerStatus = controllerStatus;
+    telemetry->InterruptStatus = interruptStatus;
     WdfWaitLockRelease(context->RegisterLock);
     return status;
 }
@@ -911,9 +1552,9 @@ TimeCardGetIdentity(PDEVICE_CONTEXT context, TIMECARD_IDENTITY *identity)
 
     RtlZeroMemory(&request, sizeof(request));
     request.Size = sizeof(request);
-    request.Address = 0x58u;
+    request.Address = TIMECARD_IDENTITY_ADDRESS;
     request.SubaddressLength = 1u;
-    request.Subaddress = 0u;
+    request.Subaddress = TIMECARD_IDENTITY_EUI48_OFFSET;
     request.Length = TIMECARD_IDENTITY_SERIAL_LENGTH;
     request.TimeoutMilliseconds = TIMECARD_I2C_DEFAULT_TIMEOUT_MS;
 

--- a/DRV/Windows/include/timecard_ioctl.h
+++ b/DRV/Windows/include/timecard_ioctl.h
@@ -80,8 +80,10 @@
     TIMECARD_IOCTL(28, FILE_READ_ACCESS | FILE_WRITE_ACCESS)
 #define IOCTL_TIMECARD_LED_SET \
     TIMECARD_IOCTL(29, FILE_READ_ACCESS | FILE_WRITE_ACCESS)
+#define IOCTL_TIMECARD_SENSOR_QUERY \
+    TIMECARD_IOCTL(30, FILE_READ_ACCESS | FILE_WRITE_ACCESS)
 
-#define TIMECARD_ABI_VERSION 7u
+#define TIMECARD_ABI_VERSION 8u
 #define TIMECARD_LAYOUT_MSI  1u
 #define TIMECARD_LAYOUT_MSIX 2u
 #define TIMECARD_UART_COUNT  4u
@@ -115,6 +117,9 @@
 
 #define TIMECARD_I2C_DEVICE_BOARD_EEPROM (1u << 0)
 #define TIMECARD_I2C_DEVICE_MAC_EEPROM   (1u << 1)
+#define TIMECARD_BOARD_EEPROM_ADDRESS    0x50u
+#define TIMECARD_IDENTITY_ADDRESS        0x58u
+#define TIMECARD_IDENTITY_EUI48_OFFSET   0x9au
 
 /* U27, PCA9546A at 0x70.  More than one downstream branch may be selected. */
 #define TIMECARD_I2C_MUX_ADDRESS         0x70u
@@ -124,7 +129,11 @@
 #define TIMECARD_I2C_MUX_CHANNEL_DC      (1u << 3)
 #define TIMECARD_I2C_MUX_CHANNEL_MASK    0x0fu
 
-/* U6, IS32FL3207 at 0x6e on the sensor branch. */
+/*
+ * U6, IS32FL3207 on the sensor branch.  The schematic's 0x6e label is
+ * the 8-bit write address; Windows and the XIIC API use 7-bit address 0x37.
+ */
+#define TIMECARD_LED_ADDRESS 0x37u
 #define TIMECARD_LED_COUNT 6u
 #define TIMECARD_LED_GNSS1 0u
 #define TIMECARD_LED_GNSS2 1u
@@ -134,7 +143,26 @@
 #define TIMECARD_LED_IO4   5u
 #define TIMECARD_LED_FLAG_PRESENT (1u << 0)
 #define TIMECARD_LED_FLAG_ENABLED (1u << 1)
+#define TIMECARD_LED_FLAG_FAULT_VALID (1u << 2)
+#define TIMECARD_LED_FLAG_DC_TEST (1u << 3)
+#define TIMECARD_LED_FLAG_RESET_TEST (1u << 4)
+#define TIMECARD_LED_FLAG_SDB_HIGH (1u << 5)
 #define TIMECARD_LED_MAX_GLOBAL_CURRENT 128u
+#define TIMECARD_LED_OUTPUT_MASK ((1u << 18) - 1u)
+
+/* Dedicated telemetry devices on PCA9546A channel 1 (SENS_I2C). */
+#define TIMECARD_SENSOR_BME280_ADDRESS 0x76u
+#define TIMECARD_SENSOR_BNO055_ADDRESS 0x29u
+#define TIMECARD_SENSOR_INA219_12V_ADDRESS 0x40u
+#define TIMECARD_SENSOR_INA219_5V_ADDRESS 0x41u
+#define TIMECARD_SENSOR_INA219_3V3_ADDRESS 0x44u
+#define TIMECARD_SENSOR_INA219_SHUNT_MICROOHMS 2000u
+#define TIMECARD_SENSOR_FLAG_PRESENT          (1u << 0)
+#define TIMECARD_SENSOR_FLAG_VALID            (1u << 1)
+#define TIMECARD_SENSOR_FLAG_CONFIGURED       (1u << 2)
+#define TIMECARD_SENSOR_FLAG_CONVERSION_READY (1u << 3)
+#define TIMECARD_SENSOR_FLAG_OVERFLOW         (1u << 4)
+#define TIMECARD_SENSOR_FLAG_EXTERNAL_CLOCK   (1u << 5)
 
 #define TIMECARD_CLOCK_SOURCE_NONE 0x00u
 #define TIMECARD_CLOCK_SOURCE_TOD  0x01u
@@ -345,8 +373,102 @@ typedef struct _TIMECARD_LED_CONTROL {
     unsigned __int32 MuxChannelMask;
     unsigned __int32 ControllerStatus;
     unsigned __int32 InterruptStatus;
-    unsigned __int32 Reserved[2];
+    /* 18-bit OUT1..OUT18 diagnostic masks from registers 0x72..0x74. */
+    unsigned __int32 OpenOutputMask;
+    unsigned __int32 ShortOutputMask;
 } TIMECARD_LED_CONTROL;
+
+/* BME280 raw sample and factory calibration; all ABI fields are 32-bit. */
+typedef struct _TIMECARD_BME280_READING {
+    unsigned __int32 Size;
+    unsigned __int32 Flags;
+    unsigned __int32 ChipId;
+    unsigned __int32 Status;
+    signed __int32 RawTemperature;
+    unsigned __int32 RawPressure;
+    unsigned __int32 RawHumidity;
+    unsigned __int32 DigT1;
+    signed __int32 DigT2;
+    signed __int32 DigT3;
+    unsigned __int32 DigP1;
+    signed __int32 DigP2;
+    signed __int32 DigP3;
+    signed __int32 DigP4;
+    signed __int32 DigP5;
+    signed __int32 DigP6;
+    signed __int32 DigP7;
+    signed __int32 DigP8;
+    signed __int32 DigP9;
+    unsigned __int32 DigH1;
+    signed __int32 DigH2;
+    unsigned __int32 DigH3;
+    signed __int32 DigH4;
+    signed __int32 DigH5;
+    signed __int32 DigH6;
+} TIMECARD_BME280_READING;
+
+typedef struct _TIMECARD_INA219_READING {
+    unsigned __int32 Size;
+    unsigned __int32 Flags;
+    unsigned __int32 Address;
+    unsigned __int32 BusMillivolts;
+    signed __int32 ShuntMicrovolts;
+    signed __int32 CurrentMilliamps;
+    signed __int32 PowerMilliwatts;
+    unsigned __int32 Configuration;
+    unsigned __int32 RawBus;
+} TIMECARD_INA219_READING;
+
+/* BNO055 raw axes use the scale selected by UnitSelection. */
+typedef struct _TIMECARD_BNO055_READING {
+    unsigned __int32 Size;
+    unsigned __int32 Flags;
+    unsigned __int32 ChipId;
+    unsigned __int32 OperationMode;
+    unsigned __int32 PowerMode;
+    unsigned __int32 UnitSelection;
+    unsigned __int32 SystemStatus;
+    unsigned __int32 SystemError;
+    unsigned __int32 Calibration;
+    unsigned __int32 SelfTest;
+    unsigned __int32 SystemClockStatus;
+    signed __int32 Temperature;
+    signed __int32 AccelerationX;
+    signed __int32 AccelerationY;
+    signed __int32 AccelerationZ;
+    signed __int32 MagneticX;
+    signed __int32 MagneticY;
+    signed __int32 MagneticZ;
+    signed __int32 GyroscopeX;
+    signed __int32 GyroscopeY;
+    signed __int32 GyroscopeZ;
+    signed __int32 Heading;
+    signed __int32 Roll;
+    signed __int32 Pitch;
+    signed __int32 QuaternionW;
+    signed __int32 QuaternionX;
+    signed __int32 QuaternionY;
+    signed __int32 QuaternionZ;
+    signed __int32 LinearAccelerationX;
+    signed __int32 LinearAccelerationY;
+    signed __int32 LinearAccelerationZ;
+    signed __int32 GravityX;
+    signed __int32 GravityY;
+    signed __int32 GravityZ;
+} TIMECARD_BNO055_READING;
+
+typedef struct _TIMECARD_SENSOR_TELEMETRY {
+    unsigned __int32 Size;
+    unsigned __int32 Flags;
+    unsigned __int32 MuxChannelMask;
+    unsigned __int32 ControllerStatus;
+    unsigned __int32 InterruptStatus;
+    TIMECARD_BME280_READING Environment;
+    TIMECARD_INA219_READING Rail12V;
+    TIMECARD_INA219_READING Rail5V;
+    TIMECARD_INA219_READING Rail3V3;
+    TIMECARD_BNO055_READING Imu;
+} TIMECARD_SENSOR_TELEMETRY;
 
 typedef struct _TIMECARD_CLOCK_SOURCE_CONTROL {
     unsigned __int32 Size;

--- a/DRV/Windows/ioctl.c
+++ b/DRV/Windows/ioctl.c
@@ -363,6 +363,20 @@ TimeCardEvtIoDeviceControl(WDFQUEUE queue, WDFREQUEST request,
         break;
     }
 
+    case IOCTL_TIMECARD_SENSOR_QUERY:
+    {
+        TIMECARD_SENSOR_TELEMETRY *output;
+
+        status = TimeCardGetOutput(request, sizeof(*output),
+                                   (PVOID *)&output);
+        if (NT_SUCCESS(status)) {
+            status = TimeCardSensorQuery(context, output);
+            if (NT_SUCCESS(status))
+                information = sizeof(*output);
+        }
+        break;
+    }
+
     case IOCTL_TIMECARD_CLOCK_SOURCE_SET:
     {
         TIMECARD_CLOCK_SOURCE_CONTROL *input;

--- a/DRV/Windows/package-release.ps1
+++ b/DRV/Windows/package-release.ps1
@@ -20,7 +20,7 @@ if (-not $OutputDirectory.StartsWith(
     throw 'OutputDirectory must be a child of the Windows driver directory.'
 }
 $driverFolder = Join-Path $OutputDirectory 'TimeCard'
-$cabPath = Join-Path $OutputDirectory 'TimeCard-1.13-x64.cab'
+$cabPath = Join-Path $OutputDirectory 'TimeCard-1.15-x64.cab'
 
 function Find-MSBuild {
     $command = Get-Command msbuild.exe -ErrorAction SilentlyContinue
@@ -126,7 +126,7 @@ $ddfLines = @(
     '.Set CompressionType=MSZIP',
     '.Set Cabinet=on',
     '.Set Compress=on',
-    '.Set CabinetNameTemplate=TimeCard-1.13-x64.cab',
+    '.Set CabinetNameTemplate=TimeCard-1.15-x64.cab',
     ".Set DiskDirectoryTemplate=`"$OutputDirectory`"",
     ".Set RptFileName=`"$(Join-Path $OutputDirectory 'TimeCard.rpt')`"",
     ".Set InfFileName=`"$(Join-Path $OutputDirectory 'TimeCard-cab.inf')`"",

--- a/DRV/Windows/ptp.c
+++ b/DRV/Windows/ptp.c
@@ -122,7 +122,7 @@ TimeCardGetInfo(PDEVICE_CONTEXT context, TIMECARD_INFO *info)
 
     RtlZeroMemory(info, sizeof(*info));
     info->AbiVersion = TIMECARD_ABI_VERSION;
-    info->DriverVersion = 0x0001000cu;
+    info->DriverVersion = 0x0001000fu;
     info->Layout = context->Layout;
     info->InterruptMessages = context->InterruptMessages;
     info->BarLength = context->Bar0Length;

--- a/DRV/Windows/timecard.h
+++ b/DRV/Windows/timecard.h
@@ -144,6 +144,8 @@ typedef struct _DEVICE_CONTEXT {
     ULONG NmeaOutOffset;
     ULONG I2cOffset;
     ULONG I2cKnownDeviceMask;
+    ULONG I2cLastStartTrace;
+    ULONG I2cLastStartEvents;
     ULONG FlashOffset;
     ULONG FlashJedecId;
     ULONG FlashCapacity;
@@ -246,6 +248,8 @@ NTSTATUS TimeCardLedQuery(PDEVICE_CONTEXT context,
 NTSTATUS TimeCardLedSet(PDEVICE_CONTEXT context,
                         const TIMECARD_LED_CONTROL *request,
                         TIMECARD_LED_CONTROL *response);
+NTSTATUS TimeCardSensorQuery(PDEVICE_CONTEXT context,
+                             TIMECARD_SENSOR_TELEMETRY *telemetry);
 NTSTATUS TimeCardGetIdentity(PDEVICE_CONTEXT context,
                              TIMECARD_IDENTITY *identity);
 

--- a/DRV/Windows/timecard.inf
+++ b/DRV/Windows/timecard.inf
@@ -7,7 +7,7 @@ Class       = TimeCard
 ClassGuid   = {B5415088-5EE1-4D3A-8519-C3487370E0BF}
 Provider    = %ProviderName%
 CatalogFile = timecard.cat
-DriverVer   = 07/14/2026,1.13.0.0
+DriverVer   = 07/15/2026,1.15.1.0
 PnpLockdown = 1
 
 [ClassInstall32]


### PR DESCRIPTION
## What changed

- expands the Windows Control Center with polished workspaces for UART, SMA generators and frequency counters, I2C routing and subsystem LEDs, FPGA flash, GNSS sky view, and board sensor/IMU telemetry
- adds guarded PCA9546A, IS32FL3207, BME280, INA219, and BNO055 driver operations while preserving the caller's mux route
- adds live PHC offset and sampling graphs, including 200-second rolling offset histories
- improves card identity, secondary GNSS presence, NMEA configuration navigation, administrator elevation, splash/logo presentation, and release packaging
- updates the Windows driver and Control Center to release 1.15.1 / ABI 8

## Why

The Windows application previously exposed only part of the Time Card hardware and relied on legacy I2C behavior. This change makes the application a complete schematic-aware control and diagnostics surface for the current card.

## Root causes addressed

- the legacy AXI IIC dynamic-start ordering could complete against a stale bus state and surface as Win32 CRC/data errors
- the IS32FL3207 schematic label is an 8-bit write address while the controller expects the 7-bit address
- onboard BME280 and BNO055 devices power up unconfigured, so raw reads alone produced sleeping or zero-output sensors
- mux-dependent devices needed guarded branch selection with exact route restoration

## Validation

- `build.cmd test` — test-signed x64 driver, Inf2Cat, and signability checks passed with no warnings or errors
- `build-gui.cmd release` — Release Control Center build passed
- installed and verified driver 1.15.1 / ABI 8 on a connected Time Card with the full child-device hierarchy present
- live-tested compensated BME280 readings, all three INA219 rails, BNO055 NDOF fusion/external clock, PCA9546A routing, and the rendered Sensors & IMU workspace
- generated the unsigned `TimeCard-1.15-x64.cab` attestation package
