### PR TITLE
Recover stalled BNO08x IMU streams

### DIFF
--- a/DRV/Windows/PRODUCTION_SIGNING.md
+++ b/DRV/Windows/PRODUCTION_SIGNING.md
@@ -15,7 +15,7 @@ From PowerShell in this directory:
 This performs a clean unsigned x64 Release build and creates:
 
 - `submission\TimeCard\` - the driver folder to add to an HLK project.
-- `submission\TimeCard-1.23-x64.cab` - a CAB with the required driver,
+- `submission\TimeCard-1.24-x64.cab` - a CAB with the required driver,
   INF, catalog, subsystem icons, and PDB in a non-root `TimeCard` folder.
 
 The CAB is intentionally unsigned unless a registered code-signing
@@ -55,7 +55,7 @@ Use this route for a retail driver and for Windows Update eligibility:
 Microsoft currently limits attestation signing to supported testing
 scenarios; attestation-signed retail drivers are not published to Windows
 Update. When the Partner Center account is eligible for such a scenario,
-upload the certificate-signed `TimeCard-1.23-x64.cab`, leave both test-signing
+upload the certificate-signed `TimeCard-1.24-x64.cab`, leave both test-signing
 options disabled, and download the Microsoft-signed result.
 
 ## Verify the returned package

--- a/DRV/Windows/README.md
+++ b/DRV/Windows/README.md
@@ -54,7 +54,7 @@ controller from starting.
 
 ## Hardware compatibility
 
-Driver 1.23 / ABI 8 selects the same three board profiles and resource maps as
+Driver 1.24 / ABI 8 selects the same three board profiles and resource maps as
 the Linux `ptp_ocp` driver. Meta/Facebook and Celestica share the rev1 and rev2
 maps. Older PCI revision 00 gateware uses the rev1 MSI map and may expose 2 or
 32 interrupt messages. Current PCI revision 02 LitePCIe gateware exposes 64
@@ -139,7 +139,7 @@ The application can restart itself with administrator rights when the driver
 requires elevation. See [TimeCardControlCenter/README.md](TimeCardControlCenter/README.md)
 for complete build, UART, and capability details.
 
-Driver **1.23 / ABI 8** is required for the complete feature set shown below.
+Driver **1.24 / ABI 8** is required for the complete feature set shown below.
 
 ![Control Center overview](assets/timecard-control-center.png)
 
@@ -330,6 +330,12 @@ BNO080/BNO08x alternative at `0x4a`/`0x4b`. BNO08x SHTP reports are configured
 and decoded into the existing ABI's fused orientation, acceleration, linear
 acceleration, gravity, angular-velocity, and magnetic-field readings; BNO055
 cards continue to use the NDOF register path.
+
+Driver 1.24 adds a BNO08x liveness watchdog. If the IMU resets internally or
+its finite SH-2 report queue stalls while the mux branch is idle, the next
+telemetry request drains stale packets, re-establishes all six feature
+subscriptions, resets the SHTP control-channel sequence, and retries the
+sample without requiring a driver reload or reboot.
 
 The schematic's U26 TMUX1072 is not software-controlled. Its `MACSER` select
 comes only from the physical DIP switch: 0 routes MAC I2C and 1 routes the FPGA

--- a/DRV/Windows/TimeCardControlCenter/Properties/AssemblyInfo.cs
+++ b/DRV/Windows/TimeCardControlCenter/Properties/AssemblyInfo.cs
@@ -9,5 +9,5 @@ using System.Windows;
 [assembly: AssemblyCopyright("Copyright © Open Compute Project contributors")]
 [assembly: ComVisible(false)]
 [assembly: ThemeInfo(ResourceDictionaryLocation.None, ResourceDictionaryLocation.SourceAssembly)]
-[assembly: AssemblyVersion("1.23.0.0")]
-[assembly: AssemblyFileVersion("1.23.0.0")]
+[assembly: AssemblyVersion("1.24.0.0")]
+[assembly: AssemblyFileVersion("1.24.0.0")]

--- a/DRV/Windows/TimeCardControlCenter/README.md
+++ b/DRV/Windows/TimeCardControlCenter/README.md
@@ -4,7 +4,7 @@ The Time Card Control Center is a dependency-free Windows desktop dashboard
 for the OCP Time Card driver. It uses the public versioned IOCTL ABI directly;
 it does not shell out to `timecardctl` or scrape Device Manager.
 
-Driver 1.23 recognizes the Meta/Facebook, Celestica, and Orolia/Safran ART
+Driver 1.24 recognizes the Meta/Facebook, Celestica, and Orolia/Safran ART
 profiles from the Linux driver. The application labels the ART layout,
 suppresses unavailable ToD/GNSS-summary fields, uses the ART-specific SMA
 function menu, and prevents the MAC-SA53 panel from sending commands to the
@@ -483,7 +483,7 @@ shown in the workspace, and automatic mapping marks affected packages as
 
 ## Sensors and IMU
 
-Driver 1.23 / ABI 8 and the dedicated Sensors & IMU workspace read every
+Driver 1.24 / ABI 8 and the dedicated Sensors & IMU workspace read every
 populated monitor on the auto-detected sensor branch. BME280 and BMP280 are
 auto-detected at `0x76` or `0x77`; BME280 cards show factory-compensated
 temperature, relative humidity, pressure, and calculated dew point, while a
@@ -503,6 +503,10 @@ acceleration, gravity, angular velocity, and magnetic field. BNO055 also
 reports temperature. Sampling is live at one hertz while the workspace is
 visible. Each query temporarily selects the discovered PCA9546A branch,
 reports missing devices separately, and restores the previous mux selection.
+For BNO08x cards, driver 1.24 also detects a silent or reset SH-2 stream,
+re-establishes the six feature subscriptions, and retries the sample
+automatically. The workspace can therefore recover from `INITIALIZING` without
+restarting the application, reloading the driver, or rebooting Windows.
 
 ## FPGA SPI flash
 

--- a/DRV/Windows/i2c.c
+++ b/DRV/Windows/i2c.c
@@ -2037,15 +2037,44 @@ TimeCardBno08xParseReports(TIMECARD_BNO055_READING *reading,
         reading->Flags |= TIMECARD_SENSOR_FLAG_VALID;
 }
 
+static BOOLEAN
+TimeCardBno08xDrainReportsLocked(PDEVICE_CONTEXT context, ULONG address,
+                                 TIMECARD_BNO055_READING *reading,
+                                 ULONG *controllerStatus,
+                                 ULONG *interruptStatus)
+{
+    UCHAR packet[TIMECARD_I2C_MAX_TRANSFER];
+    ULONG packetLength;
+    ULONG i;
+    NTSTATUS status;
+
+    for (i = 0; i < 32u; ++i) {
+        status = TimeCardBno08xReadTransferLocked(
+            context, address, packet, &packetLength,
+            controllerStatus, interruptStatus);
+        if (!NT_SUCCESS(status))
+            break;
+        if (packetLength >= 4u &&
+            packet[2] == TIMECARD_BNO08X_CHANNEL_REPORTS) {
+            /*
+             * I2C first returns a four-byte header.  The required second read
+             * repeats that header with SHTP's continuation bit set and carries
+             * the complete payload, so continuation is expected here.
+             */
+            TimeCardBno08xParseReports(
+                reading, &packet[4], packetLength - 4u);
+        }
+    }
+
+    return (reading->Flags & TIMECARD_SENSOR_FLAG_VALID) != 0;
+}
+
 static VOID
 TimeCardBno08xReadLocked(PDEVICE_CONTEXT context,
                          TIMECARD_BNO055_READING *reading,
                          ULONG *controllerStatus, ULONG *interruptStatus)
 {
-    UCHAR packet[TIMECARD_I2C_MAX_TRANSFER];
     ULONG address = 0;
-    ULONG packetLength;
-    ULONG i;
     NTSTATUS status;
 
     reading->Size = sizeof(*reading);
@@ -2069,22 +2098,41 @@ TimeCardBno08xReadLocked(PDEVICE_CONTEXT context,
     }
     reading->Flags |= TIMECARD_SENSOR_FLAG_CONFIGURED;
 
-    for (i = 0; i < 32u; ++i) {
-        status = TimeCardBno08xReadTransferLocked(
-            context, address, packet, &packetLength,
-            controllerStatus, interruptStatus);
-        if (!NT_SUCCESS(status))
-            break;
-        if (packetLength >= 4u &&
-            packet[2] == TIMECARD_BNO08X_CHANNEL_REPORTS) {
-            /*
-             * I2C first returns a four-byte header.  The required second read
-             * repeats that header with SHTP's continuation bit set and carries
-             * the complete payload, so continuation is expected here.
-             */
-            TimeCardBno08xParseReports(
-                reading, &packet[4], packetLength - 4u);
-        }
+    if (TimeCardBno08xDrainReportsLocked(
+            context, address, reading,
+            controllerStatus, interruptStatus))
+        return;
+
+    /*
+     * A BNO08x can reset internally or stop delivering reports after its
+     * finite output queue fills while the mux branch is not being sampled.
+     * The sensor still acknowledges at 0x4a/0x4b in that state, so presence
+     * alone is not a sufficient liveness check.  Re-establish all SH-2
+     * feature subscriptions and retry immediately instead of leaving the
+     * Control Center permanently stuck at INITIALIZING until a driver reload.
+     *
+     * Reset the host control-channel sequence as well: after an IMU reset the
+     * sensor's SHTP receiver has also returned to its initial sequence state.
+     */
+    context->I2cBno08xConfigured = 0;
+    context->I2cBno08xSequence = 0;
+    reading->Flags &= ~TIMECARD_SENSOR_FLAG_CONFIGURED;
+    TimeCardSensorDelayMilliseconds(10u);
+    status = TimeCardBno08xConfigureLocked(
+        context, address, controllerStatus, interruptStatus);
+    if (!NT_SUCCESS(status))
+        return;
+
+    reading->Flags |= TIMECARD_SENSOR_FLAG_CONFIGURED;
+    if (!TimeCardBno08xDrainReportsLocked(
+            context, address, reading,
+            controllerStatus, interruptStatus)) {
+        /*
+         * Keep the watchdog armed.  A sensor that is still completing a boot
+         * will be configured and sampled again on the next telemetry query.
+         */
+        context->I2cBno08xConfigured = 0;
+        reading->Flags &= ~TIMECARD_SENSOR_FLAG_CONFIGURED;
     }
 }
 

--- a/DRV/Windows/package-release.ps1
+++ b/DRV/Windows/package-release.ps1
@@ -20,7 +20,7 @@ if (-not $OutputDirectory.StartsWith(
     throw 'OutputDirectory must be a child of the Windows driver directory.'
 }
 $driverFolder = Join-Path $OutputDirectory 'TimeCard'
-$cabPath = Join-Path $OutputDirectory 'TimeCard-1.23-x64.cab'
+$cabPath = Join-Path $OutputDirectory 'TimeCard-1.24-x64.cab'
 
 function Find-MSBuild {
     $command = Get-Command msbuild.exe -ErrorAction SilentlyContinue
@@ -126,7 +126,7 @@ $ddfLines = @(
     '.Set CompressionType=MSZIP',
     '.Set Cabinet=on',
     '.Set Compress=on',
-    '.Set CabinetNameTemplate=TimeCard-1.23-x64.cab',
+    '.Set CabinetNameTemplate=TimeCard-1.24-x64.cab',
     ".Set DiskDirectoryTemplate=`"$OutputDirectory`"",
     ".Set RptFileName=`"$(Join-Path $OutputDirectory 'TimeCard.rpt')`"",
     ".Set InfFileName=`"$(Join-Path $OutputDirectory 'TimeCard-cab.inf')`"",

