### PR TITLE
Add Orolia ART Windows compatibility

### DIFF
--- a/DRV/Windows/PRODUCTION_SIGNING.md
+++ b/DRV/Windows/PRODUCTION_SIGNING.md
@@ -15,7 +15,7 @@ From PowerShell in this directory:
 This performs a clean unsigned x64 Release build and creates:
 
 - `submission\TimeCard\` - the driver folder to add to an HLK project.
-- `submission\TimeCard-1.25-x64.cab` - a CAB with the required driver,
+- `submission\TimeCard-1.29-x64.cab` - a CAB with the required driver,
   INF, catalog, subsystem icons, and PDB in a non-root `TimeCard` folder.
 
 The CAB is intentionally unsigned unless a registered code-signing
@@ -55,7 +55,7 @@ Use this route for a retail driver and for Windows Update eligibility:
 Microsoft currently limits attestation signing to supported testing
 scenarios; attestation-signed retail drivers are not published to Windows
 Update. When the Partner Center account is eligible for such a scenario,
-upload the certificate-signed `TimeCard-1.25-x64.cab`, leave both test-signing
+upload the certificate-signed `TimeCard-1.29-x64.cab`, leave both test-signing
 options disabled, and download the Microsoft-signed result.
 
 ## Verify the returned package

--- a/DRV/Windows/README.md
+++ b/DRV/Windows/README.md
@@ -13,6 +13,8 @@ applications use the versioned IOCTL ABI through `timecardctl.exe`.
 ## Features
 
 - PHC read, set, and system-bracketed cross-timestamp operations.
+- Direct Orolia/Safran ART mRO-50 FPGA-bridge telemetry and guarded fine,
+  coarse, and nonvolatile coarse-adjustment controls.
 - FPGA, TOD, synchronization, selectable clock source, UTC/leap, satellite,
   and GNSS status reporting.
 - Polled access to the GNSS, GNSS2, atomic-clock, and NMEA 16550 UARTs, plus
@@ -54,7 +56,7 @@ controller from starting.
 
 ## Hardware compatibility
 
-Driver 1.25 / ABI 8 selects the same three board profiles and resource maps as
+Driver 1.29 / ABI 9 selects the same three board profiles and resource maps as
 the Linux `ptp_ocp` driver. Meta/Facebook and Celestica share the rev1 and rev2
 maps. Older PCI revision 00 gateware uses the rev1 MSI map and may expose 2 or
 32 interrupt messages. Current PCI revision 02 LitePCIe gateware exposes 64
@@ -64,21 +66,36 @@ known Meta/Celestica map before any register access when firmware does not
 report a useful revision.
 
 The Orolia/Safran ART profile uses its Linux-defined fixed map: PHC at
-`0x01000000`, primary GNSS UART at `0x00161000`, atomic-clock UART at
-`0x00190000`, SMA routing at `0x003c0000`, OpenCores I2C at `0x00350000`, and
-Altera SPI at `0x00310000`. Its protected FPGA image begins at `0x01000000` in
-SPI-NOR. The ART profile exposes only the PHC, primary GNSS, atomic-clock, SMA,
-I2C, and flash child nodes because Linux does not map the Meta-specific ToD,
-secondary GNSS, NMEA generator/UART, signal generators, frequency counters, or
-PTM blocks on that card. Missing functions return a supported “not available”
-result rather than aliasing another register window.
+`0x01000000`, primary GNSS UART at `0x00161000`, mRO-50 UART at `0x00190000`,
+board configuration at `0x00210000`, Altera SPI at `0x00310000`, the direct
+mRO-50 bridge at `0x00340000`, OpenCores I2C at `0x00350000`, and fixed SMA
+routing at `0x003c0000`. The PCI parser accepts both the leading `PCI\VEN_`
+field and ampersand-delimited fields, so `VEN_1AD7&DEV_A000` can no longer
+silently fall back to the Meta register map.
 
-ART uses an OpenCores I2C controller and a 24c08 EEPROM. The serial Linux reads
-at absolute EEPROM offset `0x263` is accessed through slave block `0x52`,
-subaddress `0x63`. Its SMA menu is restricted to the ART gateware's PPS1 and
-10 MHz inputs plus atomic-clock, GNSS, and 10 MHz outputs. Its UART 2 device is
-an mRO-50 at 9,600 baud; the Control Center disables MAC-SA53 commands on this
-profile and leaves the generic UART console available.
+The tested ART FPGA v0.0.9 exposes the PHC, direct mRO-50 bridge, primary GNSS
+UART, fixed SMA map, OpenCores I2C/24c08 EEPROM, timestamp inputs, and Altera
+SPI-NOR. It does not implement the Meta-specific ToD/NMEA engine, secondary
+GNSS, signal generators, frequency counters, PTM, PCA9546A sensor branches, or
+IS32FL3207 LEDs. Those capabilities are reported as not implemented or not
+fitted instead of producing failed sensor and LED operations.
+
+The mRO-50 bridge reports enable/lock, raw temperature, and fine/coarse
+adjustment words without depending on the optional 16550 serial bridge. The
+temperature is intentionally displayed as a raw word because its physical
+scale is not published for this gateware image. The mRO serial port is still
+configured for 9,600 baud when present.
+
+Linux assigns no fixed baud to the ART primary-GNSS UART. Driver 1.29 likewise
+preserves its gateware divisor during device start; an operator may still set
+an explicit baud from the UART workspace or `timecardctl uart-config`.
+
+ART's 24c08 responds through bank addresses `0x50` through `0x57`. On the
+tested card it contains two copies of the mRO disciplining configuration,
+beginning with `oscillator=mRO50`, rather than the legacy serial layout at
+absolute offset `0x263`. Driver 1.29 detects that layout and returns an invalid
+identity instead of turning configuration text into a false serial number.
+Its four fixed SMA routes remain read-only in the Control Center.
 
 Subsystem availability still depends on the FPGA image and populated board
 options. Missing optional resources never prevent the controller and PHC from
@@ -139,7 +156,7 @@ The application can restart itself with administrator rights when the driver
 requires elevation. See [TimeCardControlCenter/README.md](TimeCardControlCenter/README.md)
 for complete build, UART, and capability details.
 
-Driver **1.25 / ABI 8** is required for the complete feature set shown below.
+Driver **1.29 / ABI 9** is required for the complete feature set shown below.
 
 ![Control Center overview](assets/timecard-control-center.png)
 
@@ -215,6 +232,12 @@ timecardctl nmea-set on 9600 normal
 timecardctl uart-read 3 256 1000
 timecardctl uart-config 0 115200
 timecardctl uart-read 0 256 1000
+timecardctl uart-observe 0 25
+timecardctl mro-status
+timecardctl mro-fine 2344
+timecardctl mro-coarse 4186399
+timecardctl mro-save-coarse
+timecardctl flash-status
 timecardctl hierarchy-status
 timecardctl hierarchy-enable
 timecardctl hierarchy-persist
@@ -249,6 +272,11 @@ and repeated-start read; the final argument selects a 0-, 1-, or 2-byte
 subaddress. Transfers are limited to 255 bytes. The `serial` command reads the
 same six identity bytes used by the Linux `serialnum` attribute. The ABI
 deliberately provides no I2C data-write or EEPROM-programming operation.
+On ART configuration-layout EEPROMs, `serial` deliberately reports invalid
+identity data. Use `mro-status` for non-destructive oscillator telemetry.
+`mro-fine` and `mro-coarse` steer the oscillator immediately;
+`mro-save-coarse` persists the current coarse setting and should be used only
+after the desired value has been verified.
 
 Driver 1.11 fixes the AXI IIC dynamic-receive completion sequence. It waits for
 the optional subaddress message to leave the transmit FIFO, drains data only

--- a/DRV/Windows/TimeCardControlCenter/ControlCenterProduct.cs
+++ b/DRV/Windows/TimeCardControlCenter/ControlCenterProduct.cs
@@ -66,7 +66,8 @@ namespace TimeCardControlCenter
     {
         public static HealthReport Evaluate(TimeCardSnapshot snapshot,
             UbloxReceiverSnapshot ublox, Sa53Snapshot atomic,
-            SensorTelemetrySnapshot sensors, bool connected, bool demoMode)
+            Mro50Status mro50, SensorTelemetrySnapshot sensors,
+            bool connected, bool demoMode)
         {
             List<HealthNode> nodes = new List<HealthNode>();
             if (demoMode)
@@ -114,28 +115,53 @@ namespace TimeCardControlCenter
                 "ACTIVE", string.Format(CultureInfo.InvariantCulture,
                     "Driver {0} / ABI {1} / {2}", snapshot.DriverVersion,
                     snapshot.AbiVersion, snapshot.Layout)));
+            bool isArt = snapshot.Layout == "Orolia ART";
             bool gnssOk = snapshot.GnssFixOk || (ublox != null && ublox.FixValid);
             int used = ublox == null ? snapshot.LockedSatellites : ublox.SatellitesUsed;
-            nodes.Add(Node("gnss", "GNSS receiver", "Gnss", gnssOk,
-                gnssOk ? "FIX VALID" : "NO FIX",
-                used.ToString(CultureInfo.InvariantCulture) + " satellites used"));
+            if (isArt && !snapshot.GnssTelemetryAvailable && ublox == null)
+                nodes.Add(new HealthNode("gnss", "GNSS receiver", "Gnss",
+                    HealthSeverity.Informational, "NOT EXPOSED",
+                    "The installed ART FPGA image does not publish GNSS summary registers."));
+            else
+                nodes.Add(Node("gnss", "GNSS receiver", "Gnss", gnssOk,
+                    gnssOk ? "FIX VALID" : "NO FIX",
+                    used.ToString(CultureInfo.InvariantCulture) + " satellites used"));
             bool utcValid = (snapshot.UtcStatus & (1u << 8)) != 0;
-            nodes.Add(Node("tod", "Time-of-Day engine", "Gnss", utcValid,
-                utcValid ? "UTC VALID" : "UTC INVALID",
-                string.Format(CultureInfo.InvariantCulture, "ToD status 0x{0:X8}", snapshot.TodStatus)));
+            if (!snapshot.TodTelemetryAvailable)
+                nodes.Add(new HealthNode("tod", "Time-of-Day engine", "Gnss",
+                    HealthSeverity.Informational, "NOT IMPLEMENTED",
+                    "This board profile has no FPGA ToD/NMEA engine."));
+            else
+                nodes.Add(Node("tod", "Time-of-Day engine", "Gnss", utcValid,
+                    utcValid ? "UTC VALID" : "UTC INVALID",
+                    string.Format(CultureInfo.InvariantCulture,
+                        "ToD status 0x{0:X8}", snapshot.TodStatus)));
 
             bool atomicLocked = false;
-            string atomicDetail = "Open the Atomic workspace to sample the SA53.";
-            if (atomic != null)
+            string atomicName = isArt ? "mRO-50 atomic oscillator" :
+                "SA53 atomic clock";
+            string atomicDetail = isArt ?
+                "Open the Atomic workspace to sample the ART FPGA bridge." :
+                "Open the Atomic workspace to sample the SA53.";
+            bool atomicSampled = isArt ? mro50 != null : atomic != null;
+            if (isArt && mro50 != null)
+            {
+                atomicLocked = mro50.IsLocked;
+                atomicDetail = atomicLocked ?
+                    "mRO-50 lock is asserted by ART gateware." :
+                    "mRO-50 is present but lock is not asserted.";
+            }
+            else if (atomic != null)
             {
                 atomic.TryBoolean("Locked", out atomicLocked);
                 atomicDetail = atomicLocked ? "SA53 reports oscillator lock." :
                     "SA53 is present but has not asserted lock.";
             }
-            nodes.Add(new HealthNode("atomic", "SA53 atomic clock", "Atomic",
-                atomic == null ? HealthSeverity.Informational :
+            nodes.Add(new HealthNode("atomic", atomicName, "Atomic",
+                !atomicSampled ? HealthSeverity.Informational :
                     atomicLocked ? HealthSeverity.Healthy : HealthSeverity.Attention,
-                atomic == null ? "NOT SAMPLED" : atomicLocked ? "LOCKED" : "UNLOCKED",
+                !atomicSampled ? "NOT SAMPLED" :
+                    atomicLocked ? "LOCKED" : "UNLOCKED",
                 atomicDetail));
             nodes.Add(Node("phc", "Precision hardware clock", "Clock",
                 snapshot.IsClockSynchronized,
@@ -153,6 +179,7 @@ namespace TimeCardControlCenter
                     i2cValid ? HealthSeverity.Healthy : HealthSeverity.Attention,
                 !i2cAvailable ? "ABI UPDATE" : i2cValid ? "READY" : "CHECK BUS",
                 !i2cAvailable ? "I2C controls require ABI 3 or newer." :
+                    isArt ? "OpenCores controller and ART 24c08 EEPROM banks." :
                     "Identity, LEDs, environmental sensors and power rails."));
             bool offsetReasonable = Math.Abs(snapshot.OffsetNanoseconds) < 1000000000L;
             nodes.Add(Node("system", "Windows system clock", "Clock", offsetReasonable,

--- a/DRV/Windows/TimeCardControlCenter/MainWindow.Product.cs
+++ b/DRV/Windows/TimeCardControlCenter/MainWindow.Product.cs
@@ -189,7 +189,8 @@ namespace TimeCardControlCenter
         private void UpdateHealthExperience()
         {
             lastHealthReport = ControlCenterHealth.Evaluate(lastSnapshot,
-                lastUbloxSnapshot, lastSa53Snapshot, lastSensorSnapshot,
+                lastUbloxSnapshot, lastSa53Snapshot, lastMro50Status,
+                lastSensorSnapshot,
                 client != null, productSettings != null && productSettings.DemoMode);
             TimeFlowTopology.Update(lastHealthReport, lastSmaLedStates);
             int attention = lastHealthReport.AttentionCount;
@@ -713,6 +714,11 @@ namespace TimeCardControlCenter
                 return results;
             RunCheck(results, "ABI compatibility", delegate
             {
+                if (first.Layout == "Orolia ART")
+                    return first.AbiVersion >= 9 ?
+                        Pass("ART mRO-50 feature set available") :
+                        Warning("ABI " + first.AbiVersion +
+                            " connected; the direct mRO-50 bridge requires ABI 9");
                 return first.AbiVersion >= 8 ? Pass("Full Control Center feature set available") :
                     Warning("ABI " + first.AbiVersion + " connected; sensor features require ABI 8");
             });
@@ -732,6 +738,9 @@ namespace TimeCardControlCenter
             });
             RunCheck(results, "GNSS / ToD", delegate
             {
+                if (first.Layout == "Orolia ART" &&
+                    !first.GnssTelemetryAvailable)
+                    return Skipped("GNSS/ToD summary registers are not exposed by this ART FPGA image");
                 return first.GnssFixOk ? Pass(first.GnssFix + ", " +
                     first.LockedSatellites + " satellites locked") :
                     Warning(first.GnssFix + "; antenna or sky view may need attention");
@@ -739,6 +748,8 @@ namespace TimeCardControlCenter
             RunCheck(results, "Card identity", delegate
             {
                 TimeCardIdentity identity = client.GetIdentity();
+                if (first.Layout == "Orolia ART" && !identity.IsValid)
+                    return Skipped("ART EEPROM stores oscillator configuration, not an EUI-48 serial");
                 return identity.IsValid ? Pass(identity.SerialNumber) :
                     Warning("MAC EEPROM did not return a valid serial number");
             });
@@ -755,6 +766,8 @@ namespace TimeCardControlCenter
             });
             RunCheck(results, "NMEA generator", delegate
             {
+                if (first.Layout == "Orolia ART")
+                    return Skipped("No FPGA ToD/NMEA generator in the ART profile");
                 if (first.AbiVersion < 4)
                     return Skipped("Requires ABI 4");
                 NmeaOutputState nmea = client.GetNmeaOutput();
@@ -771,6 +784,8 @@ namespace TimeCardControlCenter
             });
             RunCheck(results, "Sensor fabric", delegate
             {
+                if (first.Layout == "Orolia ART")
+                    return Skipped("PCA9546A sensors and status LEDs are not fitted on ART");
                 if (first.AbiVersion < 8)
                     return Skipped("Requires ABI 8");
                 SensorTelemetrySnapshot sensors = client.GetSensorTelemetry();
@@ -780,6 +795,8 @@ namespace TimeCardControlCenter
             RunCheck(results, "UART transport", delegate
             {
                 UartObservation observation = client.ObserveUart(0, 15);
+                if (first.Layout == "Orolia ART" && !observation.IsPresent)
+                    return Skipped("The installed ART FPGA image does not implement the 16550 UART block");
                 return observation.IsPresent ? Pass("GNSS UART present; LSR 0x" +
                     observation.LineStatus.ToString("X2", CultureInfo.InvariantCulture)) :
                     Warning("GNSS UART did not report present");
@@ -943,7 +960,8 @@ namespace TimeCardControlCenter
                 CompatibilityLine("Signal generators / counters", abi >= 5, "ABI 5") + "\n" +
                 CompatibilityLine("Guarded FPGA flash", abi >= 6, "ABI 6") + "\n" +
                 CompatibilityLine("Extended management controls", abi >= 7, "ABI 7") + "\n" +
-                CompatibilityLine("Environment / rails / IMU", abi >= 8, "ABI 8");
+                CompatibilityLine("Environment / rails / IMU", abi >= 8, "ABI 8") + "\n" +
+                CompatibilityLine("Orolia ART mRO-50 bridge", abi >= 9, "ABI 9");
         }
 
         private static string CompatibilityLine(string feature, bool available, string requirement)
@@ -1032,7 +1050,7 @@ namespace TimeCardControlCenter
             ClockChipText.Text = "SIMULATED · IN SYNC";
             ClockChipText.Foreground = healthy;
             HierarchyOverviewText.Text = "DEMO";
-            SidebarDriverText.Text = "Demo data · ABI 8";
+            SidebarDriverText.Text = "Demo data · ABI 9";
             SidebarSerialText.Text = "DEMO-TIMECARD-0001";
             if (!telemetryPaused)
             {

--- a/DRV/Windows/TimeCardControlCenter/MainWindow.xaml
+++ b/DRV/Windows/TimeCardControlCenter/MainWindow.xaml
@@ -982,9 +982,9 @@
                             <Grid>
                                 <Grid.ColumnDefinitions><ColumnDefinition Width="*" /><ColumnDefinition Width="Auto" /></Grid.ColumnDefinitions>
                                 <StackPanel>
-                                    <TextBlock Text="MICROCHIP MAC-SA53" Style="{StaticResource Eyebrow}" />
-                                    <TextBlock Text="Atomic clock configuration" Style="{StaticResource PageTitle}" Margin="0,5,0,4" />
-                                    <TextBlock Text="Live physics-package telemetry, frequency steering, 1PPS geometry, and disciplined timing control over the C3 serial interface."
+                                    <TextBlock x:Name="AtomicEyebrowText" Text="MICROCHIP MAC-SA53" Style="{StaticResource Eyebrow}" />
+                                    <TextBlock x:Name="AtomicTitleText" Text="Atomic clock configuration" Style="{StaticResource PageTitle}" Margin="0,5,0,4" />
+                                    <TextBlock x:Name="AtomicDescriptionText" Text="Live physics-package telemetry, frequency steering, 1PPS geometry, and disciplined timing control over the C3 serial interface."
                                                Foreground="{DynamicResource MutedBrush}" TextWrapping="Wrap" />
                                 </StackPanel>
                                 <StackPanel Grid.Column="1" Orientation="Horizontal" VerticalAlignment="Center">
@@ -998,22 +998,22 @@
 
                             <UniformGrid Grid.Row="1" Columns="4" Margin="0,26,0,22">
                                 <Border Style="{StaticResource MetricPanel}"><StackPanel>
-                                    <TextBlock Text="PHYSICS LOCK" Style="{StaticResource Label}" />
+                                    <TextBlock x:Name="AtomicLockLabelText" Text="PHYSICS LOCK" Style="{StaticResource Label}" />
                                     <TextBlock x:Name="AtomicLockText" Text="—" Style="{StaticResource MetricValue}" Margin="0,8,0,5" />
                                     <TextBlock x:Name="AtomicLockDetailText" Text="Awaiting SA53" Foreground="{DynamicResource MutedBrush}" />
                                 </StackPanel></Border>
                                 <Border Style="{StaticResource MetricPanel}"><StackPanel>
-                                    <TextBlock Text="TEMPERATURE" Style="{StaticResource Label}" />
+                                    <TextBlock x:Name="AtomicTemperatureLabelText" Text="TEMPERATURE" Style="{StaticResource Label}" />
                                     <TextBlock x:Name="AtomicTemperatureText" Text="—" Style="{StaticResource MetricValue}" Margin="0,8,0,5" />
                                     <TextBlock x:Name="AtomicTemperatureDetailText" Text="Baseplate must remain ≤ 75 °C" Foreground="{DynamicResource MutedBrush}" />
                                 </StackPanel></Border>
                                 <Border Style="{StaticResource MetricPanel}"><StackPanel>
-                                    <TextBlock Text="POWER SUPPLY" Style="{StaticResource Label}" />
+                                    <TextBlock x:Name="AtomicSupplyLabelText" Text="POWER SUPPLY" Style="{StaticResource Label}" />
                                     <TextBlock x:Name="AtomicSupplyText" Text="—" Style="{StaticResource MetricValue}" Margin="0,8,0,5" />
                                     <TextBlock x:Name="AtomicSupplyDetailText" Text="SA53 input telemetry" Foreground="{DynamicResource MutedBrush}" />
                                 </StackPanel></Border>
                                 <Border Style="{StaticResource Panel}"><StackPanel>
-                                    <TextBlock Text="ACTIVE ALARMS" Style="{StaticResource Label}" />
+                                    <TextBlock x:Name="AtomicAlarmLabelText" Text="ACTIVE ALARMS" Style="{StaticResource Label}" />
                                     <TextBlock x:Name="AtomicAlarmText" Text="—" Style="{StaticResource MetricValue}" Margin="0,8,0,5" />
                                     <TextBlock x:Name="AtomicAlarmDetailText" Text="Alarm word pending" Foreground="{DynamicResource MutedBrush}"
                                                TextTrimming="CharacterEllipsis" ToolTip="{Binding RelativeSource={RelativeSource Self}, Path=Text}" />
@@ -1025,7 +1025,7 @@
                                 <Border Style="{StaticResource Panel}" Margin="0,0,18,0">
                                     <StackPanel>
                                         <TextBlock Text="Clock identity" Style="{StaticResource SectionTitle}" />
-                                        <TextBlock Text="UART 2 · 57,600 baud · C3 protocol" Foreground="{DynamicResource MutedBrush}" Margin="0,5,0,17" />
+                                        <TextBlock x:Name="AtomicIdentityProtocolText" Text="UART 2 · 57,600 baud · C3 protocol" Foreground="{DynamicResource MutedBrush}" Margin="0,5,0,17" />
                                         <Grid Margin="0,5"><Grid.ColumnDefinitions><ColumnDefinition Width="110" /><ColumnDefinition Width="*" /></Grid.ColumnDefinitions>
                                             <TextBlock Text="Device" Foreground="{DynamicResource MutedBrush}" /><TextBlock x:Name="AtomicDeviceText" Grid.Column="1" Text="—" FontFamily="Segoe UI Semibold" /></Grid>
                                         <Grid Margin="0,5"><Grid.ColumnDefinitions><ColumnDefinition Width="110" /><ColumnDefinition Width="*" /></Grid.ColumnDefinitions>
@@ -1041,7 +1041,7 @@
                                 <Border Grid.Column="1" Style="{StaticResource Panel}">
                                     <StackPanel>
                                         <TextBlock Text="Oscillator &amp; discipline telemetry" Style="{StaticResource SectionTitle}" />
-                                        <TextBlock Text="Read-only operating values reported directly by the SA53." Foreground="{DynamicResource MutedBrush}" Margin="0,5,0,15" />
+                                        <TextBlock x:Name="AtomicTelemetryDescriptionText" Text="Read-only operating values reported directly by the SA53." Foreground="{DynamicResource MutedBrush}" Margin="0,5,0,15" />
                                         <UniformGrid Columns="2">
                                             <StackPanel Margin="0,5,16,10"><TextBlock Text="TOTAL RUNTIME" Style="{StaticResource Label}" /><TextBlock x:Name="AtomicRuntimeText" Text="—" Margin="0,5,0,0" /></StackPanel>
                                             <StackPanel Margin="0,5,0,10"><TextBlock Text="TOTAL LOCK TIME" Style="{StaticResource Label}" /><TextBlock x:Name="AtomicLocktimeText" Text="—" Margin="0,5,0,0" /></StackPanel>
@@ -1056,7 +1056,7 @@
                                 </Border>
                             </Grid>
 
-                            <Grid Grid.Row="3" Margin="0,18,0,0">
+                            <Grid x:Name="AtomicSa53ControlGrid" Grid.Row="3" Margin="0,18,0,0">
                                 <Grid.ColumnDefinitions><ColumnDefinition Width="0.8*" /><ColumnDefinition Width="1.2*" /></Grid.ColumnDefinitions>
                                 <Border Style="{StaticResource Panel}" Margin="0,0,18,0">
                                     <StackPanel>
@@ -1103,7 +1103,43 @@
                                 </Border>
                             </Grid>
 
-                            <Border Grid.Row="4" Style="{StaticResource Panel}" Margin="0,18,0,0">
+                            <Border x:Name="AtomicMroPanel" Grid.Row="3" Style="{StaticResource Panel}" Margin="0,18,0,0"
+                                    Visibility="Collapsed">
+                                <StackPanel>
+                                    <Grid>
+                                        <Grid.ColumnDefinitions><ColumnDefinition Width="*" /><ColumnDefinition Width="Auto" /></Grid.ColumnDefinitions>
+                                        <StackPanel>
+                                            <TextBlock Text="mRO-50 FPGA bridge" Style="{StaticResource SectionTitle}" />
+                                            <TextBlock Text="ART FPGA v0.0.9 exposes oscillator status and steering registers directly. Values are shown exactly as reported by gateware; the temperature word has no published physical scale."
+                                                       Foreground="{DynamicResource MutedBrush}" TextWrapping="Wrap" Margin="0,5,18,17" />
+                                        </StackPanel>
+                                        <Border Grid.Column="1" Style="{StaticResource StatusChip}" VerticalAlignment="Top">
+                                            <TextBlock x:Name="AtomicMroSerialRouteText" Text="SERIAL ROUTE UNKNOWN"
+                                                       Foreground="{DynamicResource MutedBrush}" FontFamily="Segoe UI Semibold" FontSize="10" />
+                                        </Border>
+                                    </Grid>
+                                    <Grid>
+                                        <Grid.ColumnDefinitions><ColumnDefinition Width="*" /><ColumnDefinition Width="*" /><ColumnDefinition Width="Auto" /></Grid.ColumnDefinitions>
+                                        <StackPanel Margin="0,0,14,0">
+                                            <TextBlock Text="FINE ADJUSTMENT (UINT32)" Style="{StaticResource Label}" Margin="0,0,0,5" />
+                                            <TextBox x:Name="AtomicMroFineTextBox" Text="0" />
+                                        </StackPanel>
+                                        <StackPanel Grid.Column="1" Margin="0,0,14,0">
+                                            <TextBlock Text="COARSE ADJUSTMENT (UINT32)" Style="{StaticResource Label}" Margin="0,0,0,5" />
+                                            <TextBox x:Name="AtomicMroCoarseTextBox" Text="0" />
+                                        </StackPanel>
+                                        <StackPanel Grid.Column="2" Orientation="Horizontal" VerticalAlignment="Bottom">
+                                            <Button Content="Set fine" Click="ApplyMroFine_Click" Margin="0,0,8,0" />
+                                            <Button Content="Set coarse" Click="ApplyMroCoarse_Click" Margin="0,0,8,0" />
+                                            <Button Content="Save coarse" Click="SaveMroCoarse_Click" Style="{StaticResource DangerButton}" />
+                                        </StackPanel>
+                                    </Grid>
+                                    <TextBlock Text="Fine and coarse writes immediately steer the oscillator. Saving coarse adjustment writes the mRO-50 nonvolatile setting and always requires confirmation."
+                                               Foreground="{DynamicResource GoldBrush}" FontSize="11" TextWrapping="Wrap" Margin="0,13,0,0" />
+                                </StackPanel>
+                            </Border>
+
+                            <Border x:Name="AtomicSa53DisciplinePanel" Grid.Row="4" Style="{StaticResource Panel}" Margin="0,18,0,0">
                                 <StackPanel>
                                     <Grid><Grid.ColumnDefinitions><ColumnDefinition Width="*" /><ColumnDefinition Width="Auto" /></Grid.ColumnDefinitions>
                                         <StackPanel><TextBlock Text="1PPS disciplining &amp; phase measurement" Style="{StaticResource SectionTitle}" />
@@ -1133,7 +1169,7 @@
                                 </StackPanel>
                             </Border>
 
-                            <Grid Grid.Row="5" Margin="0,18,0,0">
+                            <Grid x:Name="AtomicSa53ProtectedGrid" Grid.Row="5" Margin="0,18,0,0">
                                 <Grid.ColumnDefinitions><ColumnDefinition Width="1*" /><ColumnDefinition Width="1*" /></Grid.ColumnDefinitions>
                                 <Border Style="{StaticResource Panel}" Margin="0,0,18,0">
                                     <StackPanel>
@@ -1796,7 +1832,7 @@
 
                             <Grid Grid.Row="3" Margin="0,0,0,18">
                                 <Grid.ColumnDefinitions><ColumnDefinition Width="1.25*" /><ColumnDefinition Width="0.75*" /></Grid.ColumnDefinitions>
-                                <Border Style="{StaticResource Panel}" Margin="0,0,18,0">
+                                <Border x:Name="I2cMuxPanel" Style="{StaticResource Panel}" Margin="0,0,18,0">
                                     <StackPanel>
                                         <Grid><Grid.ColumnDefinitions><ColumnDefinition Width="*" /><ColumnDefinition Width="Auto" /></Grid.ColumnDefinitions><StackPanel><TextBlock Text="PCA9546A downstream routing" Style="{StaticResource SectionTitle}" /><TextBlock Text="U27 &#x00B7; upstream address 0x70 &#x00B7; channels may be combined by the device" Foreground="{DynamicResource MutedBrush}" FontSize="11" Margin="0,3,0,0" /></StackPanel><TextBlock x:Name="I2cMuxStatusText" Grid.Column="1" Text="NOT QUERIED" Foreground="{DynamicResource MutedBrush}" FontFamily="Segoe UI Semibold" FontSize="10" VerticalAlignment="Center" /></Grid>
                                         <WrapPanel Margin="0,16,0,14">
@@ -1824,7 +1860,7 @@
                                 </Border>
                             </Grid>
 
-                            <Border Grid.Row="4" Style="{StaticResource Panel}" Margin="0,0,0,18">
+                            <Border x:Name="I2cLedPanel" Grid.Row="4" Style="{StaticResource Panel}" Margin="0,0,0,18">
                                 <StackPanel>
                                     <Grid><Grid.ColumnDefinitions><ColumnDefinition Width="*" /><ColumnDefinition Width="Auto" /></Grid.ColumnDefinitions><StackPanel><TextBlock Text="Subsystem RGB status indicators" Style="{StaticResource SectionTitle}" /><TextBlock Text="IS32FL3207 at 7-bit 0x37 on sensor channel 1 &#x00B7; GNSS 1/2 and IO 1&#x2013;4" Foreground="{DynamicResource MutedBrush}" FontSize="11" Margin="0,3,0,0" /></StackPanel><StackPanel Grid.Column="1" Orientation="Horizontal" VerticalAlignment="Center"><Button x:Name="I2cLedTestButton" Content="Electrical test" Click="TestI2cLeds_Click" Style="{StaticResource SecondaryButton}" Padding="12,6" Margin="0,0,14,0" /><CheckBox x:Name="I2cLedAutoCheckBox" Content="Automatic status mapping" IsChecked="True" Click="I2cLedAuto_Click" VerticalAlignment="Center" /></StackPanel></Grid>
                                     <Grid Margin="0,18,0,0"><Grid.ColumnDefinitions><ColumnDefinition Width="1.05*" /><ColumnDefinition Width="0.95*" /></Grid.ColumnDefinitions>

--- a/DRV/Windows/TimeCardControlCenter/MainWindow.xaml.cs
+++ b/DRV/Windows/TimeCardControlCenter/MainWindow.xaml.cs
@@ -76,6 +76,7 @@ namespace TimeCardControlCenter
         private DateTime lastSecondaryLedObservationUtc = DateTime.MinValue;
         private bool atomicRefreshing;
         private Sa53Snapshot lastSa53Snapshot;
+        private Mro50Status lastMro50Status;
         private bool ubloxRefreshing;
         private UbloxReceiverSnapshot lastUbloxSnapshot;
         private uint? lastUbloxPort;
@@ -153,6 +154,7 @@ namespace TimeCardControlCenter
             public I2cProbeResult MacEeprom { get; set; }
             public List<uint> Addresses { get; set; }
             public bool FullScan { get; set; }
+            public bool IsArt { get; set; }
         }
 
         private sealed class BoardLedColor
@@ -519,6 +521,10 @@ namespace TimeCardControlCenter
             LastRefreshText.Text = "Sampled " + DateTime.Now.ToString("HH:mm:ss", CultureInfo.InvariantCulture);
             UpdateI2cDriverCompatibility(snapshot);
             UpdateSensorsCompatibility(snapshot);
+            ConfigureAtomicWorkspaceForProfile(
+                snapshot.Layout == "Orolia ART");
+            ConfigureUartWorkspaceForProfile(
+                snapshot.Layout == "Orolia ART");
 
             SyncStatusText.Text = snapshot.IsClockSynchronized ? "IN SYNC" : "NOT LOCKED";
             SyncStatusText.Foreground = snapshot.IsClockSynchronized ? healthyBrush : warningBrush;
@@ -1426,6 +1432,17 @@ namespace TimeCardControlCenter
 
         private async Task RefreshNmeaAsync(bool showError)
         {
+            if (lastSnapshot != null &&
+                lastSnapshot.Layout == "Orolia ART")
+            {
+                NmeaStatusText.Text = "NOT IMPLEMENTED ON ART";
+                NmeaStatusText.Foreground =
+                    (Brush)FindResource("GoldBrush");
+                NmeaApplyButton.IsEnabled = false;
+                NmeaRegisterText.Text =
+                    "The ART FPGA profile has no ToD/NMEA sentence generator or UART 3.";
+                return;
+            }
             if (client == null || lastSnapshot == null || lastSnapshot.AbiVersion < 4)
             {
                 NmeaStatusText.Text = "DRIVER 1.9 / ABI 4 REQUIRED";
@@ -1455,6 +1472,15 @@ namespace TimeCardControlCenter
         {
             if (!EnsureConnected())
                 return;
+            if (lastSnapshot != null &&
+                lastSnapshot.Layout == "Orolia ART")
+            {
+                MessageBox.Show(this,
+                    "The Orolia ART FPGA profile does not implement the Time Card NMEA generator.",
+                    "NMEA not implemented", MessageBoxButton.OK,
+                    MessageBoxImage.Information);
+                return;
+            }
             try
             {
                 uint baud = ParseUnsigned(SelectedComboText(NmeaBaudCombo),
@@ -1490,7 +1516,8 @@ namespace TimeCardControlCenter
             finally
             {
                 NmeaApplyButton.IsEnabled = client != null &&
-                    lastSnapshot != null && lastSnapshot.AbiVersion >= 4;
+                    lastSnapshot != null && lastSnapshot.AbiVersion >= 4 &&
+                    lastSnapshot.Layout != "Orolia ART";
             }
         }
 
@@ -2334,18 +2361,54 @@ namespace TimeCardControlCenter
             if (lastSnapshot != null &&
                 lastSnapshot.Layout == "Orolia ART")
             {
-                AtomicConnectionText.Text = "OROLIA ART · MRO-50";
+                if (lastSnapshot.AbiVersion < 9)
+                {
+                    AtomicConnectionText.Text = "DRIVER 1.29 / ABI 9 REQUIRED";
+                    AtomicConnectionText.Foreground =
+                        (Brush)FindResource("GoldBrush");
+                    AtomicRefreshButton.IsEnabled = false;
+                    return;
+                }
+                if (client == null)
+                {
+                    AtomicConnectionText.Text = "DRIVER ACCESS REQUIRED";
+                    AtomicConnectionText.Foreground =
+                        (Brush)FindResource("GoldBrush");
+                    if (showError)
+                        EnsureConnected();
+                    return;
+                }
+
+                atomicRefreshing = true;
+                AtomicRefreshButton.IsEnabled = false;
+                AtomicConnectionText.Text = "QUERYING FPGA BRIDGE";
                 AtomicConnectionText.Foreground =
                     (Brush)FindResource("GoldBrush");
-                AtomicLockDetailText.Text =
-                    "Use UART 2 at 9,600 baud for the ART oscillator console";
-                AtomicRefreshButton.IsEnabled = false;
-                if (showError)
+                try
                 {
-                    MessageBox.Show(this,
-                        "The Orolia ART card uses an mRO-50 oscillator, not the Microchip MAC-SA53 command set. Use the UART workspace on port 2 at 9,600 baud; SA53 writes are disabled for this card profile.",
-                        "Different atomic clock",
-                        MessageBoxButton.OK, MessageBoxImage.Information);
+                    Mro50Status status = await Task.Run(
+                        () => client.GetMro50Status());
+                    lastMro50Status = status;
+                    lastSa53Snapshot = null;
+                    ApplyMro50Status(status);
+                    UpdateHealthExperience();
+                    Log("Orolia ART mRO-50 FPGA telemetry refreshed.");
+                }
+                catch (Exception ex)
+                {
+                    AtomicConnectionText.Text = "MRO-50 UNAVAILABLE";
+                    AtomicConnectionText.Foreground =
+                        (Brush)FindResource("DangerBrush");
+                    Log("mRO-50 refresh failed: " + ex.Message);
+                    if (showError)
+                        MessageBox.Show(this, ex.Message,
+                            "mRO-50 unavailable", MessageBoxButton.OK,
+                            MessageBoxImage.Error);
+                }
+                finally
+                {
+                    AtomicRefreshButton.IsEnabled = true;
+                    atomicRefreshing = false;
                 }
                 return;
             }
@@ -2387,6 +2450,220 @@ namespace TimeCardControlCenter
                     MessageBox.Show(this, ex.Message +
                         "\r\n\r\nVerify that UART 2 is connected to a Microchip MAC-SA53 and is using its default 57,600-baud C3 interface.",
                         "Atomic clock unavailable", MessageBoxButton.OK, MessageBoxImage.Error);
+            }
+            finally
+            {
+                AtomicRefreshButton.IsEnabled = true;
+                atomicRefreshing = false;
+            }
+        }
+
+        private void ConfigureAtomicWorkspaceForProfile(bool isArt)
+        {
+            AtomicEyebrowText.Text = isArt ?
+                "SAFRAN / OROLIA MRO-50" : "MICROCHIP MAC-SA53";
+            AtomicTitleText.Text = isArt ?
+                "ART atomic oscillator" : "Atomic clock configuration";
+            AtomicDescriptionText.Text = isArt ?
+                "Live lock, temperature word, and frequency steering through the ART FPGA's direct mRO-50 bridge." :
+                "Live physics-package telemetry, frequency steering, 1PPS geometry, and disciplined timing control over the C3 serial interface.";
+            AtomicRefreshButton.Content = isArt ? "Refresh mRO-50" : "Refresh SA53";
+            AtomicLockLabelText.Text = isArt ? "OSCILLATOR LOCK" : "PHYSICS LOCK";
+            AtomicTemperatureLabelText.Text = isArt ? "RAW TEMPERATURE" : "TEMPERATURE";
+            AtomicSupplyLabelText.Text = isArt ? "FINE ADJUSTMENT" : "POWER SUPPLY";
+            AtomicAlarmLabelText.Text = isArt ? "COARSE ADJUSTMENT" : "ACTIVE ALARMS";
+            AtomicIdentityProtocolText.Text = isArt ?
+                "Direct FPGA bridge at BAR + 0x00340000" :
+                "UART 2 \u00B7 57,600 baud \u00B7 C3 protocol";
+            AtomicTelemetryDescriptionText.Text = isArt ?
+                "Read-only operating values reported by the ART gateware." :
+                "Read-only operating values reported directly by the SA53.";
+            AtomicSa53ControlGrid.Visibility = isArt ?
+                Visibility.Collapsed : Visibility.Visible;
+            AtomicMroPanel.Visibility = isArt ?
+                Visibility.Visible : Visibility.Collapsed;
+            AtomicSa53DisciplinePanel.Visibility = isArt ?
+                Visibility.Collapsed : Visibility.Visible;
+            AtomicSa53ProtectedGrid.Visibility = isArt ?
+                Visibility.Collapsed : Visibility.Visible;
+        }
+
+        private void ConfigureUartWorkspaceForProfile(bool isArt)
+        {
+            if (UartPortCombo == null)
+                return;
+            string[] standard =
+            {
+                "0 \u00B7 Primary GNSS",
+                "1 \u00B7 Secondary GNSS",
+                "2 \u00B7 Atomic clock",
+                "3 \u00B7 NMEA output"
+            };
+            string[] art =
+            {
+                "0 \u00B7 ART GNSS (gateware baud)",
+                "1 \u00B7 Not implemented on ART",
+                "2 \u00B7 mRO-50 serial (9600)",
+                "3 \u00B7 No NMEA UART on ART"
+            };
+            for (uint port = 0; port < 4; port++)
+            {
+                ComboBoxItem item = UartPortCombo.Items
+                    .OfType<ComboBoxItem>().FirstOrDefault(candidate =>
+                        string.Equals(Convert.ToString(candidate.Tag,
+                            CultureInfo.InvariantCulture),
+                            port.ToString(CultureInfo.InvariantCulture),
+                            StringComparison.Ordinal));
+                if (item == null)
+                    continue;
+                item.Content = isArt ? art[port] : standard[port];
+                item.IsEnabled = !isArt || port == 0 || port == 2;
+            }
+            if (isArt && SelectedGenericComPort() == null)
+            {
+                uint selected = SelectedUartPort();
+                if (selected == 1 || selected == 3)
+                    UartPortCombo.SelectedIndex = 0;
+            }
+        }
+
+        private void ApplyMro50Status(Mro50Status status)
+        {
+            Brush healthy = (Brush)FindResource("AccentBrush");
+            Brush warning = (Brush)FindResource("GoldBrush");
+            AtomicConnectionText.Text = status.IsPresent ?
+                "LIVE \u00B7 FPGA BRIDGE" : "NOT PRESENT";
+            AtomicConnectionText.Foreground = status.IsPresent ?
+                healthy : warning;
+            AtomicLockText.Text = status.IsLocked ? "LOCKED" :
+                status.IsEnabled ? "ENABLED" : "DISABLED";
+            AtomicLockText.Foreground = status.IsLocked ? healthy : warning;
+            AtomicLockDetailText.Text = string.Format(
+                CultureInfo.InvariantCulture, "Control 0x{0:X8}",
+                status.Control);
+
+            AtomicTemperatureText.Text = string.Format(
+                CultureInfo.InvariantCulture, "0x{0:X8}",
+                status.TemperatureRaw);
+            AtomicTemperatureDetailText.Text =
+                "Raw ART gateware word; no physical scale is published";
+            AtomicSupplyText.Text = status.IsFineValid ?
+                status.FineAdjustment.ToString(CultureInfo.InvariantCulture) :
+                "NOT VALID";
+            AtomicSupplyDetailText.Text = status.IsFineValid ?
+                "0x" + status.FineAdjustment.ToString(
+                    "X8", CultureInfo.InvariantCulture) :
+                "FPGA read did not complete";
+            AtomicAlarmText.Text = status.IsCoarseValid ?
+                status.CoarseAdjustment.ToString(CultureInfo.InvariantCulture) :
+                "NOT VALID";
+            AtomicAlarmText.Foreground = status.IsCoarseValid ?
+                healthy : warning;
+            AtomicAlarmDetailText.Text = status.IsCoarseValid ?
+                "0x" + status.CoarseAdjustment.ToString(
+                    "X8", CultureInfo.InvariantCulture) :
+                "FPGA read did not complete";
+
+            AtomicDeviceText.Text = "mRO-50";
+            AtomicPartText.Text = "Safran / Orolia ART";
+            AtomicSerialText.Text =
+                "Not exposed by this EEPROM image";
+            AtomicFirmwareText.Text = lastSnapshot == null ?
+                "ART FPGA bridge" : "ART FPGA " + lastSnapshot.ClockVersion;
+            AtomicHardwareText.Text = "PCI 1AD7:A000";
+
+            AtomicRuntimeText.Text = status.IsPresent ? "FPGA bridge active" : "\u2014";
+            AtomicLocktimeText.Text = "Not exposed";
+            AtomicPpsDetectedText.Text = "Not exposed";
+            AtomicDisciplineStateText.Text = status.IsEnabled ?
+                "ENABLED" : "DISABLED";
+            AtomicPhaseText.Text = "Control 0x" +
+                status.Control.ToString("X8", CultureInfo.InvariantCulture);
+            AtomicEffectiveTuningText.Text = status.IsFineValid ?
+                status.FineAdjustment.ToString(CultureInfo.InvariantCulture) :
+                "\u2014";
+            AtomicDisciplineTuningText.Text = status.IsCoarseValid ?
+                status.CoarseAdjustment.ToString(CultureInfo.InvariantCulture) :
+                "\u2014";
+            AtomicLastCorrectionText.Text = "Board config 0x" +
+                status.BoardConfig.ToString("X8", CultureInfo.InvariantCulture);
+            AtomicMroFineTextBox.Text = status.FineAdjustment.ToString(
+                CultureInfo.InvariantCulture);
+            AtomicMroCoarseTextBox.Text = status.CoarseAdjustment.ToString(
+                CultureInfo.InvariantCulture);
+            AtomicMroSerialRouteText.Text = status.IsSerialRouteEnabled ?
+                "SERIAL ROUTE ENABLED" : "DIRECT BRIDGE ACTIVE";
+            AtomicMroSerialRouteText.Foreground = status.IsPresent ?
+                healthy : warning;
+        }
+
+        private async void ApplyMroFine_Click(object sender, RoutedEventArgs e)
+        {
+            uint value;
+            if (!uint.TryParse(AtomicMroFineTextBox.Text,
+                NumberStyles.Integer, CultureInfo.InvariantCulture, out value))
+            {
+                MessageBox.Show(this, "Enter a valid unsigned 32-bit fine adjustment.",
+                    "Invalid mRO-50 value", MessageBoxButton.OK,
+                    MessageBoxImage.Warning);
+                return;
+            }
+            await RunMro50OperationAsync(
+                activeClient => activeClient.SetMro50FineAdjustment(value),
+                "mRO-50 fine adjustment updated.");
+        }
+
+        private async void ApplyMroCoarse_Click(object sender, RoutedEventArgs e)
+        {
+            uint value;
+            if (!uint.TryParse(AtomicMroCoarseTextBox.Text,
+                NumberStyles.Integer, CultureInfo.InvariantCulture, out value))
+            {
+                MessageBox.Show(this, "Enter a valid unsigned 32-bit coarse adjustment.",
+                    "Invalid mRO-50 value", MessageBoxButton.OK,
+                    MessageBoxImage.Warning);
+                return;
+            }
+            await RunMro50OperationAsync(
+                activeClient => activeClient.SetMro50CoarseAdjustment(value),
+                "mRO-50 coarse adjustment updated.");
+        }
+
+        private async void SaveMroCoarse_Click(object sender, RoutedEventArgs e)
+        {
+            if (MessageBox.Show(this,
+                "Save the current mRO-50 coarse adjustment to nonvolatile storage?",
+                "Confirm mRO-50 write", MessageBoxButton.YesNo,
+                MessageBoxImage.Warning) != MessageBoxResult.Yes)
+                return;
+            await RunMro50OperationAsync(
+                activeClient => activeClient.SaveMro50CoarseAdjustment(),
+                "mRO-50 coarse adjustment saved.");
+        }
+
+        private async Task RunMro50OperationAsync(
+            Func<TimeCardClient, Mro50Status> operation, string success)
+        {
+            if (client == null || atomicRefreshing)
+                return;
+            atomicRefreshing = true;
+            AtomicRefreshButton.IsEnabled = false;
+            TimeCardClient activeClient = client;
+            try
+            {
+                Mro50Status status = await Task.Run(
+                    () => operation(activeClient));
+                if (client != activeClient)
+                    return;
+                lastMro50Status = status;
+                ApplyMro50Status(status);
+                Log(success);
+            }
+            catch (Exception ex)
+            {
+                Log("mRO-50 operation failed: " + ex.Message);
+                MessageBox.Show(this, ex.Message, "mRO-50 operation failed",
+                    MessageBoxButton.OK, MessageBoxImage.Error);
             }
             finally
             {
@@ -3549,7 +3826,9 @@ namespace TimeCardControlCenter
             I2cControllerStateText.Text = fullScan ? "SCANNING" : "REFRESHING";
             I2cScanResultText.Text = fullScan ?
                 "Probing 7-bit addresses 0x08 through 0x77..." :
-                "Probing the two declared onboard devices...";
+                lastSnapshot != null && lastSnapshot.Layout == "Orolia ART" ?
+                    "Probing the ART 24c08 EEPROM banks at 0x50 through 0x57..." :
+                    "Probing the two declared onboard devices...";
             TimeCardClient activeClient = client;
             try
             {
@@ -3558,20 +3837,25 @@ namespace TimeCardControlCenter
                     I2cRefreshResult value = new I2cRefreshResult
                     {
                         Addresses = new List<uint>(),
-                        FullScan = fullScan
+                        FullScan = fullScan,
+                        IsArt = lastSnapshot != null &&
+                            lastSnapshot.Layout == "Orolia ART"
                     };
-                    if (lastSnapshot != null && lastSnapshot.AbiVersion >= 7)
+                    if (!value.IsArt && lastSnapshot != null &&
+                        lastSnapshot.AbiVersion >= 7)
                         value.Mux = activeClient.GetI2cMux();
                     uint first = fullScan ? 0x08u : 0x50u;
-                    uint last = fullScan ? 0x77u : 0x58u;
+                    uint last = fullScan ? 0x77u :
+                        value.IsArt ? 0x57u : 0x58u;
                     for (uint address = first; address <= last; address++)
                     {
-                        if (!fullScan && address != 0x50u && address != 0x58u)
+                        if (!fullScan && !value.IsArt &&
+                            address != 0x50u && address != 0x58u)
                             continue;
                         I2cProbeResult probe = activeClient.ProbeI2c(address);
                         if (address == 0x50u)
                             value.BoardEeprom = probe;
-                        else if (address == 0x58u)
+                        else if (!value.IsArt && address == 0x58u)
                             value.MacEeprom = probe;
                         if (probe.IsPresent)
                             value.Addresses.Add(address);
@@ -3608,7 +3892,15 @@ namespace TimeCardControlCenter
             I2cControllerStatus status = result.Status;
             bool readsSupported = SupportsReliableI2cReads();
 
-            ApplyI2cMuxState(result.Mux);
+            if (result.IsArt)
+            {
+                I2cMuxStatusText.Text = "NOT FITTED ON ART";
+                I2cMuxStatusText.Foreground = warningBrush;
+            }
+            else
+            {
+                ApplyI2cMuxState(result.Mux);
+            }
 
             I2cControllerStateText.Text = status.IsPresent ?
                 (status.IsEnabled ? "ENABLED" : "PRESENT") : "NOT PRESENT";
@@ -3630,9 +3922,11 @@ namespace TimeCardControlCenter
                 result.BoardEeprom.IsPresent ? "PRESENT" : "NO ACK";
             I2cBoardStatusText.Foreground = result.BoardEeprom != null &&
                 result.BoardEeprom.IsPresent ? healthyBrush : warningBrush;
-            I2cMacStatusText.Text = result.MacEeprom != null &&
+            I2cMacStatusText.Text = result.IsArt ? "NOT FITTED" :
+                result.MacEeprom != null &&
                 result.MacEeprom.IsPresent ? "PRESENT" : "NO ACK";
-            I2cMacStatusText.Foreground = result.MacEeprom != null &&
+            I2cMacStatusText.Foreground = result.IsArt ? warningBrush :
+                result.MacEeprom != null &&
                 result.MacEeprom.IsPresent ? healthyBrush : warningBrush;
 
             I2cDeviceCountText.Text = result.Addresses.Count.ToString(
@@ -3644,7 +3938,8 @@ namespace TimeCardControlCenter
             I2cAddressMapText.Text = FormatI2cAddressMap(result);
             I2cDiagnosticsText.Text = FormatI2cControllerDiagnostics(
                 status, result.FullScan ? "Full 7-bit scan completed." :
-                "Known-device probe completed.");
+                result.IsArt ? "ART 24c08 bank probe completed." :
+                    "Known-device probe completed.");
             I2cReadButton.IsEnabled = readsSupported;
             I2cPreviousButton.IsEnabled = readsSupported;
             I2cNextButton.IsEnabled = readsSupported;
@@ -3663,7 +3958,9 @@ namespace TimeCardControlCenter
             bool abiSupported = snapshot.AbiVersion >= 3;
             bool reliableReads = abiSupported &&
                 DriverVersionAtLeast(snapshot.DriverVersion, 1, 14);
-            bool boardControls = snapshot.AbiVersion >= 7 && reliableReads;
+            bool isArt = snapshot.Layout == "Orolia ART";
+            bool boardControls = !isArt &&
+                snapshot.AbiVersion >= 7 && reliableReads;
             Brush stateBrush = (Brush)FindResource(
                 boardControls ? "AccentBrush" : "GoldBrush");
 
@@ -3672,6 +3969,28 @@ namespace TimeCardControlCenter
             I2cLedAutoCheckBox.IsEnabled = boardControls;
             I2cLedManualPanel.IsEnabled = boardControls &&
                 I2cLedAutoCheckBox.IsChecked != true;
+            I2cMuxPanel.IsEnabled = !isArt && boardControls;
+            I2cMuxPanel.Opacity = isArt ? 0.55 : 1.0;
+            I2cLedPanel.IsEnabled = boardControls;
+            I2cLedPanel.Opacity = isArt ? 0.55 : 1.0;
+            foreach (ComboBoxItem preset in
+                I2cPresetCombo.Items.OfType<ComboBoxItem>())
+            {
+                string tag = Convert.ToString(preset.Tag,
+                    CultureInfo.InvariantCulture);
+                preset.IsEnabled = !isArt ||
+                    tag == "custom" || tag == "board" || tag == "direct";
+            }
+            if (isArt && reliableReads)
+            {
+                I2cLedAutoCheckBox.IsChecked = false;
+                I2cDriverBadgeText.Text = "OROLIA ART \u00B7 READS";
+                I2cSafetyBannerText.Text =
+                    "Direct OpenCores I\u00B2C at BAR + 0x00350000 exposes the ART 24c08 EEPROM banks at 0x50-0x57. This board profile has no PCA9546A sensor mux or IS32FL3207 LEDs.";
+                I2cLedOperationText.Text =
+                    "Status LEDs are not fitted on the Orolia ART profile.";
+                return;
+            }
             if (boardControls)
             {
                 I2cDriverBadgeText.Text = "DRIVER " + snapshot.DriverVersion;
@@ -3714,6 +4033,7 @@ namespace TimeCardControlCenter
         private bool SupportsI2cBoardControls()
         {
             return client != null && lastSnapshot != null &&
+                lastSnapshot.Layout != "Orolia ART" &&
                 lastSnapshot.AbiVersion >= 7 &&
                 DriverVersionAtLeast(lastSnapshot.DriverVersion, 1, 14);
         }
@@ -5771,6 +6091,30 @@ namespace TimeCardControlCenter
 
         private void UpdateSensorsCompatibility(TimeCardSnapshot snapshot)
         {
+            if (snapshot != null && snapshot.Layout == "Orolia ART")
+            {
+                lastSensorSnapshot = null;
+                SensorsRefreshButton.IsEnabled = false;
+                SensorsDriverText.Text =
+                    "The Orolia ART profile has no PCA9546A sensor branch. The mRO-50 raw temperature word is available in the Atomic workspace.";
+                SensorsStatusText.Text = "NOT FITTED ON ART";
+                SensorsStatusText.Foreground =
+                    (Brush)FindResource("GoldBrush");
+                SensorsStatusDot.Fill = (Brush)FindResource("GoldBrush");
+                SensorsLastSampleText.Text = "BOARD PROFILE";
+                SetEnvironmentUnavailable(
+                    "ENVIRONMENT SENSOR \u00B7 NOT FITTED ON OROLIA ART");
+                Rail12StatusText.Text = "NOT FITTED";
+                Rail5StatusText.Text = "NOT FITTED";
+                Rail3V3StatusText.Text = "NOT FITTED";
+                ImuStatusText.Text = "NOT FITTED";
+                ImuDetailText.Text =
+                    "IMU sensor branch is not implemented by the Orolia ART profile";
+                ImuDetailText.Foreground =
+                    (Brush)FindResource("GoldBrush");
+                return;
+            }
+
             bool supported = snapshot != null && snapshot.AbiVersion >= 8;
             SensorsRefreshButton.IsEnabled = supported && client != null &&
                 !sensorsRefreshing;
@@ -5805,6 +6149,11 @@ namespace TimeCardControlCenter
                 UpdateSensorsCompatibility(lastSnapshot);
                 return;
             }
+            if (lastSnapshot.Layout == "Orolia ART")
+            {
+                UpdateSensorsCompatibility(lastSnapshot);
+                return;
+            }
 
             sensorsRefreshing = true;
             SensorsRefreshButton.IsEnabled = false;
@@ -5832,7 +6181,8 @@ namespace TimeCardControlCenter
             {
                 sensorsRefreshing = false;
                 SensorsRefreshButton.IsEnabled = client != null &&
-                    lastSnapshot != null && lastSnapshot.AbiVersion >= 8;
+                    lastSnapshot != null && lastSnapshot.AbiVersion >= 8 &&
+                    lastSnapshot.Layout != "Orolia ART";
             }
         }
 

--- a/DRV/Windows/TimeCardControlCenter/Models.cs
+++ b/DRV/Windows/TimeCardControlCenter/Models.cs
@@ -370,6 +370,28 @@ namespace TimeCardControlCenter
         public uint Reserved2;
     }
 
+    [StructLayout(LayoutKind.Sequential)]
+    internal struct TimeCardMro50StatusRaw
+    {
+        public uint Size;
+        public uint Flags;
+        public uint Control;
+        public uint FineAdjustment;
+        public uint CoarseAdjustment;
+        public uint Temperature;
+        public uint BoardConfig;
+        public uint Reserved;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    internal struct TimeCardMro50ControlRaw
+    {
+        public uint Size;
+        public uint Action;
+        public uint Value;
+        public uint Reserved;
+    }
+
     public enum SmaDirection : uint
     {
         Input = 0,
@@ -960,6 +982,36 @@ namespace TimeCardControlCenter
         public bool IsPresent { get; private set; }
         public bool HasActivity { get; private set; }
         public uint LineStatus { get; private set; }
+    }
+
+    public sealed class Mro50Status
+    {
+        internal Mro50Status(TimeCardMro50StatusRaw value)
+        {
+            IsPresent = (value.Flags & 1u) != 0;
+            IsEnabled = (value.Flags & 2u) != 0;
+            IsLocked = (value.Flags & 4u) != 0;
+            IsFineValid = (value.Flags & 8u) != 0;
+            IsCoarseValid = (value.Flags & 16u) != 0;
+            IsSerialRouteEnabled = (value.Flags & 32u) != 0;
+            Control = value.Control;
+            FineAdjustment = value.FineAdjustment;
+            CoarseAdjustment = value.CoarseAdjustment;
+            TemperatureRaw = value.Temperature;
+            BoardConfig = value.BoardConfig;
+        }
+
+        public bool IsPresent { get; private set; }
+        public bool IsEnabled { get; private set; }
+        public bool IsLocked { get; private set; }
+        public bool IsFineValid { get; private set; }
+        public bool IsCoarseValid { get; private set; }
+        public bool IsSerialRouteEnabled { get; private set; }
+        public uint Control { get; private set; }
+        public uint FineAdjustment { get; private set; }
+        public uint CoarseAdjustment { get; private set; }
+        public uint TemperatureRaw { get; private set; }
+        public uint BoardConfig { get; private set; }
     }
 
     public sealed class TimeCardSnapshot

--- a/DRV/Windows/TimeCardControlCenter/Properties/AssemblyInfo.cs
+++ b/DRV/Windows/TimeCardControlCenter/Properties/AssemblyInfo.cs
@@ -9,5 +9,5 @@ using System.Windows;
 [assembly: AssemblyCopyright("Copyright © Open Compute Project contributors")]
 [assembly: ComVisible(false)]
 [assembly: ThemeInfo(ResourceDictionaryLocation.None, ResourceDictionaryLocation.SourceAssembly)]
-[assembly: AssemblyVersion("1.25.0.0")]
-[assembly: AssemblyFileVersion("1.25.0.0")]
+[assembly: AssemblyVersion("1.29.0.0")]
+[assembly: AssemblyFileVersion("1.29.0.0")]

--- a/DRV/Windows/TimeCardControlCenter/README.md
+++ b/DRV/Windows/TimeCardControlCenter/README.md
@@ -4,12 +4,13 @@ The Time Card Control Center is a dependency-free Windows desktop dashboard
 for the OCP Time Card driver. It uses the public versioned IOCTL ABI directly;
 it does not shell out to `timecardctl` or scrape Device Manager.
 
-Driver 1.25 recognizes the Meta/Facebook, Celestica, and Orolia/Safran ART
-profiles from the Linux driver. The application labels the ART layout,
-suppresses unavailable ToD/GNSS-summary fields, uses the ART-specific SMA
-function menu, and prevents the MAC-SA53 panel from sending commands to the
-ART card's mRO-50 oscillator. Its generic UART 2 console remains available at
-the ART default of 9,600 baud.
+Driver 1.29 / ABI 9 recognizes the Meta/Facebook, Celestica, and Orolia/Safran
+ART profiles from the Linux driver. On ART, the application switches to a
+native mRO-50 FPGA-bridge workspace, probes all 24c08 banks at `0x50-0x57`,
+uses the fixed ART SMA map, and labels the absent ToD/NMEA, secondary-GNSS,
+sensor-mux, and RGB-LED capabilities as not implemented or not fitted.
+The ART GNSS console preserves the baud selected by gateware until the operator
+explicitly chooses a new divisor.
 
 ![Control Center overview](../assets/timecard-control-center.png)
 
@@ -369,7 +370,7 @@ updates receiver firmware. Parameter keys, bounds, frame formats, and ACK/NAK
 handling follow the official
 [RCB-F9T Interface Description](https://content.u-blox.com/sites/default/files/RCB-F9T_InterfaceDescription_%28UBX-19003606%29.pdf).
 
-## Microchip MAC-SA53 atomic clock
+## Atomic clocks: MAC-SA53 and ART mRO-50
 
 The **Atomic Clock** workspace talks directly to UART 2 using Microchip's C3
 protocol at the factory-default 57,600 baud, 8N1. It uses the documented
@@ -379,9 +380,18 @@ The general UART monitor is stopped before an SA53 transaction and the complete
 command/response exchange is serialized so monitor reads cannot consume C3
 responses.
 
-On an Orolia/Safran ART card, the SA53 refresh and write actions are disabled
-because ART uses an mRO-50 rather than a MAC-SA53. Use the generic UART
-workspace, select UART 2, and configure 9,600 baud, 8N1.
+On an Orolia/Safran ART card, the workspace changes automatically to the
+mRO-50 direct FPGA bridge. It reports oscillator enable and lock, the raw
+gateware temperature word, fine adjustment, coarse adjustment, bridge control,
+and board-configuration state. Fine and coarse writes are available from the
+ART panel; saving coarse adjustment to nonvolatile storage requires explicit
+confirmation. The application does not invent a Celsius conversion for the
+raw temperature word because ART FPGA v0.0.9 does not publish its scale.
+
+The optional ART 16550 mRO serial route remains configured for 9,600 baud, 8N1
+when implemented. The direct bridge is authoritative and continues to work on
+the tested FPGA v0.0.9 image even though its mRO UART block reports line status
+`0x00`.
 
 Digital tuning and discipline settings take effect immediately. Enabling PPS
 disciplining can initiate a JamSync and move the 1PPS phase; the application
@@ -483,8 +493,9 @@ shown in the workspace, and automatic mapping marks affected packages as
 
 ## Sensors and IMU
 
-Driver 1.25 / ABI 8 and the dedicated Sensors & IMU workspace read every
-populated monitor on the auto-detected sensor branch. BME280 and BMP280 are
+On Meta/Facebook and Celestica profiles, driver 1.25 / ABI 8 and the dedicated
+Sensors & IMU workspace read every populated monitor on the auto-detected
+sensor branch. BME280 and BMP280 are
 auto-detected at `0x76` or `0x77`; BME280 cards show factory-compensated
 temperature, relative humidity, pressure, and calculated dew point, while a
 BMP280 correctly reports humidity and dew point as unavailable. The three
@@ -511,6 +522,11 @@ Driver 1.25 additionally probes SH-2 report `0x0e` and displays its signed-Q7
 ambient temperature when the installed BNO08x firmware publishes it. Firmware
 without that optional report continues to show an em dash rather than a
 fabricated die-temperature value.
+
+The Orolia ART profile has no PCA9546A environmental/power/IMU branch and no
+IS32FL3207 status-LED controller. These workspaces therefore show **not fitted
+on ART** and do not issue unsupported sensor, mux, or LED IOCTLs. The mRO-50
+raw temperature word remains available in the Atomic workspace.
 
 ## FPGA SPI flash
 

--- a/DRV/Windows/TimeCardControlCenter/TimeCardClient.cs
+++ b/DRV/Windows/TimeCardControlCenter/TimeCardClient.cs
@@ -57,6 +57,8 @@ namespace TimeCardControlCenter
         private static readonly uint IoctlLedQuery = ControlCode(28, FileReadAccess | FileWriteAccess);
         private static readonly uint IoctlLedSet = ControlCode(29, FileReadAccess | FileWriteAccess);
         private static readonly uint IoctlSensorQuery = ControlCode(30, FileReadAccess | FileWriteAccess);
+        private static readonly uint IoctlMro50Query = ControlCode(31, FileReadAccess);
+        private static readonly uint IoctlMro50Control = ControlCode(32, FileReadAccess | FileWriteAccess);
 
         private readonly object gate = new object();
         private SafeFileHandle handle;
@@ -810,6 +812,46 @@ namespace TimeCardControlCenter
         {
             return new SensorTelemetrySnapshot(
                 GetOutput<TimeCardSensorTelemetryRaw>(IoctlSensorQuery));
+        }
+
+        public Mro50Status GetMro50Status()
+        {
+            return new Mro50Status(
+                GetOutput<TimeCardMro50StatusRaw>(IoctlMro50Query));
+        }
+
+        public Mro50Status SetMro50FineAdjustment(uint value)
+        {
+            return ControlMro50(1, value);
+        }
+
+        public Mro50Status SetMro50CoarseAdjustment(uint value)
+        {
+            return ControlMro50(2, value);
+        }
+
+        public Mro50Status SaveMro50CoarseAdjustment()
+        {
+            return ControlMro50(3, 0);
+        }
+
+        public Mro50Status SetMro50SerialRoute(bool enabled)
+        {
+            return ControlMro50(4, enabled ? 1u : 0u);
+        }
+
+        private Mro50Status ControlMro50(uint action, uint value)
+        {
+            TimeCardMro50ControlRaw request = new TimeCardMro50ControlRaw
+            {
+                Size = (uint)Marshal.SizeOf(typeof(TimeCardMro50ControlRaw)),
+                Action = action,
+                Value = value
+            };
+            byte[] output = Call(IoctlMro50Control, StructToBytes(request),
+                Marshal.SizeOf(typeof(TimeCardMro50StatusRaw)));
+            return new Mro50Status(
+                BytesToStruct<TimeCardMro50StatusRaw>(output));
         }
 
         private TimeCardHierarchyRaw SetHierarchyRaw(uint action, bool persist)

--- a/DRV/Windows/TimeCardControlCenter/TimeCardTopologyView.cs
+++ b/DRV/Windows/TimeCardControlCenter/TimeCardTopologyView.cs
@@ -153,7 +153,11 @@ namespace TimeCardControlCenter
                     hot ? 1.8 : 1.0), layout.Bounds, 11, 11);
             dc.DrawEllipse(new SolidColorBrush(color), null,
                 new Point(layout.Bounds.Left + 15, layout.Bounds.Top + 17), 4.5, 4.5);
-            dc.DrawText(Text(layout.Title, 11, Colors.White, FontWeights.SemiBold),
+            string title = layout.Key == "atomic" && node != null &&
+                node.Name.StartsWith("mRO-50",
+                    StringComparison.OrdinalIgnoreCase) ?
+                "MRO-50 ATOMIC" : layout.Title;
+            dc.DrawText(Text(title, 11, Colors.White, FontWeights.SemiBold),
                 new Point(layout.Bounds.Left + 27, layout.Bounds.Top + 9));
             string status = node == null ? "WAITING" : node.Status;
             dc.DrawText(Text(status, 9, color, FontWeights.SemiBold),

--- a/DRV/Windows/driver.c
+++ b/DRV/Windows/driver.c
@@ -21,14 +21,23 @@ TimeCardFindPciField(const WCHAR *hardwareIds, ULONG characters,
 {
     ULONG i;
 
-    for (i = 0; i + 5u + digits <= characters; ++i) {
+    for (i = 0; i + 4u + digits <= characters; ++i) {
         ULONG parsed = 0;
         ULONG j;
 
-        if (hardwareIds[i] != L'&')
+        /*
+         * A PCI hardware ID begins with "PCI\VEN_"; subsequent fields begin
+         * after '&'.  Requiring '&' for every field silently discarded the
+         * vendor ID and made all non-Facebook cards fall back to that board
+         * profile even when their INF match was exact.
+         */
+        if (i == 0 ||
+            (hardwareIds[i - 1u] != L'\\' &&
+             hardwareIds[i - 1u] != L'&')) {
             continue;
+        }
         for (j = 0; j < 4u; ++j) {
-            WCHAR actual = hardwareIds[i + 1u + j];
+            WCHAR actual = hardwareIds[i + j];
             WCHAR expected = field[j];
 
             if (actual >= L'a' && actual <= L'z')
@@ -39,7 +48,7 @@ TimeCardFindPciField(const WCHAR *hardwareIds, ULONG characters,
         if (j != 4u)
             continue;
         for (j = 0; j < digits; ++j) {
-            int digit = TimeCardHexDigit(hardwareIds[i + 5u + j]);
+            int digit = TimeCardHexDigit(hardwareIds[i + 4u + j]);
 
             if (digit < 0)
                 break;
@@ -157,6 +166,8 @@ TimeCardSelectArtLayout(PDEVICE_CONTEXT context)
     context->SmaMap1 = NULL;
     context->SmaMap2 = NULL;
     context->ArtSma = NULL;
+    context->ArtBoardConfig = NULL;
+    context->Mro50 = NULL;
     context->I2c = NULL;
     context->Flash = NULL;
     context->I2cKnownDeviceMask = 0;
@@ -196,6 +207,18 @@ TimeCardSelectArtLayout(PDEVICE_CONTEXT context)
                           sizeof(TIMECARD_ART_SMA_REG))) {
         context->ArtSma = (volatile TIMECARD_ART_SMA_REG *)(
             context->Bar0Base + TIMECARD_SMA_OFFSET_ART);
+    }
+    if (TimeCardRangeFits(context->Bar0Length,
+                          TIMECARD_BOARD_CONFIG_OFFSET_ART,
+                          sizeof(ULONG))) {
+        context->ArtBoardConfig = (volatile ULONG *)(
+            context->Bar0Base + TIMECARD_BOARD_CONFIG_OFFSET_ART);
+    }
+    if (TimeCardRangeFits(context->Bar0Length,
+                          TIMECARD_MRO50_OFFSET_ART,
+                          sizeof(TIMECARD_MRO50_REG))) {
+        context->Mro50 = (volatile TIMECARD_MRO50_REG *)(
+            context->Bar0Base + TIMECARD_MRO50_OFFSET_ART);
     }
     if (TimeCardRangeFits(context->Bar0Length, context->I2cOffset, 0x100u))
         context->I2c = context->Bar0Base + context->I2cOffset;
@@ -322,6 +345,8 @@ TimeCardSelectLayout(PDEVICE_CONTEXT context)
     context->SmaMap1 = NULL;
     context->SmaMap2 = NULL;
     context->ArtSma = NULL;
+    context->ArtBoardConfig = NULL;
+    context->Mro50 = NULL;
     context->NmeaOut = NULL;
     context->I2c = NULL;
     context->I2cKnownDeviceMask = 0;
@@ -545,6 +570,8 @@ TimeCardEvtReleaseHardware(WDFDEVICE device,
     context->SmaMap1 = NULL;
     context->SmaMap2 = NULL;
     context->ArtSma = NULL;
+    context->ArtBoardConfig = NULL;
+    context->Mro50 = NULL;
     context->I2c = NULL;
     context->Flash = NULL;
     context->FlashJedecId = 0;
@@ -568,9 +595,36 @@ NTSTATUS
 TimeCardEvtD0Entry(WDFDEVICE device, WDF_POWER_DEVICE_STATE previousState)
 {
     PDEVICE_CONTEXT context = DeviceGetContext(device);
+    TIMECARD_UART_CONFIG uartConfig;
     NTSTATUS status;
 
     UNREFERENCED_PARAMETER(previousState);
+
+    if (context->BoardProfile == TIMECARD_BOARD_ART) {
+        /*
+         * ART gateware keeps the mRO-50 UART disconnected until this board
+         * configuration bit is asserted.  This is also done by the upstream
+         * Linux ptp_ocp ART initializer.
+         */
+        if (context->ArtBoardConfig != NULL) {
+            WdfWaitLockAcquire(context->RegisterLock, NULL);
+            WRITE_REGISTER_ULONG((PULONG)context->ArtBoardConfig, 1u);
+            WdfWaitLockRelease(context->RegisterLock);
+        }
+
+        /*
+         * Unlike the Meta/Celestica resources, Linux deliberately provides
+         * no fixed baud for the ART GNSS UART. Preserve the gateware divisor
+         * so cards populated with different receiver images remain usable.
+         */
+        uartConfig.Port = TIMECARD_UART_MAC;
+        uartConfig.Baud = 9600u;
+        status = TimeCardUartConfigure(context, &uartConfig);
+        if (!NT_SUCCESS(status)) {
+            KdPrint(("timecard: ART mRO-50 UART initialization unavailable, "
+                     "status 0x%08lx\n", status));
+        }
+    }
 
     status = TimeCardNmeaInitialize(context);
     if (!NT_SUCCESS(status)) {

--- a/DRV/Windows/i2c.c
+++ b/DRV/Windows/i2c.c
@@ -2391,6 +2391,7 @@ Exit:
 NTSTATUS
 TimeCardGetIdentity(PDEVICE_CONTEXT context, TIMECARD_IDENTITY *identity)
 {
+    static const UCHAR artConfigurationHeader[] = "oscillator=";
     TIMECARD_I2C_READ_REQUEST request;
     TIMECARD_I2C_TRANSFER transfer;
     BOOLEAN allZero = TRUE;
@@ -2404,6 +2405,30 @@ TimeCardGetIdentity(PDEVICE_CONTEXT context, TIMECARD_IDENTITY *identity)
     RtlZeroMemory(&request, sizeof(request));
     request.Size = sizeof(request);
     if (context->BoardProfile == TIMECARD_BOARD_ART) {
+        /*
+         * Some production ART images use the entire 24c08 for the mRO-50
+         * disciplining configuration.  In that layout offset 0x263 is text
+         * inside "ctrl_drift_coeffs_factory", not a six-byte serial.  Detect
+         * the configuration header so we never present those text bytes as a
+         * plausible card identity.
+         */
+        request.Address = 0x50u;
+        request.Subaddress = 0u;
+        request.SubaddressLength = 1u;
+        request.Length = sizeof(artConfigurationHeader) - 1u;
+        request.TimeoutMilliseconds = TIMECARD_I2C_DEFAULT_TIMEOUT_MS;
+        status = TimeCardI2cRead(context, &request, &transfer);
+        if (NT_SUCCESS(status) &&
+            transfer.Length == sizeof(artConfigurationHeader) - 1u &&
+            RtlCompareMemory(transfer.Data, artConfigurationHeader,
+                             sizeof(artConfigurationHeader) - 1u) ==
+                sizeof(artConfigurationHeader) - 1u) {
+            identity->Flags = TIMECARD_IDENTITY_FLAG_PRESENT;
+            return STATUS_SUCCESS;
+        }
+
+        RtlZeroMemory(&request, sizeof(request));
+        request.Size = sizeof(request);
         /*
          * Linux's ART EEPROM map stores the serial at absolute 24c08
          * offset 0x263. The high address block selects slave 0x52.

--- a/DRV/Windows/include/timecard_ioctl.h
+++ b/DRV/Windows/include/timecard_ioctl.h
@@ -82,8 +82,12 @@
     TIMECARD_IOCTL(29, FILE_READ_ACCESS | FILE_WRITE_ACCESS)
 #define IOCTL_TIMECARD_SENSOR_QUERY \
     TIMECARD_IOCTL(30, FILE_READ_ACCESS | FILE_WRITE_ACCESS)
+#define IOCTL_TIMECARD_MRO50_QUERY \
+    TIMECARD_IOCTL(31, FILE_READ_ACCESS)
+#define IOCTL_TIMECARD_MRO50_CONTROL \
+    TIMECARD_IOCTL(32, FILE_READ_ACCESS | FILE_WRITE_ACCESS)
 
-#define TIMECARD_ABI_VERSION 8u
+#define TIMECARD_ABI_VERSION 9u
 #define TIMECARD_LAYOUT_MSI  1u
 #define TIMECARD_LAYOUT_MSIX 2u
 #define TIMECARD_LAYOUT_ART  3u
@@ -95,6 +99,19 @@
 #define TIMECARD_UART_GNSS2 1u
 #define TIMECARD_UART_MAC   2u
 #define TIMECARD_UART_NMEA  3u
+
+#define TIMECARD_MRO50_FLAG_PRESENT        (1u << 0)
+#define TIMECARD_MRO50_FLAG_ENABLED        (1u << 1)
+#define TIMECARD_MRO50_FLAG_LOCKED         (1u << 2)
+#define TIMECARD_MRO50_FLAG_FINE_VALID     (1u << 3)
+#define TIMECARD_MRO50_FLAG_COARSE_VALID   (1u << 4)
+#define TIMECARD_MRO50_FLAG_SERIAL_ENABLED (1u << 5)
+
+#define TIMECARD_MRO50_ACTION_QUERY         0u
+#define TIMECARD_MRO50_ACTION_ADJUST_FINE   1u
+#define TIMECARD_MRO50_ACTION_ADJUST_COARSE 2u
+#define TIMECARD_MRO50_ACTION_SAVE_COARSE   3u
+#define TIMECARD_MRO50_ACTION_SERIAL_ENABLE 4u
 
 #define TIMECARD_HIERARCHY_QUERY   0u
 #define TIMECARD_HIERARCHY_ENABLE  1u
@@ -480,6 +497,28 @@ typedef struct _TIMECARD_SENSOR_TELEMETRY {
     TIMECARD_INA219_READING Rail3V3;
     TIMECARD_BNO055_READING Imu;
 } TIMECARD_SENSOR_TELEMETRY;
+
+/*
+ * Orolia/Safran ART mRO-50 FPGA bridge. Temperature is the raw gateware
+ * telemetry word; its physical scaling depends on the installed ART image.
+ */
+typedef struct _TIMECARD_MRO50_STATUS {
+    unsigned __int32 Size;
+    unsigned __int32 Flags;
+    unsigned __int32 Control;
+    unsigned __int32 FineAdjustment;
+    unsigned __int32 CoarseAdjustment;
+    unsigned __int32 Temperature;
+    unsigned __int32 BoardConfig;
+    unsigned __int32 Reserved;
+} TIMECARD_MRO50_STATUS;
+
+typedef struct _TIMECARD_MRO50_CONTROL {
+    unsigned __int32 Size;
+    unsigned __int32 Action;
+    unsigned __int32 Value;
+    unsigned __int32 Reserved;
+} TIMECARD_MRO50_CONTROL;
 
 typedef struct _TIMECARD_CLOCK_SOURCE_CONTROL {
     unsigned __int32 Size;

--- a/DRV/Windows/ioctl.c
+++ b/DRV/Windows/ioctl.c
@@ -654,6 +654,41 @@ TimeCardEvtIoDeviceControl(WDFQUEUE queue, WDFREQUEST request,
         break;
     }
 
+    case IOCTL_TIMECARD_MRO50_QUERY:
+    {
+        TIMECARD_MRO50_STATUS *output;
+
+        status = TimeCardGetOutput(request, sizeof(*output),
+                                   (PVOID *)&output);
+        if (NT_SUCCESS(status)) {
+            status = TimeCardMro50Query(context, output);
+            if (NT_SUCCESS(status))
+                information = sizeof(*output);
+        }
+        break;
+    }
+
+    case IOCTL_TIMECARD_MRO50_CONTROL:
+    {
+        TIMECARD_MRO50_CONTROL *input;
+        TIMECARD_MRO50_CONTROL requestValue;
+        TIMECARD_MRO50_STATUS *output;
+
+        status = TimeCardGetInput(request, sizeof(*input),
+                                  (PVOID *)&input, NULL);
+        if (!NT_SUCCESS(status))
+            break;
+        requestValue = *input;
+        status = TimeCardGetOutput(request, sizeof(*output),
+                                   (PVOID *)&output);
+        if (NT_SUCCESS(status)) {
+            status = TimeCardMro50Control(context, &requestValue, output);
+            if (NT_SUCCESS(status))
+                information = sizeof(*output);
+        }
+        break;
+    }
+
     default:
         status = STATUS_INVALID_DEVICE_REQUEST;
         break;

--- a/DRV/Windows/mro50.c
+++ b/DRV/Windows/mro50.c
@@ -1,0 +1,164 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+/* Orolia/Safran ART mRO-50 FPGA bridge, matched to Linux ptp_ocp. */
+
+#include "timecard.h"
+
+#define MRO50_CTRL_ENABLE        (1u << 0)
+#define MRO50_CTRL_LOCK          (1u << 1)
+#define MRO50_CTRL_READ_CMD      (1u << 2)
+#define MRO50_CTRL_READ_COARSE   (1u << 3)
+#define MRO50_CTRL_READ_DONE     (1u << 4)
+#define MRO50_CTRL_ADJUST_CMD    (1u << 5)
+#define MRO50_CTRL_ADJUST_COARSE (1u << 6)
+#define MRO50_CTRL_SAVE_COARSE   (1u << 7)
+
+#define MRO50_OP_READ_FINE \
+    (MRO50_CTRL_ENABLE | MRO50_CTRL_READ_CMD)
+#define MRO50_OP_READ_COARSE \
+    (MRO50_OP_READ_FINE | MRO50_CTRL_READ_COARSE)
+#define MRO50_OP_ADJUST_FINE \
+    (MRO50_CTRL_ENABLE | MRO50_CTRL_ADJUST_CMD)
+#define MRO50_OP_ADJUST_COARSE \
+    (MRO50_OP_ADJUST_FINE | MRO50_CTRL_ADJUST_COARSE)
+#define MRO50_OP_SAVE_COARSE \
+    (MRO50_CTRL_ENABLE | MRO50_CTRL_SAVE_COARSE)
+
+static NTSTATUS
+TimeCardMro50Wait(PDEVICE_CONTEXT context, ULONG mask)
+{
+    LARGE_INTEGER interval;
+    ULONG i;
+
+    interval.QuadPart = -1000; /* 100 microseconds, relative */
+    for (i = 0; i < 100u; ++i) {
+        ULONG control = READ_REGISTER_ULONG(
+            (PULONG)&context->Mro50->Control);
+
+        if ((control & mask) != 0)
+            return STATUS_SUCCESS;
+        KeDelayExecutionThread(KernelMode, FALSE, &interval);
+    }
+    return STATUS_IO_TIMEOUT;
+}
+
+static NTSTATUS
+TimeCardMro50ReadLocked(PDEVICE_CONTEXT context, ULONG operation,
+                        PULONG value)
+{
+    NTSTATUS status;
+
+    WRITE_REGISTER_ULONG((PULONG)&context->Mro50->Control, operation);
+    status = TimeCardMro50Wait(context, MRO50_CTRL_READ_DONE);
+    if (NT_SUCCESS(status)) {
+        *value = READ_REGISTER_ULONG((PULONG)&context->Mro50->Value);
+    }
+    return status;
+}
+
+static NTSTATUS
+TimeCardMro50AdjustLocked(PDEVICE_CONTEXT context, ULONG operation,
+                          ULONG value)
+{
+    WRITE_REGISTER_ULONG((PULONG)&context->Mro50->Adjust, value);
+    WRITE_REGISTER_ULONG((PULONG)&context->Mro50->Control, operation);
+    return TimeCardMro50Wait(context, MRO50_CTRL_ADJUST_CMD);
+}
+
+NTSTATUS
+TimeCardMro50Query(PDEVICE_CONTEXT context, TIMECARD_MRO50_STATUS *status)
+{
+    NTSTATUS fineStatus;
+    NTSTATUS coarseStatus;
+    ULONG control;
+    ULONG fine = 0;
+    ULONG coarse = 0;
+
+    if (!context->HardwareReady ||
+        context->BoardProfile != TIMECARD_BOARD_ART ||
+        context->Mro50 == NULL) {
+        return STATUS_NOT_SUPPORTED;
+    }
+
+    RtlZeroMemory(status, sizeof(*status));
+    status->Size = sizeof(*status);
+    status->Flags = TIMECARD_MRO50_FLAG_PRESENT;
+
+    WdfWaitLockAcquire(context->RegisterLock, NULL);
+    status->Temperature = READ_REGISTER_ULONG(
+        (PULONG)&context->Mro50->Temperature);
+    status->BoardConfig = context->ArtBoardConfig != NULL ?
+        READ_REGISTER_ULONG((PULONG)context->ArtBoardConfig) : 0u;
+    fineStatus = TimeCardMro50ReadLocked(
+        context, MRO50_OP_READ_FINE, &fine);
+    coarseStatus = TimeCardMro50ReadLocked(
+        context, MRO50_OP_READ_COARSE, &coarse);
+    control = READ_REGISTER_ULONG((PULONG)&context->Mro50->Control);
+    WdfWaitLockRelease(context->RegisterLock);
+
+    status->Control = control;
+    status->FineAdjustment = fine;
+    status->CoarseAdjustment = coarse;
+    if ((control & MRO50_CTRL_ENABLE) != 0)
+        status->Flags |= TIMECARD_MRO50_FLAG_ENABLED;
+    if ((control & MRO50_CTRL_LOCK) != 0)
+        status->Flags |= TIMECARD_MRO50_FLAG_LOCKED;
+    if (NT_SUCCESS(fineStatus))
+        status->Flags |= TIMECARD_MRO50_FLAG_FINE_VALID;
+    if (NT_SUCCESS(coarseStatus))
+        status->Flags |= TIMECARD_MRO50_FLAG_COARSE_VALID;
+    if (status->BoardConfig != 0)
+        status->Flags |= TIMECARD_MRO50_FLAG_SERIAL_ENABLED;
+    return STATUS_SUCCESS;
+}
+
+NTSTATUS
+TimeCardMro50Control(PDEVICE_CONTEXT context,
+                     const TIMECARD_MRO50_CONTROL *control,
+                     TIMECARD_MRO50_STATUS *status)
+{
+    NTSTATUS operationStatus = STATUS_SUCCESS;
+
+    if (!context->HardwareReady ||
+        context->BoardProfile != TIMECARD_BOARD_ART ||
+        context->Mro50 == NULL) {
+        return STATUS_NOT_SUPPORTED;
+    }
+    if (control->Size < sizeof(*control) ||
+        control->Reserved != 0) {
+        return STATUS_INVALID_PARAMETER;
+    }
+
+    WdfWaitLockAcquire(context->RegisterLock, NULL);
+    switch (control->Action) {
+    case TIMECARD_MRO50_ACTION_QUERY:
+        break;
+    case TIMECARD_MRO50_ACTION_ADJUST_FINE:
+        operationStatus = TimeCardMro50AdjustLocked(
+            context, MRO50_OP_ADJUST_FINE, control->Value);
+        break;
+    case TIMECARD_MRO50_ACTION_ADJUST_COARSE:
+        operationStatus = TimeCardMro50AdjustLocked(
+            context, MRO50_OP_ADJUST_COARSE, control->Value);
+        break;
+    case TIMECARD_MRO50_ACTION_SAVE_COARSE:
+        WRITE_REGISTER_ULONG((PULONG)&context->Mro50->Control,
+                             MRO50_OP_SAVE_COARSE);
+        break;
+    case TIMECARD_MRO50_ACTION_SERIAL_ENABLE:
+        if (context->ArtBoardConfig == NULL) {
+            operationStatus = STATUS_NOT_SUPPORTED;
+        } else {
+            WRITE_REGISTER_ULONG((PULONG)context->ArtBoardConfig,
+                                 control->Value != 0 ? 1u : 0u);
+        }
+        break;
+    default:
+        operationStatus = STATUS_INVALID_PARAMETER;
+        break;
+    }
+    WdfWaitLockRelease(context->RegisterLock);
+
+    if (!NT_SUCCESS(operationStatus))
+        return operationStatus;
+    return TimeCardMro50Query(context, status);
+}

--- a/DRV/Windows/package-release.ps1
+++ b/DRV/Windows/package-release.ps1
@@ -20,7 +20,7 @@ if (-not $OutputDirectory.StartsWith(
     throw 'OutputDirectory must be a child of the Windows driver directory.'
 }
 $driverFolder = Join-Path $OutputDirectory 'TimeCard'
-$cabPath = Join-Path $OutputDirectory 'TimeCard-1.25-x64.cab'
+$cabPath = Join-Path $OutputDirectory 'TimeCard-1.29-x64.cab'
 
 function Find-MSBuild {
     $command = Get-Command msbuild.exe -ErrorAction SilentlyContinue
@@ -126,7 +126,7 @@ $ddfLines = @(
     '.Set CompressionType=MSZIP',
     '.Set Cabinet=on',
     '.Set Compress=on',
-    '.Set CabinetNameTemplate=TimeCard-1.25-x64.cab',
+    '.Set CabinetNameTemplate=TimeCard-1.29-x64.cab',
     ".Set DiskDirectoryTemplate=`"$OutputDirectory`"",
     ".Set RptFileName=`"$(Join-Path $OutputDirectory 'TimeCard.rpt')`"",
     ".Set InfFileName=`"$(Join-Path $OutputDirectory 'TimeCard-cab.inf')`"",