--- a/DRV/Windows/ptp.c
+++ b/DRV/Windows/ptp.c
@@ -121,7 +121,7 @@ TimeCardGetInfo(PDEVICE_CONTEXT context, TIMECARD_INFO *info)
 
     RtlZeroMemory(info, sizeof(*info));
     info->AbiVersion = TIMECARD_ABI_VERSION;
-    info->DriverVersion = 0x00010017u;
+    info->DriverVersion = 0x00010018u;
     info->Layout = context->Layout;
     info->InterruptMessages = context->InterruptMessages;
     info->BarLength = context->Bar0Length;

--- a/DRV/Windows/timecard.inf
+++ b/DRV/Windows/timecard.inf
@@ -7,7 +7,7 @@ Class       = TimeCard
 ClassGuid   = {B5415088-5EE1-4D3A-8519-C3487370E0BF}
 Provider    = %ProviderName%
 CatalogFile = timecard.cat
-DriverVer   = 07/22/2026,1.23.0.0
+DriverVer   = 07/23/2026,1.24.0.0
 PnpLockdown = 1
 
 [ClassInstall32]

--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ Using a Calnex Sentinel device are comparing various things. Here we are compari
   [`DRV/Windows`](DRV/Windows)
 * CAD files for the custom PCIe bracket 
 
-The Windows package currently ships driver **1.23 / ABI 8** and a native
+The Windows package currently ships driver **1.24 / ABI 8** and a native
 Control Center that brings the complete Time Card into one application:
 
 * Precision-clock telemetry, detail-focused rolling offset graphs, clock-source


### PR DESCRIPTION
## Summary

- add a BNO08x liveness watchdog to the Windows I2C sensor path
- drain queued SHTP packets, reset the control-channel sequence, restore all six SH-2 feature subscriptions, and retry within the same telemetry request
- bump the Windows driver and Control Center package metadata to 1.24 / ABI 8
- update package filenames and Windows documentation for the recovery behavior

## Root cause and impact

The BNO08x could remain present at `0x4A` while its SH-2 report stream stopped after an internal reset or output-queue stall. The driver cached the configured state indefinitely, so the Control Center remained at `INITIALIZING` until the driver was reloaded. Driver 1.24 treats an empty report drain as a liveness failure and automatically re-establishes the stream, allowing telemetry to recover without a reboot.

## Validation

- Windows WDK test-signed build completed with zero errors and zero warnings
- Control Center Release build passed
- board-profile, Control Center product, and GNSS/NMEA decoder tests passed
- installed locally as `oem256.inf`; active driver reports 1.24 / ABI 8
- official `verify.ps1 -ExpectHierarchy -TestSensors` passed
- eight consecutive live BNO08x reads returned valid acceleration, gravity, gyroscope, magnetic-field, linear-acceleration, and quaternion telemetry
- Control Center remained responsive and displayed `SH2 LIVE`