--- a/DRV/Windows/ptp.c
+++ b/DRV/Windows/ptp.c
@@ -121,7 +121,7 @@ TimeCardGetInfo(PDEVICE_CONTEXT context, TIMECARD_INFO *info)
 
     RtlZeroMemory(info, sizeof(*info));
     info->AbiVersion = TIMECARD_ABI_VERSION;
-    info->DriverVersion = 0x00010019u;
+    info->DriverVersion = 0x0001001du;
     info->Layout = context->Layout;
     info->InterruptMessages = context->InterruptMessages;
     info->BarLength = context->Bar0Length;

--- a/DRV/Windows/timecard.h
+++ b/DRV/Windows/timecard.h
@@ -48,6 +48,8 @@ extern const GUID GUID_DEVCLASS_TIMECARD;
 #define TIMECARD_SMA_OFFSET_ART         0x003c0000u
 #define TIMECARD_I2C_OFFSET_ART         0x00350000u
 #define TIMECARD_FLASH_OFFSET_ART       0x00310000u
+#define TIMECARD_BOARD_CONFIG_OFFSET_ART 0x00210000u
+#define TIMECARD_MRO50_OFFSET_ART       0x00340000u
 
 #define TIMECARD_REGISTER_WINDOW_SIZE   0x00010000u
 #define TIMECARD_UART_CLOCK_HZ          50000000u
@@ -153,6 +155,13 @@ typedef struct _TIMECARD_ART_SMA_REG {
     TIMECARD_ART_SMA_ENTRY Map[TIMECARD_SMA_COUNT];
 } TIMECARD_ART_SMA_REG, *PTIMECARD_ART_SMA_REG;
 
+typedef struct _TIMECARD_MRO50_REG {
+    ULONG Control;
+    ULONG Value;
+    ULONG Adjust;
+    ULONG Temperature;
+} TIMECARD_MRO50_REG, *PTIMECARD_MRO50_REG;
+
 typedef struct _DEVICE_CONTEXT {
     WDFDEVICE Device;
     volatile UCHAR *Bar0Base;
@@ -163,6 +172,8 @@ typedef struct _DEVICE_CONTEXT {
     volatile TIMECARD_GPIO_REG *SmaMap1;
     volatile TIMECARD_GPIO_REG *SmaMap2;
     volatile TIMECARD_ART_SMA_REG *ArtSma;
+    volatile ULONG *ArtBoardConfig;
+    volatile TIMECARD_MRO50_REG *Mro50;
     volatile TIMECARD_SIGNAL_REG *Signal[TIMECARD_SIGNAL_COUNT];
     volatile TIMECARD_FREQUENCY_REG *Frequency[TIMECARD_FREQUENCY_COUNT];
     volatile UCHAR *I2c;
@@ -323,6 +334,11 @@ NTSTATUS TimeCardLedSet(PDEVICE_CONTEXT context,
                         TIMECARD_LED_CONTROL *response);
 NTSTATUS TimeCardSensorQuery(PDEVICE_CONTEXT context,
                              TIMECARD_SENSOR_TELEMETRY *telemetry);
+NTSTATUS TimeCardMro50Query(PDEVICE_CONTEXT context,
+                            TIMECARD_MRO50_STATUS *status);
+NTSTATUS TimeCardMro50Control(PDEVICE_CONTEXT context,
+                              const TIMECARD_MRO50_CONTROL *control,
+                              TIMECARD_MRO50_STATUS *status);
 NTSTATUS TimeCardGetIdentity(PDEVICE_CONTEXT context,
                              TIMECARD_IDENTITY *identity);
 

--- a/DRV/Windows/timecard.inf
+++ b/DRV/Windows/timecard.inf
@@ -7,7 +7,7 @@ Class       = TimeCard
 ClassGuid   = {B5415088-5EE1-4D3A-8519-C3487370E0BF}
 Provider    = %ProviderName%
 CatalogFile = timecard.cat
-DriverVer   = 07/23/2026,1.25.0.0
+DriverVer   = 07/23/2026,1.29.0.0
 PnpLockdown = 1
 
 [ClassInstall32]

--- a/DRV/Windows/timecard.vcxproj
+++ b/DRV/Windows/timecard.vcxproj
@@ -66,6 +66,7 @@
     <ClCompile Include="i2c.c" />
     <ClCompile Include="i2c_ocores.c" />
     <ClCompile Include="ioctl.c" />
+    <ClCompile Include="mro50.c" />
     <ClCompile Include="nmea.c" />
     <ClCompile Include="ptp.c" />
     <ClCompile Include="serial.c" />

--- a/DRV/Windows/tools/test-board-profiles.ps1
+++ b/DRV/Windows/tools/test-board-profiles.ps1
@@ -9,6 +9,8 @@ $driverSource = Get-Content -Raw (Join-Path $windows 'driver.c')
 $headerSource = Get-Content -Raw (Join-Path $windows 'timecard.h')
 $infSource = Get-Content -Raw (Join-Path $windows 'timecard.inf')
 $projectSource = Get-Content -Raw (Join-Path $windows 'timecard.vcxproj')
+$abiSource = Get-Content -Raw (Join-Path $windows 'include\timecard_ioctl.h')
+$mroSource = Get-Content -Raw (Join-Path $windows 'mro50.c')
 
 function Assert-Match {
     param(
@@ -67,10 +69,22 @@ Assert-Match $driverSource 'TIMECARD_I2C_CONTROLLER_OCORES' `
     'ART does not select the OpenCores I2C transport'
 Assert-Match $driverSource 'TIMECARD_FLASH_CONTROLLER_ALTERA' `
     'ART does not select the Altera SPI transport'
+Assert-Match $driverSource ([regex]::Escape("hardwareIds[i - 1u] != L'\\'")) `
+    'PCI parser does not accept the leading PCI\VEN_ field'
+Assert-Match $headerSource 'TIMECARD_MRO50_OFFSET_ART\s+0x00340000u' `
+    'ART direct mRO-50 bridge offset is missing'
+Assert-Match $headerSource 'TIMECARD_BOARD_CONFIG_OFFSET_ART\s+0x00210000u' `
+    'ART board-configuration offset is missing'
+Assert-Match $abiSource 'TIMECARD_ABI_VERSION\s+9u' `
+    'mRO-50 support did not advance the public ABI'
+Assert-Match $mroSource 'TimeCardMro50Query' `
+    'ART mRO-50 query implementation is missing'
 Assert-Match $projectSource 'i2c_ocores\.c' `
     'OpenCores I2C implementation is not in the driver build'
 Assert-Match $projectSource 'flash_altera\.c' `
     'Altera SPI implementation is not in the driver build'
+Assert-Match $projectSource 'mro50\.c' `
+    'mRO-50 implementation is not in the driver build'
 Assert-Match $headerSource 'TIMECARD_SUBSYSTEM_MASK_ART' `
     'ART subsystem capability mask is missing'
 

--- a/DRV/Windows/tools/test-control-center-product.ps1
+++ b/DRV/Windows/tools/test-control-center-product.ps1
@@ -16,6 +16,8 @@ namespace TimeCardControlCenter
         public uint AbiVersion { get; set; }
         public string Layout { get; set; }
         public bool GnssFixOk { get; set; }
+        public bool GnssTelemetryAvailable { get; set; }
+        public bool TodTelemetryAvailable { get; set; }
         public int LockedSatellites { get; set; }
         public uint UtcStatus { get; set; }
         public uint TodStatus { get; set; }
@@ -33,6 +35,10 @@ namespace TimeCardControlCenter
     {
         public bool TryBoolean(string name, out bool value) { value = true; return true; }
     }
+    public sealed class Mro50Status
+    {
+        public bool IsLocked { get; set; }
+    }
     public sealed class SensorTelemetrySnapshot
     {
         public uint ControllerStatus { get; set; }
@@ -46,7 +52,8 @@ namespace TimeCardControlCenter
     {
         public static string Run()
         {
-            HealthReport demo = ControlCenterHealth.Evaluate(null, null, null, null, false, true);
+            HealthReport demo = ControlCenterHealth.Evaluate(
+                null, null, null, null, null, false, true);
             if (demo.Overall != HealthSeverity.Healthy || demo.Nodes.Count != 8)
                 throw new Exception("Demo health graph failed.");
 
@@ -54,14 +61,29 @@ namespace TimeCardControlCenter
             {
                 DriverVersion = "1.15", AbiVersion = 8, Layout = "MSI-X",
                 GnssFixOk = true, LockedSatellites = 12, UtcStatus = 1u << 8,
+                GnssTelemetryAvailable = true, TodTelemetryAvailable = true,
                 IsClockSynchronized = true, OffsetNanoseconds = 4,
                 SamplingWindowNanoseconds = 9000
             };
-            HealthReport health = ControlCenterHealth.Evaluate(live, null, null,
-                new SensorTelemetrySnapshot(), true, false);
+            HealthReport health = ControlCenterHealth.Evaluate(
+                live, null, null, null, new SensorTelemetrySnapshot(),
+                true, false);
             if (health.Find("phc").Severity != HealthSeverity.Healthy ||
                 health.Find("gnss").Severity != HealthSeverity.Healthy)
                 throw new Exception("Live health evaluation failed.");
+
+            TimeCardSnapshot art = new TimeCardSnapshot
+            {
+                DriverVersion = "1.29", AbiVersion = 9,
+                Layout = "Orolia ART", IsClockSynchronized = true,
+                OffsetNanoseconds = 4, SamplingWindowNanoseconds = 9000
+            };
+            HealthReport artHealth = ControlCenterHealth.Evaluate(
+                art, null, null, new Mro50Status { IsLocked = true },
+                null, true, false);
+            if (artHealth.Find("atomic").Severity != HealthSeverity.Healthy ||
+                artHealth.Find("tod").Severity != HealthSeverity.Informational)
+                throw new Exception("Orolia ART capability health evaluation failed.");
 
             IList<ConfigurationProfile> profiles = BuiltInProfiles.Create();
             if (profiles.Count < 5 || !profiles.Any(item => item.HasNmea) ||

--- a/DRV/Windows/tools/timecardctl.c
+++ b/DRV/Windows/tools/timecardctl.c
@@ -331,6 +331,63 @@ cmd_uart_read(HANDLE handle, int argc, char **argv)
 }
 
 static int
+cmd_uart_read_hex(HANDLE handle, int argc, char **argv)
+{
+    TIMECARD_UART_READ_REQUEST request;
+    TIMECARD_UART_TRANSFER transfer;
+    DWORD returned;
+    unsigned long i;
+
+    if (argc < 3 || argc > 5)
+        return 2;
+    request.Port = (unsigned __int32)parse_ulong(argv[2], "port");
+    request.MaximumBytes = argc >= 4 ?
+        (unsigned __int32)parse_ulong(argv[3], "byte count") : 256u;
+    request.TimeoutMilliseconds = argc >= 5 ?
+        (unsigned __int32)parse_ulong(argv[4], "timeout") : 1000u;
+    request.Reserved = 0;
+    if (timecard_ioctl(handle, IOCTL_TIMECARD_UART_READ,
+                       &request, sizeof(request), &transfer,
+                       sizeof(transfer), &returned))
+        return 1;
+    for (i = 0; i < transfer.Length; ++i) {
+        if (i != 0)
+            putchar(' ');
+        printf("%02X", transfer.Data[i]);
+    }
+    putchar('\n');
+    printf("[%lu byte(s), LSR 0x%02lx]\n",
+           (unsigned long)transfer.Length,
+           (unsigned long)(transfer.LineStatus & 0xff));
+    return 0;
+}
+
+static int
+cmd_uart_observe(HANDLE handle, int argc, char **argv)
+{
+    TIMECARD_UART_OBSERVE request;
+    TIMECARD_UART_OBSERVE response;
+
+    if (argc < 3 || argc > 4)
+        return 2;
+    RtlZeroMemory(&request, sizeof(request));
+    request.Size = sizeof(request);
+    request.Port = (unsigned __int32)parse_ulong(argv[2], "port");
+    request.TimeoutMilliseconds = argc == 4 ?
+        (unsigned __int32)parse_ulong(argv[3], "timeout") : 0u;
+    if (timecard_ioctl(handle, IOCTL_TIMECARD_UART_OBSERVE,
+                       &request, sizeof(request), &response,
+                       sizeof(response), NULL))
+        return 1;
+    printf("UART %lu: %s, LSR 0x%02lx\n",
+           (unsigned long)response.Port,
+           (response.Flags & TIMECARD_UART_OBSERVE_FLAG_ACTIVITY) ?
+               "receive data ready" : "idle",
+           (unsigned long)(response.LineStatus & 0xffu));
+    return 0;
+}
+
+static int
 cmd_uart_write(HANDLE handle, int argc, char **argv)
 {
     TIMECARD_UART_TRANSFER transfer;
@@ -358,6 +415,113 @@ cmd_uart_write(HANDLE handle, int argc, char **argv)
     printf("Wrote %lu byte(s), LSR 0x%02lx\n",
            (unsigned long)result.BytesTransferred,
            (unsigned long)(result.LineStatus & 0xff));
+    return 0;
+}
+
+static void
+print_mro50(const TIMECARD_MRO50_STATUS *status)
+{
+    printf("mRO-50 bridge:    %s%s\n",
+           (status->Flags & TIMECARD_MRO50_FLAG_ENABLED) ?
+               "enabled" : "disabled",
+           (status->Flags & TIMECARD_MRO50_FLAG_LOCKED) ?
+               ", locked" : ", acquiring");
+    printf("Control:          0x%08lx\n",
+           (unsigned long)status->Control);
+    printf("Fine adjustment:  ");
+    if ((status->Flags & TIMECARD_MRO50_FLAG_FINE_VALID) != 0)
+        printf("0x%08lx\n", (unsigned long)status->FineAdjustment);
+    else
+        printf("unavailable\n");
+    printf("Coarse adjustment:");
+    if ((status->Flags & TIMECARD_MRO50_FLAG_COARSE_VALID) != 0)
+        printf(" 0x%08lx\n", (unsigned long)status->CoarseAdjustment);
+    else
+        printf(" unavailable\n");
+    printf("Temperature raw:  0x%08lx\n",
+           (unsigned long)status->Temperature);
+    printf("Board config:     0x%08lx (serial route %s)\n",
+           (unsigned long)status->BoardConfig,
+           (status->Flags & TIMECARD_MRO50_FLAG_SERIAL_ENABLED) ?
+               "enabled" : "disabled");
+}
+
+static int
+cmd_mro50_status(HANDLE handle)
+{
+    TIMECARD_MRO50_STATUS status;
+
+    if (timecard_ioctl(handle, IOCTL_TIMECARD_MRO50_QUERY,
+                       NULL, 0, &status, sizeof(status), NULL))
+        return 1;
+    print_mro50(&status);
+    return 0;
+}
+
+static int
+cmd_mro50_control(HANDLE handle, int argc, char **argv)
+{
+    TIMECARD_MRO50_CONTROL control;
+    TIMECARD_MRO50_STATUS status;
+
+    RtlZeroMemory(&control, sizeof(control));
+    control.Size = sizeof(control);
+    if (strcmp(argv[1], "mro-fine") == 0 && argc == 3) {
+        control.Action = TIMECARD_MRO50_ACTION_ADJUST_FINE;
+        control.Value = (unsigned __int32)parse_ulong(argv[2], "fine value");
+    } else if (strcmp(argv[1], "mro-coarse") == 0 && argc == 3) {
+        control.Action = TIMECARD_MRO50_ACTION_ADJUST_COARSE;
+        control.Value = (unsigned __int32)parse_ulong(argv[2], "coarse value");
+    } else if (strcmp(argv[1], "mro-save-coarse") == 0 && argc == 2) {
+        control.Action = TIMECARD_MRO50_ACTION_SAVE_COARSE;
+    } else if (strcmp(argv[1], "mro-serial") == 0 && argc == 3) {
+        control.Action = TIMECARD_MRO50_ACTION_SERIAL_ENABLE;
+        if (_stricmp(argv[2], "on") == 0)
+            control.Value = 1u;
+        else if (_stricmp(argv[2], "off") != 0)
+            return 2;
+    } else {
+        return 2;
+    }
+
+    if (timecard_ioctl(handle, IOCTL_TIMECARD_MRO50_CONTROL,
+                       &control, sizeof(control), &status,
+                       sizeof(status), NULL))
+        return 1;
+    print_mro50(&status);
+    return 0;
+}
+
+static int
+cmd_flash_status(HANDLE handle)
+{
+    TIMECARD_FLASH_STATUS status;
+
+    if (timecard_ioctl(handle, IOCTL_TIMECARD_FLASH_QUERY,
+                       NULL, 0, &status, sizeof(status), NULL))
+        return 1;
+    printf("FPGA flash:        %s%s%s\n",
+           (status.Flags & TIMECARD_FLASH_FLAG_PRESENT) ?
+               "present" : "not present",
+           (status.Flags & TIMECARD_FLASH_FLAG_IDENTIFIED) ?
+               ", identified" : "",
+           (status.Flags & TIMECARD_FLASH_FLAG_SUPPORTED) ?
+               ", writable geometry supported" : "");
+    printf("Controller offset: 0x%08lx\n",
+           (unsigned long)status.Offset);
+    printf("JEDEC ID:          0x%06lx\n",
+           (unsigned long)(status.JedecId & 0xffffffu));
+    printf("Capacity:          %lu bytes\n",
+           (unsigned long)status.CapacityBytes);
+    printf("Firmware offset:   0x%08lx\n",
+           (unsigned long)status.FirmwareOffset);
+    printf("Erase / page:      %lu / %lu bytes\n",
+           (unsigned long)status.EraseSize,
+           (unsigned long)status.PageSize);
+    printf("Controller status: 0x%08lx\n",
+           (unsigned long)status.ControllerStatus);
+    printf("Flash status:      0x%08lx\n",
+           (unsigned long)status.FlashStatus);
     return 0;
 }
 
@@ -928,7 +1092,15 @@ usage(void)
             "  timecardctl nmea-set <on|off> <baud> [normal|inverted]\n"
             "  timecardctl uart-config <port 0..3> <baud>\n"
             "  timecardctl uart-read <port> [bytes] [timeout-ms]\n"
+            "  timecardctl uart-read-hex <port> [bytes] [timeout-ms]\n"
+            "  timecardctl uart-observe <port> [timeout-ms]\n"
             "  timecardctl uart-write <port> <text>\n"
+            "  timecardctl mro-status\n"
+            "  timecardctl mro-fine <value>\n"
+            "  timecardctl mro-coarse <value>\n"
+            "  timecardctl mro-save-coarse\n"
+            "  timecardctl mro-serial <on|off>\n"
+            "  timecardctl flash-status\n"
             "  timecardctl hierarchy-status\n"
             "  timecardctl hierarchy-enable\n"
             "  timecardctl hierarchy-persist\n"
@@ -976,8 +1148,18 @@ main(int argc, char **argv)
         result = cmd_uart_config(handle, argc, argv);
     else if (strcmp(argv[1], "uart-read") == 0)
         result = cmd_uart_read(handle, argc, argv);
+    else if (strcmp(argv[1], "uart-read-hex") == 0)
+        result = cmd_uart_read_hex(handle, argc, argv);
+    else if (strcmp(argv[1], "uart-observe") == 0)
+        result = cmd_uart_observe(handle, argc, argv);
     else if (strcmp(argv[1], "uart-write") == 0)
         result = cmd_uart_write(handle, argc, argv);
+    else if (strcmp(argv[1], "mro-status") == 0 && argc == 2)
+        result = cmd_mro50_status(handle);
+    else if (strncmp(argv[1], "mro-", 4) == 0)
+        result = cmd_mro50_control(handle, argc, argv);
+    else if (strcmp(argv[1], "flash-status") == 0 && argc == 2)
+        result = cmd_flash_status(handle);
     else if (strcmp(argv[1], "hierarchy-status") == 0 && argc == 2)
         result = cmd_hierarchy(handle, TIMECARD_HIERARCHY_QUERY, 0);
     else if (strcmp(argv[1], "hierarchy-enable") == 0 && argc == 2)

--- a/README.md
+++ b/README.md
@@ -171,20 +171,24 @@ Using a Calnex Sentinel device are comparing various things. Here we are compari
   [`DRV/Windows`](DRV/Windows)
 * CAD files for the custom PCIe bracket 
 
-The Windows package currently ships driver **1.25 / ABI 8** and a native
+The Windows package currently ships driver **1.29 / ABI 9** and a native
 Control Center that brings the complete Time Card into one application:
 
 * Precision-clock telemetry, detail-focused rolling offset graphs, clock-source
   selection, and guarded synchronization in both directions.
 * Primary and secondary GNSS status, u-blox configuration, and a vendor-style
   satellite sky map.
-* Atomic-clock control, multi-format UART consoles, and an FPGA NMEA generator.
+* Board-aware atomic-clock control for Microchip MAC-SA53 and the Orolia ART
+  mRO-50 FPGA bridge, plus multi-format UART consoles and FPGA NMEA where
+  implemented.
 * SMA routing plus four PHC-aligned generators and four frequency counters.
 * Schematic-aware I2C routing, card identity, automatic/manual RGB status LEDs,
   electrical diagnostics, live environmental sensors, power rails, and IMU.
 * Device hierarchy controls and guarded, verified FPGA SPI-flash updates.
 * Explicit Meta/Facebook, Celestica, and Orolia/Safran ART board profiles
-  matching the PCI identities and resource maps in the Linux driver.
+  matching the PCI identities and resource maps in the Linux driver. ART
+  capability detection prevents absent Meta-only sensors, LEDs, ToD/NMEA,
+  secondary GNSS, PTM, and generator blocks from appearing as hardware faults.
 
 See the [Windows driver guide](DRV/Windows/README.md) and the
 [Control Center guide](DRV/Windows/TimeCardControlCenter/README.md) for build,


### PR DESCRIPTION
## Summary
- add Orolia/Safran ART Time Card PCI layout and capability detection to the Windows driver
- add direct mRO-50 atomic-clock control, ART flash/I2C/SMA support, and matching CLI commands
- make Time Card Control Center capability-aware for ART hardware and document driver/app 1.29 (ABI 9)

## Why
The ART card uses different FPGA register locations and peripherals from the Meta/OCP reference card. Without a dedicated profile, it was misidentified and several subsystems were accessed through incompatible layouts.

## Validation
- `build.cmd test`
- `build-gui.cmd release`
- `tools/test-board-profiles.ps1`
- `tools/test-control-center-product.ps1`
- `tools/test-ublox-decoder.ps1`
- live ART hardware: driver 1.29 / ABI 9, mRO-50 lock/status, flash identification, I2C banks, and fixed SMA map